### PR TITLE
Switch UpCloud Terraform auth from basic auth to API token

### DIFF
--- a/deploy/terraform/main.tf
+++ b/deploy/terraform/main.tf
@@ -9,7 +9,8 @@ terraform {
 }
 
 provider "upcloud" {
-  # Credentials via UPCLOUD_USERNAME and UPCLOUD_PASSWORD env vars
+  # Credentials via UPCLOUD_TOKEN env var (API token from UpCloud profile)
+  # No basic auth (username/password) needed
 }
 
 # ── Server ──

--- a/deploy/terraform/terraform.tfvars.example
+++ b/deploy/terraform/terraform.tfvars.example
@@ -11,8 +11,7 @@ domain = "greenhouse.madekivi.fi"
 # server_plan = "1xCPU-2GB"
 
 # Required environment variables (not in tfvars for security):
-#   export UPCLOUD_USERNAME="your-username"
-#   export UPCLOUD_PASSWORD="your-password"
+#   export UPCLOUD_TOKEN="your-api-token"
 #
 # After `terraform apply`, note the server_ip output and create
 # an A record in Gandi DNS pointing your domain to that IP.

--- a/specs/001-deploy-web-ui-cloud/quickstart.md
+++ b/specs/001-deploy-web-ui-cloud/quickstart.md
@@ -58,8 +58,7 @@ docker compose up
 cd deploy/terraform
 
 # Set credentials
-export UPCLOUD_USERNAME="your-username"
-export UPCLOUD_PASSWORD="your-password"
+export UPCLOUD_TOKEN="your-api-token"
 export CLOUDFLARE_API_TOKEN="your-token"
 
 # Configure variables


### PR DESCRIPTION
Use UPCLOUD_TOKEN env var instead of UPCLOUD_USERNAME/UPCLOUD_PASSWORD so basic auth API access doesn't need to be enabled in UpCloud.

https://claude.ai/code/session_01K5gRp6QUWhTqz9kJqAkutD