### PR TITLE
fix: fetch CA cert from UpCloud API /1.3/database/certificate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ deploy/terraform/.terraform/
 deploy/terraform/*.tfstate*
 deploy/terraform/terraform.tfvars
 deploy/terraform/.terraform.lock.hcl
-deploy/terraform/db-ca-cert.pem
 
 # Copied runtime deps for playground (from repo root into playground/ for GH Pages compatibility)
 playground/system.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ deploy/terraform/.terraform/
 deploy/terraform/*.tfstate*
 deploy/terraform/terraform.tfvars
 deploy/terraform/.terraform.lock.hcl
+deploy/terraform/db-ca-cert.pem
 
 # Copied runtime deps for playground (from repo root into playground/ for GH Pages compatibility)
 playground/system.yaml

--- a/deploy/terraform/main.tf
+++ b/deploy/terraform/main.tf
@@ -117,9 +117,9 @@ resource "upcloud_managed_database_postgresql" "timeseries" {
 }
 
 # ── Store DATABASE_URL and CA certificate in S3 ──
-# Fetches the managed database CA cert via UpCloud API, then stores both
-# the connection URL and CA cert in S3 using the db-config.js helper.
-# Runs on the Terraform operator's machine (needs node + npm install + curl).
+# Extracts the CA cert from the database TLS connection via openssl, then stores
+# both the connection URL and CA cert in S3 using the db-config.js helper.
+# Runs on the Terraform operator's machine (needs node + npm install + openssl).
 
 resource "null_resource" "store_db_url" {
   triggers = {
@@ -129,10 +129,11 @@ resource "null_resource" "store_db_url" {
   provisioner "local-exec" {
     working_dir = "${path.module}/../.."
     command     = <<-EOT
-      curl -sf -H "Authorization: Bearer $UPCLOUD_TOKEN" \
-        "https://api.upcloud.com/1.3/database/${upcloud_managed_database_postgresql.timeseries.id}/ca-certificate" \
-        | node -e "var d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{var j=JSON.parse(d);process.stdout.write(j.certificate||j.ca_certificate||'')})" \
+      openssl s_client -connect ${upcloud_managed_database_postgresql.timeseries.service_host}:${upcloud_managed_database_postgresql.timeseries.service_port} \
+        -showcerts </dev/null 2>/dev/null \
+        | sed -n '/-----BEGIN CERTIFICATE-----/,/-----END CERTIFICATE-----/p' \
         > /tmp/db-ca-cert.pem \
+      && [ -s /tmp/db-ca-cert.pem ] \
       && node monitor/lib/db-config.js store "${upcloud_managed_database_postgresql.timeseries.service_uri}" --ca /tmp/db-ca-cert.pem \
       && rm -f /tmp/db-ca-cert.pem
     EOT

--- a/deploy/terraform/main.tf
+++ b/deploy/terraform/main.tf
@@ -117,9 +117,10 @@ resource "upcloud_managed_database_postgresql" "timeseries" {
 }
 
 # ── Store DATABASE_URL and CA certificate in S3 ──
-# Extracts the CA cert from the database TLS connection via openssl, then stores
-# both the connection URL and CA cert in S3 using the db-config.js helper.
-# Runs on the Terraform operator's machine (needs node + npm install + openssl).
+# Stores the connection URL and (optionally) CA cert in S3 via db-config.js.
+# To include the CA cert, place it at deploy/terraform/db-ca-cert.pem (download
+# from UpCloud control panel → Database → Overview → CA Certificate).
+# Runs on the Terraform operator's machine (needs node + npm install).
 
 resource "null_resource" "store_db_url" {
   triggers = {
@@ -129,13 +130,12 @@ resource "null_resource" "store_db_url" {
   provisioner "local-exec" {
     working_dir = "${path.module}/../.."
     command     = <<-EOT
-      openssl s_client -connect ${upcloud_managed_database_postgresql.timeseries.service_host}:${upcloud_managed_database_postgresql.timeseries.service_port} \
-        -showcerts </dev/null 2>/dev/null \
-        | sed -n '/-----BEGIN CERTIFICATE-----/,/-----END CERTIFICATE-----/p' \
-        > /tmp/db-ca-cert.pem \
-      && [ -s /tmp/db-ca-cert.pem ] \
-      && node monitor/lib/db-config.js store "${upcloud_managed_database_postgresql.timeseries.service_uri}" --ca /tmp/db-ca-cert.pem \
-      && rm -f /tmp/db-ca-cert.pem
+      if [ -f deploy/terraform/db-ca-cert.pem ]; then
+        node monitor/lib/db-config.js store "${upcloud_managed_database_postgresql.timeseries.service_uri}" --ca deploy/terraform/db-ca-cert.pem
+      else
+        echo "WARNING: deploy/terraform/db-ca-cert.pem not found — storing URL without CA cert"
+        node monitor/lib/db-config.js store "${upcloud_managed_database_postgresql.timeseries.service_uri}"
+      fi
     EOT
     environment = {
       S3_ENDPOINT          = "https://${[for e in upcloud_managed_object_storage.credentials.endpoint : e.domain_name if e.type == "public"][0]}"

--- a/deploy/terraform/main.tf
+++ b/deploy/terraform/main.tf
@@ -117,10 +117,10 @@ resource "upcloud_managed_database_postgresql" "timeseries" {
 }
 
 # ── Store DATABASE_URL and CA certificate in S3 ──
-# Stores the connection URL and (optionally) CA cert in S3 via db-config.js.
-# To include the CA cert, place it at deploy/terraform/db-ca-cert.pem (download
-# from UpCloud control panel → Database → Overview → CA Certificate).
-# Runs on the Terraform operator's machine (needs node + npm install).
+# Fetches the per-account CA cert from the UpCloud API, then stores both
+# the connection URL and CA cert in S3 using the db-config.js helper.
+# Runs on the Terraform operator's machine (needs node + npm install + curl).
+# Requires UPCLOUD_TOKEN env var (same as the Terraform provider).
 
 resource "null_resource" "store_db_url" {
   triggers = {
@@ -130,12 +130,11 @@ resource "null_resource" "store_db_url" {
   provisioner "local-exec" {
     working_dir = "${path.module}/../.."
     command     = <<-EOT
-      if [ -f deploy/terraform/db-ca-cert.pem ]; then
-        node monitor/lib/db-config.js store "${upcloud_managed_database_postgresql.timeseries.service_uri}" --ca deploy/terraform/db-ca-cert.pem
-      else
-        echo "WARNING: deploy/terraform/db-ca-cert.pem not found — storing URL without CA cert"
-        node monitor/lib/db-config.js store "${upcloud_managed_database_postgresql.timeseries.service_uri}"
-      fi
+      curl -sf -H "Authorization: Bearer $UPCLOUD_TOKEN" \
+        "https://api.upcloud.com/1.3/database/certificate" \
+        | node -e "var d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{var c=JSON.parse(d).certificate;require('fs').writeFileSync('/tmp/db-ca-cert.pem',c)})" \
+      && node monitor/lib/db-config.js store "${upcloud_managed_database_postgresql.timeseries.service_uri}" --ca /tmp/db-ca-cert.pem \
+      && rm -f /tmp/db-ca-cert.pem
     EOT
     environment = {
       S3_ENDPOINT          = "https://${[for e in upcloud_managed_object_storage.credentials.endpoint : e.domain_name if e.type == "public"][0]}"


### PR DESCRIPTION
The CA certificate endpoint is per-account (no database UUID), not
per-database. Fetches it automatically during terraform apply via
the same UPCLOUD_TOKEN used by the provider.