### PR TITLE
Fix server creation on UpCloud trial accounts

### DIFF
--- a/deploy/terraform/main.tf
+++ b/deploy/terraform/main.tf
@@ -82,6 +82,7 @@ resource "upcloud_server" "monitor" {
     keys = [var.ssh_public_key]
   }
 
+  firewall = true
   metadata = true
 
   user_data = templatefile("${path.module}/cloud-init.yaml", {


### PR DESCRIPTION
Add firewall = true to upcloud_server resource. Trial accounts require the firewall to be explicitly enabled at server creation time.

https://claude.ai/code/session_01GZr9UPeAQccoQ2zXEpwzqE