### PR TITLE
Fix login page: allow CSS without auth, add .mjs MIME type

### DIFF
--- a/poc/server.js
+++ b/poc/server.js
@@ -28,6 +28,7 @@ const MIME = {
   '.json': 'application/json',
   '.svg': 'image/svg+xml',
   '.png': 'image/png',
+  '.mjs': 'application/javascript',
   '.ico': 'image/x-icon',
 };
 
@@ -158,7 +159,7 @@ var server = http.createServer(function (req, res) {
   }
 
   // Login page and its assets — accessible without auth
-  if (urlPath === '/login.html' || urlPath === '/js/login.js' || urlPath === '/vendor/simplewebauthn-browser.mjs') {
+  if (urlPath === '/login.html' || urlPath === '/js/login.js' || urlPath === '/vendor/simplewebauthn-browser.mjs' || urlPath === '/css/style.css') {
     serveStatic(req, res);
     return;
   }


### PR DESCRIPTION
The auth gate only whitelisted login.html, login.js, and the WebAuthn vendor module. CSS and .mjs files were being redirected to login.html, causing MIME type mismatches that broke styling and JavaScript modules.

https://claude.ai/code/session_01GZr9UPeAQccoQ2zXEpwzqE