### PR TITLE
Improve live mode connection state handling and display

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -504,12 +504,13 @@
           if (lastDataTime > 0 && (Date.now() - lastDataTime) > 60000) return 'stale';
           return 'active';
         }
-        // No data yet — allow a grace period before declaring device offline
+        // WS connected, waiting for MQTT status or data — show connecting overlay
+        // Brief grace period (2s) before declaring device offline
         var connectedAt = liveSource ? liveSource._connectedAt : 0;
-        if (connectedAt > 0 && (Date.now() - connectedAt) > 10000) {
+        if (connectedAt > 0 && (Date.now() - connectedAt) > 2000) {
           return 'device_offline';
         }
-        return 'active'; // within grace period
+        return 'connecting';
       }
 
       // WS is not connected or reconnecting
@@ -590,8 +591,10 @@
           lastDataTime = Date.now();
           if (activeSource === 'live') {
             updateDisplay(state, result);
+            refreshConnectionIndicator();
             updateConnectionOverlays();
             updateSidebarSubtitle();
+            updateDevicePushState();
           }
         });
         liveSource.onConnectionChange(function (status) {
@@ -613,8 +616,30 @@
         stalenessTimer = setInterval(checkStaleness, 5000);
       }
       // Immediately show connecting/offline state (don't show stale simulation data)
+      clearLiveDisplay();
       updateConnectionUI('disconnected');
       updateSidebarSubtitle();
+    }
+
+    function clearLiveDisplay() {
+      // Reset display to placeholder values — never show simulation defaults in live mode
+      document.getElementById('mode-card-title').textContent = '--';
+      document.getElementById('mode-card-status').innerHTML = '';
+      document.getElementById('tank-temp-val').textContent = '--';
+      document.getElementById('tank-temp-status').textContent = '';
+      document.getElementById('tank-temp-message').textContent = '';
+      document.getElementById('tank-stat-energy').textContent = '--';
+      document.getElementById('tank-stat-greenhouse').textContent = '--';
+      document.getElementById('inactive-modes').innerHTML = '';
+      document.getElementById('graph-peak-label').textContent = "Yesterday's High: --";
+      var arc = document.getElementById('tank-gauge-arc');
+      if (arc) arc.setAttribute('stroke-dashoffset', '628');
+      // Clear component statuses
+      var compEls = document.querySelectorAll('.comp-status');
+      compEls.forEach(function(el) { el.textContent = '--'; });
+      // Clear simulation graph data and redraw empty canvas
+      store.reset();
+      drawHistoryGraph();
     }
 
     function switchToSimulation() {

--- a/tests/data-source.test.js
+++ b/tests/data-source.test.js
@@ -149,10 +149,10 @@ describe('data-source contract', () => {
         if (lastDataTime > 0 && (now - lastDataTime) > 60000) return 'stale';
         return 'active';
       }
-      if (connectedAt > 0 && (now - connectedAt) > 10000) {
+      if (connectedAt > 0 && (now - connectedAt) > 2000) {
         return 'device_offline';
       }
-      return 'active'; // within grace period
+      return 'connecting'; // waiting for MQTT status
     }
 
     // WS is not connected or reconnecting
@@ -191,7 +191,7 @@ describe('data-source contract', () => {
   });
 
   it('display state: device_offline after grace period with no data', () => {
-    var connectedAt = Date.now() - 15000; // 15s ago
+    var connectedAt = Date.now() - 5000; // 5s ago (> 2s grace)
     assert.strictEqual(getConnectionDisplayState({
       connectionStatus: 'connected',
       mqttStatus: 'connected',
@@ -201,15 +201,15 @@ describe('data-source contract', () => {
     }), 'device_offline');
   });
 
-  it('display state: active during grace period (WS just connected, no data yet)', () => {
-    var connectedAt = Date.now() - 2000; // 2s ago
+  it('display state: connecting during grace period (WS just connected, no data yet)', () => {
+    var connectedAt = Date.now() - 500; // 500ms ago (< 2s grace)
     assert.strictEqual(getConnectionDisplayState({
       connectionStatus: 'connected',
       mqttStatus: 'unknown',
       hasReceivedData: false,
       connectedAt: connectedAt,
       now: Date.now(),
-    }), 'active');
+    }), 'connecting');
   });
 
   it('display state: stale when data stops flowing for 60+ seconds', () => {


### PR DESCRIPTION
## Summary
This PR refines the connection state management and display behavior in live mode to provide clearer user feedback during the initial connection phase and prevent stale simulation data from being shown.

## Key Changes

- **Reduced grace period from 10s to 2s**: Devices are now marked as offline more quickly if no data arrives after WebSocket connection, improving responsiveness to actual connection issues.

- **New "connecting" state**: Introduced a distinct `connecting` display state that shows during the brief grace period after WebSocket connection but before MQTT data arrives. This replaces the misleading `active` state and provides clearer visual feedback to users.

- **Clear live display on mode switch**: Added `clearLiveDisplay()` function that resets all UI elements to placeholder values (`--`) when entering live mode. This prevents simulation data from being momentarily visible before live data arrives.

- **Enhanced data update callbacks**: Added calls to `refreshConnectionIndicator()` and `updateDevicePushState()` when live data is received, ensuring all connection-related UI elements stay synchronized.

- **Updated test cases**: Modified test expectations to reflect the new 2-second grace period and `connecting` state behavior.

## Implementation Details

The `clearLiveDisplay()` function comprehensively resets:
- Mode card title and status
- Tank temperature values and messages
- Energy and greenhouse statistics
- Component statuses
- Graph data and visualization

This ensures a clean slate in live mode and prevents confusing transitions from simulation defaults to actual device data.

https://claude.ai/code/session_01MXMK5A4hQQGHXyBD2ZKX3o