### PR TITLE
Fix 404 for /playground/ URLs when authenticated

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,9 +4,7 @@ tests/
 specs/
 deploy/terraform/
 design/
-playground/
 .github/
-shelly/
 test-results/
 *.md
 !monitor/**/*.md

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -12,6 +12,11 @@ RUN npm ci --omit=dev
 # Copy application code
 COPY monitor/ ./monitor/
 
+# Copy playground and its runtime dependencies (system.yaml, control logic)
+COPY playground/ ./playground/
+COPY system.yaml ./
+COPY shelly/control-logic.js ./shelly/
+
 # Make app directory owned by node user
 RUN chown -R node:node /app
 

--- a/monitor/index.html
+++ b/monitor/index.html
@@ -16,7 +16,7 @@
   <header class="page-header">
     <h1>Shelly Monitor</h1>
     <nav>
-      <a href="../playground/index.html">Playground</a>
+      <a href="/playground/">Playground</a>
       <button id="invite-btn" class="invite-btn" hidden>Add Device</button>
       <button id="logout-btn" class="logout-btn" hidden>Logout</button>
     </nav>

--- a/monitor/server.js
+++ b/monitor/server.js
@@ -43,44 +43,43 @@ const MIME = {
 };
 
 // ── Static file serving ──
-// Playground is the primary app; monitor files are also served for login, PWA, etc.
+// Monitor is the primary app at /; playground is served under /playground/.
+
+var SHELLY_DIR = path.join(__dirname, '..', 'shelly');
+var REPO_ROOT = path.join(__dirname, '..');
 
 function serveStatic(req, res) {
   var urlPath = new URL(req.url, 'http://localhost').pathname;
-  if (urlPath === '/') urlPath = '/index.html';
 
-  // Try playground first, then monitor directory
-  var playgroundPath = path.join(PLAYGROUND_DIR, urlPath);
-  var monitorPath = path.join(MONITOR_DIR, urlPath);
-
-  // Security: prevent directory traversal
-  if (!playgroundPath.startsWith(PLAYGROUND_DIR) && !monitorPath.startsWith(MONITOR_DIR)) {
-    res.writeHead(403);
-    res.end('Forbidden');
-    return;
+  // Playground routes: /playground, /playground/, /playground/**
+  if (urlPath === '/playground' || urlPath === '/playground/') {
+    return serveFile(path.join(PLAYGROUND_DIR, 'index.html'), '/index.html', res);
   }
+  if (urlPath.startsWith('/playground/')) {
+    var subPath = urlPath.slice('/playground'.length); // e.g. /js/app.js
 
-  // Serve system.yaml from repo root for playground
-  if (urlPath === '/system.yaml') {
-    var yamlPath = path.join(__dirname, '..', 'system.yaml');
-    return serveFile(yamlPath, urlPath, res);
-  }
-
-  // Serve shelly/ files for playground control-logic-loader
-  if (urlPath.startsWith('/shelly/')) {
-    var shellyPath = path.join(__dirname, '..', urlPath);
-    return serveFile(shellyPath, urlPath, res);
-  }
-
-  // Try playground directory first
-  fs.access(playgroundPath, fs.constants.R_OK, function (err) {
-    if (!err) {
-      serveFile(playgroundPath, urlPath, res);
-    } else {
-      // Fall back to monitor directory
-      serveFile(monitorPath, urlPath, res);
+    // /playground/shelly/* → serve from shelly/ dir (control-logic-loader fetches relative 'shelly/control-logic.js')
+    if (subPath.startsWith('/shelly/')) {
+      var shellyFile = path.join(SHELLY_DIR, subPath.slice('/shelly'.length));
+      if (!shellyFile.startsWith(SHELLY_DIR)) { res.writeHead(403); res.end('Forbidden'); return; }
+      return serveFile(shellyFile, subPath, res);
     }
-  });
+
+    var filePath = path.join(PLAYGROUND_DIR, subPath);
+    if (!filePath.startsWith(PLAYGROUND_DIR)) { res.writeHead(403); res.end('Forbidden'); return; }
+    return serveFile(filePath, subPath, res);
+  }
+
+  // Serve system.yaml from repo root (playground fetches ../system.yaml → /system.yaml)
+  if (urlPath === '/system.yaml') {
+    return serveFile(path.join(REPO_ROOT, 'system.yaml'), urlPath, res);
+  }
+
+  // Monitor routes: everything else from MONITOR_DIR
+  if (urlPath === '/') urlPath = '/index.html';
+  var monitorPath = path.join(MONITOR_DIR, urlPath);
+  if (!monitorPath.startsWith(MONITOR_DIR)) { res.writeHead(403); res.end('Forbidden'); return; }
+  serveFile(monitorPath, urlPath, res);
 }
 
 function serveFile(filePath, urlPath, res) {

--- a/monitor/server.js
+++ b/monitor/server.js
@@ -49,8 +49,16 @@ function serveStatic(req, res) {
   var urlPath = new URL(req.url, 'http://localhost').pathname;
   if (urlPath === '/') urlPath = '/index.html';
 
+  // Strip /playground/ prefix — PLAYGROUND_DIR already points to the playground folder
+  var playgroundUrlPath = urlPath;
+  if (urlPath === '/playground' || urlPath === '/playground/') {
+    playgroundUrlPath = '/index.html';
+  } else if (urlPath.startsWith('/playground/')) {
+    playgroundUrlPath = urlPath.slice('/playground'.length);
+  }
+
   // Try playground first, then monitor directory
-  var playgroundPath = path.join(PLAYGROUND_DIR, urlPath);
+  var playgroundPath = path.join(PLAYGROUND_DIR, playgroundUrlPath);
   var monitorPath = path.join(MONITOR_DIR, urlPath);
 
   // Security: prevent directory traversal

--- a/monitor/server.js
+++ b/monitor/server.js
@@ -49,16 +49,8 @@ function serveStatic(req, res) {
   var urlPath = new URL(req.url, 'http://localhost').pathname;
   if (urlPath === '/') urlPath = '/index.html';
 
-  // Strip /playground/ prefix — PLAYGROUND_DIR already points to the playground folder
-  var playgroundUrlPath = urlPath;
-  if (urlPath === '/playground' || urlPath === '/playground/') {
-    playgroundUrlPath = '/index.html';
-  } else if (urlPath.startsWith('/playground/')) {
-    playgroundUrlPath = urlPath.slice('/playground'.length);
-  }
-
   // Try playground first, then monitor directory
-  var playgroundPath = path.join(PLAYGROUND_DIR, playgroundUrlPath);
+  var playgroundPath = path.join(PLAYGROUND_DIR, urlPath);
   var monitorPath = path.join(MONITOR_DIR, urlPath);
 
   // Security: prevent directory traversal


### PR DESCRIPTION
## Summary

- **Root cause**: The server overlaid playground and monitor files at the same root `/` path, and the Docker image excluded playground files entirely. Requesting `/playground/index.html` resolved to `playground/playground/index.html` (doubled path → 404).
- **Fix**: Separate URL namespaces — monitor serves at `/`, playground serves at `/playground/`
- Include `playground/`, `system.yaml`, and `shelly/control-logic.js` in the Docker image
- Fix monitor nav link from `../playground/index.html` to `/playground/`

## Changes

- `monitor/server.js` — Rewrite `serveStatic` to route `/playground/**` to `PLAYGROUND_DIR` and everything else to `MONITOR_DIR`. Handle `/playground/shelly/*` for control-logic-loader.
- `monitor/index.html` — Fix playground link to `/playground/`
- `deploy/docker/Dockerfile` — Copy playground, system.yaml, and control-logic.js into image
- `.dockerignore` — Remove `playground/` and `shelly/` exclusions so Docker build context includes them

## Test plan

- [ ] Verify `https://greenhouse.madekivi.fi/playground/` loads correctly after passkey login
- [ ] Verify `https://greenhouse.madekivi.fi/playground/index.html` loads correctly
- [ ] Verify playground sub-resources load (JS, CSS, vendor, shelly/control-logic.js)
- [ ] Verify root `/` serves the monitor dashboard (not playground)
- [ ] Verify "Playground" link in monitor nav works
- [ ] Verify unauthenticated access to `/playground/` redirects to login

https://claude.ai/code/session_01XJhjQ6M1UgAmEbkbkq7VQB