### PR TITLE
Optimize CI/CD workflows with npm and Playwright caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,17 @@ jobs:
           node-version: 22
       - name: Install dependencies
         run: npm ci
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
       - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
+      - name: Install Playwright system deps only
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
       - name: Run e2e tests
         run: npm run test:e2e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 22
+          cache: npm
       - name: Install dependencies
         run: npm ci
       - name: Run unit & simulation tests
@@ -23,6 +24,7 @@ jobs:
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 22
+          cache: npm
       - name: Install dependencies
         run: npm ci
       - name: Cache Playwright browsers

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,8 +21,18 @@ jobs:
 
       - run: npm ci
 
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
       - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
+      - name: Install Playwright system deps only
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
 
       - run: npm test
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 22
+          cache: npm
 
       - run: npm ci
 

--- a/.github/workflows/lint-shelly.yml
+++ b/.github/workflows/lint-shelly.yml
@@ -16,8 +16,10 @@ jobs:
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 22
+          cache: npm
+          cache-dependency-path: shelly/lint/package-lock.json
       - name: Install linter dependencies
         working-directory: shelly/lint
-        run: npm install
+        run: npm ci
       - name: Lint Shelly scripts
         run: node shelly/lint/bin/shelly-lint.js shelly/control-logic.js shelly/control.js --config system.yaml --format github


### PR DESCRIPTION
## Summary
This PR optimizes GitHub Actions workflows by implementing caching strategies for npm dependencies and Playwright browsers, reducing build times and improving CI/CD efficiency across all workflows.

## Key Changes
- **npm dependency caching**: Added `cache: npm` to the `setup-node` action in all three workflows (ci.yml, deploy.yml, lint-shelly.yml) to cache node_modules and avoid redundant downloads
- **Playwright browser caching**: Implemented intelligent caching for Playwright browsers in ci.yml and deploy.yml:
  - Cache Playwright browsers at `~/.cache/ms-playwright` using package-lock.json as the cache key
  - Only run full `playwright install --with-deps` when cache is missed
  - Run `playwright install-deps` only when cache is hit to install system dependencies without re-downloading browsers
- **Dependency installation improvements**: Changed `npm install` to `npm ci` in lint-shelly.yml for more reliable and reproducible builds
- **Lint workflow configuration**: Added explicit `cache-dependency-path` for the Shelly lint workflow to properly cache its isolated dependencies

## Implementation Details
The Playwright caching strategy uses conditional steps based on cache hit status:
- Cache miss: Full installation with dependencies (`--with-deps`)
- Cache hit: System dependencies only (`install-deps`), reusing cached browsers

This approach significantly reduces workflow execution time while maintaining proper system dependency installation.

https://claude.ai/code/session_013tZX4F5wL7Egq89xwrfzLW