### PR TITLE
Deduplicate CI test runs on main via reusable workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches-ignore: [main, master]
+  workflow_call:
 
 jobs:
   test-unit:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   push:
+    branches-ignore: [main, master]
 
 jobs:
   test-unit:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   push:
+    branches-ignore: [main, master]
   workflow_call:
 
 jobs:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,31 +11,7 @@ env:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
-
-      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
-        with:
-          node-version: 22
-          cache: npm
-
-      - run: npm ci
-
-      - name: Cache Playwright browsers
-        id: playwright-cache
-        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
-      - name: Install Playwright browsers
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: npx playwright install --with-deps chromium
-      - name: Install Playwright system deps only
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
-        run: npx playwright install-deps chromium
-
-      - run: npm test
+    uses: ./.github/workflows/ci.yml
 
   build-app:
     needs: test


### PR DESCRIPTION
## Summary

- **deploy.yml** now calls **ci.yml** via `workflow_call` instead of defining its own test job. This eliminates duplicated test configuration and ensures tests run exactly once on main.
- **ci.yml** adds `branches-ignore: [main, master]` so it only triggers standalone on feature branches, and `workflow_call` so deploy.yml can invoke it on main.

**Result**: pushes to main run tests once (unit + e2e in parallel via ci.yml) → build → deploy. Previously tests ran twice (ci.yml + deploy.yml's own serial test job).

## Test plan

- [ ] Verify CI passes on this branch (unit + e2e via ci.yml)
- [ ] After merge, confirm only deploy.yml triggers on main (no standalone ci.yml run)
- [ ] Confirm deploy.yml test job shows two parallel sub-jobs (test-unit, test-e2e)

https://claude.ai/code/session_013tZX4F5wL7Egq89xwrfzLW