### PR TITLE
Fix deployer: lowercase github_repo for Docker image references

### DIFF
--- a/deploy/terraform/main.tf
+++ b/deploy/terraform/main.tf
@@ -93,7 +93,7 @@ resource "upcloud_server" "monitor" {
     s3_access_key_id = upcloud_managed_object_storage_user_access_key.app.access_key_id
     s3_secret_key    = upcloud_managed_object_storage_user_access_key.app.secret_access_key
     s3_region        = var.objsto_region
-    github_repo      = var.github_repo
+    github_repo      = lower(var.github_repo)
     vpn_check_host   = ""
   })
 }

--- a/deploy/terraform/variables.tf
+++ b/deploy/terraform/variables.tf
@@ -45,6 +45,6 @@ variable "objsto_region" {
 }
 
 variable "github_repo" {
-  description = "GitHub repository in owner/name format for GHCR image (e.g., Wnt/greenhouse-solar-heater)"
+  description = "GitHub repository in owner/name format for GHCR image. Automatically lowercased for Docker compatibility."
   type        = string
 }


### PR DESCRIPTION
Docker requires all-lowercase image names, but the GitHub repo owner "Wnt" has an uppercase letter, causing the deployer service to fail with "invalid reference format".

https://claude.ai/code/session_01GZr9UPeAQccoQ2zXEpwzqE