### PR TITLE
Add optional IP-restricted SSH access via firewall rule

### DIFF
--- a/deploy/terraform/main.tf
+++ b/deploy/terraform/main.tf
@@ -124,6 +124,21 @@ resource "upcloud_firewall_rules" "monitor" {
   }
 
   dynamic "firewall_rule" {
+    for_each = var.ssh_allow_ip != "" ? [1] : []
+    content {
+      action                    = "accept"
+      direction                 = "in"
+      family                    = "IPv4"
+      protocol                  = "tcp"
+      destination_port_start    = 22
+      destination_port_end      = 22
+      source_address_start      = var.ssh_allow_ip
+      source_address_end        = var.ssh_allow_ip
+      comment                   = "SSH (restricted to admin IP)"
+    }
+  }
+
+  dynamic "firewall_rule" {
     for_each = var.enable_vpn ? [1] : []
     content {
       action                 = "accept"

--- a/deploy/terraform/terraform.tfvars.example
+++ b/deploy/terraform/terraform.tfvars.example
@@ -2,7 +2,7 @@
 ssh_public_key = "ssh-ed25519 AAAA..."
 
 # Allow SSH from this IP address (optional — leave commented out to disable SSH access)
-# ssh_allow_ip = "88.192.35.229"
+# ssh_allow_ip = "your.ip.address.here"
 
 # Domain name for the monitoring UI
 domain = "greenhouse.madekivi.fi"

--- a/deploy/terraform/terraform.tfvars.example
+++ b/deploy/terraform/terraform.tfvars.example
@@ -1,5 +1,8 @@
-# SSH public key — required by UpCloud cloud-init templates (SSH port is NOT exposed)
+# SSH public key for server access
 ssh_public_key = "ssh-ed25519 AAAA..."
+
+# Allow SSH from this IP address (optional — leave commented out to disable SSH access)
+# ssh_allow_ip = "88.192.35.229"
 
 # Domain name for the monitoring UI
 domain = "greenhouse.madekivi.fi"

--- a/deploy/terraform/variables.tf
+++ b/deploy/terraform/variables.tf
@@ -4,7 +4,7 @@ variable "ssh_public_key" {
 }
 
 variable "ssh_allow_ip" {
-  description = "IP address allowed to SSH into the server (e.g., 88.192.35.229). Leave empty to disable SSH access."
+  description = "IP address allowed to SSH into the server. Leave empty to disable SSH access."
   type        = string
   default     = ""
 }

--- a/deploy/terraform/variables.tf
+++ b/deploy/terraform/variables.tf
@@ -1,6 +1,12 @@
 variable "ssh_public_key" {
-  description = "SSH public key for server access (required by UpCloud cloud-init templates, but SSH port is not exposed)"
+  description = "SSH public key for server access"
   type        = string
+}
+
+variable "ssh_allow_ip" {
+  description = "IP address allowed to SSH into the server (e.g., 88.192.35.229). Leave empty to disable SSH access."
+  type        = string
+  default     = ""
 }
 
 variable "domain" {


### PR DESCRIPTION
New ssh_allow_ip variable opens port 22 only to the specified IP. Defaults to empty (SSH disabled). The actual IP is set in terraform.tfvars which is gitignored.

https://claude.ai/code/session_01GZr9UPeAQccoQ2zXEpwzqE