### PR TITLE
Simplify Terraform: remove Cloudflare, keep WireGuard inactive

### DIFF
--- a/deploy/terraform/cloud-init.yaml
+++ b/deploy/terraform/cloud-init.yaml
@@ -33,22 +33,21 @@ runcmd:
   - mkdir -p /opt/app/data /opt/app/caddy_data
   - chown deploy:deploy /opt/app/data /opt/app/caddy_data
 
-  # Enable IP forwarding for WireGuard
+  # Enable IP forwarding for WireGuard (ready for later)
   - echo "net.ipv4.ip_forward=1" >> /etc/sysctl.d/99-wireguard.conf
   - sysctl -p /etc/sysctl.d/99-wireguard.conf
 
-  # Generate WireGuard keypair
+  # Generate WireGuard keypair (ready for later)
   - mkdir -p /etc/wireguard
   - wg genkey | tee /etc/wireguard/private.key | wg pubkey > /etc/wireguard/public.key
   - chmod 600 /etc/wireguard/private.key
 
-  # Create placeholder wg0.conf (operator fills in peer details)
+  # Create placeholder wg0.conf (operator fills in peer details when enabling VPN)
   - |
     cat > /etc/wireguard/wg0.conf << 'EOF'
     [Interface]
     Address = 10.10.10.1/24
     ListenPort = 51820
-    # PrivateKey is loaded from file below
     PostUp = wg set %i private-key /etc/wireguard/private.key; iptables -A FORWARD -i %i -j ACCEPT; iptables -t nat -A POSTROUTING -o $(ip route show default | awk '{print $5}') -j MASQUERADE
     PostDown = iptables -D FORWARD -i %i -j ACCEPT; iptables -t nat -D POSTROUTING -o $(ip route show default | awk '{print $5}') -j MASQUERADE
 
@@ -59,5 +58,5 @@ runcmd:
     EOF
   - chmod 600 /etc/wireguard/wg0.conf
 
-  # Enable WireGuard (will start once peer is configured)
-  - systemctl enable wg-quick@wg0
+  # WireGuard is installed but NOT enabled — enable manually when VPN is needed:
+  #   systemctl enable --now wg-quick@wg0

--- a/deploy/terraform/main.tf
+++ b/deploy/terraform/main.tf
@@ -5,19 +5,11 @@ terraform {
       source  = "UpCloudLtd/upcloud"
       version = "~> 5.0"
     }
-    cloudflare = {
-      source  = "cloudflare/cloudflare"
-      version = "~> 4.0"
-    }
   }
 }
 
 provider "upcloud" {
   # Credentials via UPCLOUD_USERNAME and UPCLOUD_PASSWORD env vars
-}
-
-provider "cloudflare" {
-  # Credentials via CLOUDFLARE_API_TOKEN env var
 }
 
 # ── Server ──
@@ -87,7 +79,7 @@ resource "upcloud_firewall_rules" "monitor" {
     protocol               = "udp"
     destination_port_start = 51820
     destination_port_end   = 51820
-    comment                = "WireGuard VPN"
+    comment                = "WireGuard VPN (not active yet, ready for later)"
   }
 
   firewall_rule {
@@ -103,15 +95,4 @@ resource "upcloud_firewall_rules" "monitor" {
     family    = "IPv6"
     comment   = "Drop all inbound IPv6"
   }
-}
-
-# ── DNS ──
-
-resource "cloudflare_record" "monitor" {
-  zone_id = var.cloudflare_zone_id
-  name    = var.domain
-  content = upcloud_server.monitor.network_interface[0].ip_address
-  type    = "A"
-  ttl     = 300
-  proxied = false
 }

--- a/deploy/terraform/outputs.tf
+++ b/deploy/terraform/outputs.tf
@@ -1,9 +1,9 @@
 output "server_ip" {
-  description = "Public IP address of the UpCloud server"
+  description = "Public IP address of the UpCloud server — create an A record pointing your domain to this IP"
   value       = upcloud_server.monitor.network_interface[0].ip_address
 }
 
 output "domain" {
-  description = "Domain name pointing to the server"
+  description = "Domain name for the server"
   value       = var.domain
 }

--- a/deploy/terraform/terraform.tfvars.example
+++ b/deploy/terraform/terraform.tfvars.example
@@ -2,10 +2,7 @@
 ssh_public_key = "ssh-ed25519 AAAA..."
 
 # Domain name for the monitoring UI
-domain = "monitor.example.com"
-
-# Cloudflare zone ID (find in Cloudflare dashboard → domain → Overview → API section)
-cloudflare_zone_id = "your-zone-id"
+domain = "greenhouse.madekivi.fi"
 
 # UpCloud zone (default: fi-hel1 = Helsinki)
 # upcloud_zone = "fi-hel1"
@@ -16,4 +13,6 @@ cloudflare_zone_id = "your-zone-id"
 # Required environment variables (not in tfvars for security):
 #   export UPCLOUD_USERNAME="your-username"
 #   export UPCLOUD_PASSWORD="your-password"
-#   export CLOUDFLARE_API_TOKEN="your-token"
+#
+# After `terraform apply`, note the server_ip output and create
+# an A record in Gandi DNS pointing your domain to that IP.

--- a/deploy/terraform/variables.tf
+++ b/deploy/terraform/variables.tf
@@ -4,12 +4,7 @@ variable "ssh_public_key" {
 }
 
 variable "domain" {
-  description = "Domain name for the monitoring UI (e.g., monitor.example.com)"
-  type        = string
-}
-
-variable "cloudflare_zone_id" {
-  description = "Cloudflare zone ID for DNS record management"
+  description = "Domain name for the monitoring UI (e.g., greenhouse.madekivi.fi)"
   type        = string
 }
 


### PR DESCRIPTION
- Remove Cloudflare provider — DNS managed manually in Gandi
- Remove cloudflare_zone_id variable (not needed)
- Keep WireGuard installed via cloud-init but NOT auto-enabled
- Keep WireGuard firewall rule open for later activation
- Update tfvars.example for Gandi DNS workflow

https://claude.ai/code/session_01K5gRp6QUWhTqz9kJqAkutD