### PR TITLE
feat: trust UpCloud managed DB CA cert for TLS connections

### DIFF
--- a/deploy/terraform/main.tf
+++ b/deploy/terraform/main.tf
@@ -116,9 +116,10 @@ resource "upcloud_managed_database_postgresql" "timeseries" {
   }
 }
 
-# ── Store DATABASE_URL in S3 ──
-# Uses the app image to run the db-config.js helper, same pattern as VPN config.
-# Runs on the Terraform operator's machine (needs node + npm install).
+# ── Store DATABASE_URL and CA certificate in S3 ──
+# Fetches the managed database CA cert via UpCloud API, then stores both
+# the connection URL and CA cert in S3 using the db-config.js helper.
+# Runs on the Terraform operator's machine (needs node + npm install + curl).
 
 resource "null_resource" "store_db_url" {
   triggers = {
@@ -127,7 +128,14 @@ resource "null_resource" "store_db_url" {
 
   provisioner "local-exec" {
     working_dir = "${path.module}/../.."
-    command     = "node monitor/lib/db-config.js store \"${upcloud_managed_database_postgresql.timeseries.service_uri}\""
+    command     = <<-EOT
+      curl -sf -H "Authorization: Bearer $UPCLOUD_TOKEN" \
+        "https://api.upcloud.com/1.3/database/${upcloud_managed_database_postgresql.timeseries.id}/ca-certificate" \
+        | node -e "var d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{var j=JSON.parse(d);process.stdout.write(j.certificate||j.ca_certificate||'')})" \
+        > /tmp/db-ca-cert.pem \
+      && node monitor/lib/db-config.js store "${upcloud_managed_database_postgresql.timeseries.service_uri}" --ca /tmp/db-ca-cert.pem \
+      && rm -f /tmp/db-ca-cert.pem
+    EOT
     environment = {
       S3_ENDPOINT          = "https://${[for e in upcloud_managed_object_storage.credentials.endpoint : e.domain_name if e.type == "public"][0]}"
       S3_BUCKET            = upcloud_managed_object_storage_bucket.credentials.name

--- a/monitor/lib/db-config.js
+++ b/monitor/lib/db-config.js
@@ -56,20 +56,24 @@ function load(callback) {
   }).then(function (body) {
     try {
       var data = JSON.parse(body);
-      callback(null, data.url || null);
+      callback(null, data.url || null, data.ca || null);
     } catch (e) {
       callback(new Error('Failed to parse database config JSON'));
     }
   }).catch(function (err) {
     if (err.name === 'NoSuchKey' || (err.$metadata && err.$metadata.httpStatusCode === 404)) {
-      callback(null, null);
+      callback(null, null, null);
     } else {
       callback(err);
     }
   });
 }
 
-function store(url, callback) {
+function store(url, ca, callback) {
+  if (typeof ca === 'function') {
+    callback = ca;
+    ca = null;
+  }
   var config = getS3Config();
   if (!config) {
     callback(new Error('S3 not configured'));
@@ -77,7 +81,9 @@ function store(url, callback) {
   }
   var PutObjectCommand = require('@aws-sdk/client-s3').PutObjectCommand;
   var client = getS3Client(config);
-  var body = JSON.stringify({ url: url }, null, 2);
+  var data = { url: url };
+  if (ca) data.ca = ca;
+  var body = JSON.stringify(data, null, 2);
   var cmd = new PutObjectCommand({
     Bucket: config.bucket,
     Key: S3_KEY,
@@ -113,15 +119,21 @@ function main() {
   } else if (command === 'store') {
     var url = args[1];
     if (!url) {
-      console.error('Usage: node db-config.js store <database-url>');
+      console.error('Usage: node db-config.js store <database-url> [--ca <cert-file>]');
       process.exit(1);
     }
-    store(url, function (err) {
+    var ca = null;
+    var caIdx = args.indexOf('--ca');
+    if (caIdx !== -1 && args[caIdx + 1]) {
+      var fs = require('fs');
+      ca = fs.readFileSync(args[caIdx + 1], 'utf8');
+    }
+    store(url, ca, function (err) {
       if (err) {
         console.error('[db-config] Store error: ' + err.message);
         process.exit(1);
       }
-      console.log('[db-config] Database URL stored in S3');
+      console.log('[db-config] Database URL' + (ca ? ' and CA cert' : '') + ' stored in S3');
     });
   } else {
     console.error('Usage: node db-config.js <store|load> [url]');

--- a/monitor/lib/db.js
+++ b/monitor/lib/db.js
@@ -13,6 +13,7 @@ var log = createLogger('db');
 
 var pool = null;
 var resolvedUrl = null;
+var resolvedCa = null;
 
 function getConnectionUrl() {
   return resolvedUrl || process.env.DATABASE_URL || null;
@@ -28,7 +29,7 @@ function resolveUrl(callback) {
 
   // 2. Try S3
   var dbConfig = require('./db-config');
-  dbConfig.load(function (err, url) {
+  dbConfig.load(function (err, url, ca) {
     if (err) {
       log.warn('failed to load DATABASE_URL from S3', { error: err.message });
       callback(null, null);
@@ -37,6 +38,10 @@ function resolveUrl(callback) {
     if (url) {
       resolvedUrl = url;
       log.info('DATABASE_URL loaded from S3');
+    }
+    if (ca) {
+      resolvedCa = ca;
+      log.info('DB CA certificate loaded from S3');
     }
     callback(null, resolvedUrl);
   });
@@ -47,11 +52,15 @@ function getPool() {
   var url = getConnectionUrl();
   if (!url) return null;
   var Pool = require('pg').Pool;
-  pool = new Pool({
+  var opts = {
     connectionString: url,
     max: 5,
     idleTimeoutMillis: 30000,
-  });
+  };
+  if (resolvedCa) {
+    opts.ssl = { ca: resolvedCa };
+  }
+  pool = new Pool(opts);
   pool.on('error', function (err) {
     log.error('unexpected pool error', { error: err.message });
   });
@@ -318,5 +327,5 @@ module.exports = {
   getHistory: getHistory,
   getEvents: getEvents,
   close: close,
-  _reset: function () { pool = null; },
+  _reset: function () { pool = null; resolvedCa = null; },
 };


### PR DESCRIPTION
Store the managed PostgreSQL CA certificate alongside the DATABASE_URL in S3 (database-url.json). The pg Pool receives the cert via ssl.ca, enabling proper TLS verification without disabling certificate checks.

- db-config.js: load() returns ca as third arg, store() accepts --ca
- db.js: passes ssl.ca to Pool when CA cert is available
- Terraform: fetches CA cert from UpCloud API before storing config

Fixes "self-signed certificate in certificate chain" error.

https://claude.ai/code/session_01XJhjQ6M1UgAmEbkbkq7VQB