### PR TITLE
Fix fetch paths for GH Pages: use same-directory relative paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,10 @@ deploy/terraform/*.tfstate*
 deploy/terraform/terraform.tfvars
 deploy/terraform/.terraform.lock.hcl
 
+# Copied runtime deps for playground (from repo root into playground/ for GH Pages compatibility)
+playground/system.yaml
+playground/shelly/
+
 # Environment files
 .env
 .env.*

--- a/playground/js/control-logic-loader.js
+++ b/playground/js/control-logic-loader.js
@@ -11,7 +11,7 @@ let _module;
 
 async function load() {
   if (_module) return _module;
-  const resp = await fetch('../shelly/control-logic.js');
+  const resp = await fetch('shelly/control-logic.js');
   const src = await resp.text();
 
   // Provide a `module` shim so the CommonJS export block works

--- a/playground/js/yaml-loader.js
+++ b/playground/js/yaml-loader.js
@@ -5,7 +5,7 @@
 
 let _cachedConfig = null;
 
-export async function loadSystemYaml(path = '../system.yaml') {
+export async function loadSystemYaml(path = 'system.yaml') {
   if (_cachedConfig) return _cachedConfig;
 
   const resp = await fetch(path);

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -19,7 +19,7 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: 'npx serve -l 3210 --no-clipboard',
+    command: 'cp system.yaml playground/ && mkdir -p playground/shelly && cp shelly/control-logic.js playground/shelly/ && npx serve -l 3210 --no-clipboard',
     port: 3210,
     reuseExistingServer: true,
     timeout: 10000,

--- a/playwright.screenshots.config.js
+++ b/playwright.screenshots.config.js
@@ -19,7 +19,7 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: 'npx serve -l 3210 --no-clipboard',
+    command: 'cp system.yaml playground/ && mkdir -p playground/shelly && cp shelly/control-logic.js playground/shelly/ && npx serve -l 3210 --no-clipboard',
     port: 3210,
     reuseExistingServer: true,
     timeout: 10000,


### PR DESCRIPTION
The playground fetches system.yaml and shelly/control-logic.js via ../ relative paths, which resolve above the GH Pages site root (404).

Changed fetch paths from ../system.yaml to system.yaml and from ../shelly/control-logic.js to shelly/control-logic.js. The deploy-pages workflow already copies these files into the playground artifact. Updated Playwright configs to also copy the files before serving locally.

https://claude.ai/code/session_01TosAgGymN7xUru7dcpwSWN