### PR TITLE
Fix GH Pages startup: copy runtime dependencies into artifact

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -23,6 +23,11 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: actions/configure-pages@v5
+      - name: Copy runtime dependencies into playground
+        run: |
+          cp system.yaml playground/
+          mkdir -p playground/shelly
+          cp shelly/control-logic.js playground/shelly/
       - uses: actions/upload-pages-artifact@v3
         with:
           path: playground


### PR DESCRIPTION
## Summary

- The playground app fetches `../system.yaml` and `../shelly/control-logic.js` at runtime via relative paths
- The Pages deploy workflow only uploads the `playground/` directory, so these files were missing → 404 errors → SyntaxError on startup
- Added a build step to copy `system.yaml` and `shelly/control-logic.js` into the playground directory before uploading the Pages artifact

## Test plan

- [ ] Verify the deploy-pages workflow completes successfully
- [ ] Verify `https://wnt.github.io/greenhouse-solar-heater/system.yaml` returns YAML (not 404)
- [ ] Verify `https://wnt.github.io/greenhouse-solar-heater/shelly/control-logic.js` returns JS (not 404)
- [ ] Verify the playground loads without console errors

https://claude.ai/code/session_01TosAgGymN7xUru7dcpwSWN