### PR TITLE
fix: remove dns from app container (inherits from openvpn network)

### DIFF
--- a/deploy/deployer/deploy.sh
+++ b/deploy/deployer/deploy.sh
@@ -78,8 +78,8 @@ fi
 
 # Step 5: Resolve app image name for one-shot S3 operations
 # docker compose config --images lists ALL service images (no service filter).
-# Filter to the app image by excluding known non-app images (caddy, openvpn).
-APP_IMAGE=$(cd "$APP_DIR" && docker compose config --images 2>/dev/null | grep -v -e openvpn -e caddy | head -1)
+# Filter to the app image by excluding known non-app images (caddy, openvpn, mosquitto).
+APP_IMAGE=$(cd "$APP_DIR" && docker compose config --images 2>/dev/null | grep -v -e openvpn -e caddy -e mosquitto | head -1)
 if [ -z "$APP_IMAGE" ]; then
   log "WARNING: Could not determine app image — skipping VPN config sync"
 else

--- a/deploy/deployer/deploy.sh
+++ b/deploy/deployer/deploy.sh
@@ -77,9 +77,7 @@ if ! docker compose -f "$COMPOSE_FILE" pull --quiet 2>/dev/null; then
 fi
 
 # Step 5: Resolve app image name for one-shot S3 operations
-# docker compose config --images lists ALL service images (no service filter).
-# Filter to the app image by excluding known non-app images (caddy, openvpn, mosquitto).
-APP_IMAGE=$(cd "$APP_DIR" && docker compose config --images 2>/dev/null | grep -v -e openvpn -e caddy -e mosquitto | head -1)
+APP_IMAGE=$(cd "$APP_DIR" && docker compose config --images app 2>/dev/null)
 if [ -z "$APP_IMAGE" ]; then
   log "WARNING: Could not determine app image — skipping VPN config sync"
 else

--- a/deploy/deployer/docker-compose.yml
+++ b/deploy/deployer/docker-compose.yml
@@ -5,8 +5,6 @@ services:
     read_only: true
     user: "1000:1000"
     network_mode: "service:openvpn"
-    dns:
-      - 172.17.0.1
     env_file: .env
     tmpfs:
       - /tmp:noexec,nosuid,size=64m


### PR DESCRIPTION
Docker doesn't allow dns + network_mode on the same container. The app
uses network_mode: "service:openvpn", so it inherits DNS from the
openvpn container which already has dns: 172.17.0.1.

Also exclude mosquitto from the app image filter in deploy.sh.