### PR TITLE
Add JS reload prompt with editorial toast

### DIFF
--- a/playground/css/style.css
+++ b/playground/css/style.css
@@ -1063,82 +1063,85 @@ button.primary:hover { opacity: 0.9; }
 
 .staleness-banner.visible { display: block; }
 
-/* ── Update Toast ── */
+/* ── Update Toast (top-right, compact) ── */
 .update-toast {
   position: fixed;
-  bottom: -120px;
-  left: 50%;
-  transform: translateX(-50%);
+  top: 16px;
+  right: 16px;
   z-index: 48;
-  transition: bottom 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+  opacity: 0;
+  transform: translateY(-12px);
+  transition: opacity 0.3s ease, transform 0.3s ease;
   pointer-events: none;
 }
 
 .update-toast.visible {
-  bottom: 100px;
+  opacity: 1;
+  transform: translateY(0);
   pointer-events: auto;
 }
 
 .update-toast-body {
-  background: var(--primary-container);
-  border: 1px solid rgba(233, 195, 73, 0.2);
-  border-radius: 12px;
-  padding: 16px 20px;
-  text-align: center;
-  min-width: 280px;
-  max-width: 380px;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  background: var(--surface-container-high);
+  border: 1px solid rgba(233, 195, 73, 0.15);
+  border-radius: 10px;
+  padding: 10px 14px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5);
+  max-width: 340px;
+}
+
+.update-toast-content {
+  flex: 1;
+  min-width: 0;
 }
 
 .update-toast-headline {
   font-family: 'Newsreader', Georgia, serif;
-  font-size: 16px;
+  font-style: italic;
+  font-size: 14px;
   font-weight: 500;
-  color: var(--primary);
-  margin-bottom: 4px;
-}
-
-.update-toast-text {
-  font-family: 'Manrope', sans-serif;
-  font-size: 13px;
-  color: var(--on-surface-variant);
-  margin-bottom: 12px;
+  color: var(--on-surface);
+  line-height: 1.3;
 }
 
 .update-toast-actions {
   display: flex;
-  gap: 8px;
-  justify-content: center;
+  gap: 6px;
+  flex-shrink: 0;
 }
 
 .update-toast-refresh {
   font-family: 'Manrope', sans-serif;
-  font-size: 13px;
+  font-size: 12px;
   font-weight: 600;
   background: var(--primary);
   color: var(--surface-container-lowest);
   border: none;
-  border-radius: 8px;
-  padding: 6px 16px;
+  border-radius: 6px;
+  padding: 5px 12px;
   cursor: pointer;
   transition: transform 0.2s, box-shadow 0.2s;
+  white-space: nowrap;
 }
 
 .update-toast-refresh:hover {
   transform: scale(1.04);
-  box-shadow: 0 2px 12px rgba(233, 195, 73, 0.3);
+  box-shadow: 0 2px 10px rgba(233, 195, 73, 0.3);
 }
 
 .update-toast-dismiss {
   font-family: 'Manrope', sans-serif;
-  font-size: 13px;
+  font-size: 12px;
   background: transparent;
   color: var(--on-surface-variant);
-  border: 1px solid var(--outline-variant);
-  border-radius: 8px;
-  padding: 6px 16px;
+  border: none;
+  padding: 5px 8px;
   cursor: pointer;
   transition: color 0.2s;
+  white-space: nowrap;
 }
 
 .update-toast-dismiss:hover {
@@ -1146,11 +1149,13 @@ button.primary:hover { opacity: 0.9; }
 }
 
 @media (max-width: 768px) {
-  .update-toast.visible {
-    bottom: calc(100px + env(safe-area-inset-bottom, 0px));
+  .update-toast {
+    top: 12px;
+    right: 12px;
+    left: 12px;
   }
   .update-toast-body {
-    min-width: 240px;
+    max-width: none;
   }
 }
 

--- a/playground/js/version-check.js
+++ b/playground/js/version-check.js
@@ -15,11 +15,12 @@ function createToast() {
   el.className = 'update-toast';
   el.innerHTML =
     '<div class="update-toast-body">' +
-      '<div class="update-toast-headline">A new edition is available</div>' +
-      '<div class="update-toast-text">We\u2019ve made some improvements. Refresh to see the latest.</div>' +
+      '<div class="update-toast-content">' +
+        '<div class="update-toast-headline">A new edition is available</div>' +
+      '</div>' +
       '<div class="update-toast-actions">' +
-        '<button class="update-toast-refresh">Refresh now</button>' +
-        '<button class="update-toast-dismiss">Later</button>' +
+        '<button class="update-toast-refresh">Refresh</button>' +
+        '<button class="update-toast-dismiss">\u00d7</button>' +
       '</div>' +
     '</div>';
   el.querySelector('.update-toast-refresh').addEventListener('click', function () {

--- a/tests/e2e/version-check.spec.js
+++ b/tests/e2e/version-check.spec.js
@@ -41,9 +41,8 @@ test.describe('Version check toast', () => {
     await triggerPoll(page);
 
     await expect(page.locator('.update-toast-headline')).toHaveText('A new edition is available');
-    await expect(page.locator('.update-toast-text')).toContainText('improvements');
-    await expect(page.locator('.update-toast-refresh')).toHaveText('Refresh now');
-    await expect(page.locator('.update-toast-dismiss')).toHaveText('Later');
+    await expect(page.locator('.update-toast-refresh')).toHaveText('Refresh');
+    await expect(page.locator('.update-toast-dismiss')).toHaveText('\u00d7');
   });
 
   test('dismiss hides the toast', async ({ page }) => {


### PR DESCRIPTION
## Summary

- Add `GET /version` server endpoint that returns the `GIT_COMMIT` env var (already baked into the Docker image at build time via `github.sha`), enabling clients to detect new deployments
- Add `playground/js/version-check.js` ES6 module that polls `/version` every 30s and shows a compact top-right toast when the commit hash changes
- Toast uses editorial language ("A new edition is available") in Newsreader italic serif, with a "Refresh" button and × dismiss — subtle and non-obstructive
- Styled with the Stitch design system: high-contrast text (`--on-surface` on `--surface-container-high`), gold accent button, fade-slide animation
- Responsive: top-right corner on desktop, full-width banner on mobile (≤768px)
- Silent failure on network errors — no visible errors to the user
- In local dev, `GIT_COMMIT` defaults to `"unknown"` so the toast never triggers false positives

## Test plan

- [x] 3 unit tests: GIT_COMMIT value returned, default to "unknown", stability
- [x] 5 Playwright e2e tests: toast appearance, editorial copy, dismiss, no-change, silent failure
- [ ] Manual verification: start server with `GIT_COMMIT=abc`, restart with `GIT_COMMIT=def`, confirm toast appears within 30s

https://claude.ai/code/session_01TGADsVEd2gaY3JaY56EZPZ