### PR TITLE
Hide Settings view on GitHub Pages

### DIFF
--- a/playground/js/app-state.js
+++ b/playground/js/app-state.js
@@ -57,9 +57,15 @@ export const derived = {
 
   get availableViews() {
     const phase = store.get('phase');
-    if (phase === 'live' || phase === 'init') return ['status', 'components', 'schematic', 'sensors', 'device', 'settings'];
-    if (phase === 'simulation') return ['status', 'components', 'schematic', 'controls', 'settings'];
-    return ['status', 'components', 'schematic', 'settings'];
+    // Settings (PWA install, notifications, account) only makes sense when the
+    // app is backed by a real server. On GH Pages (isLiveCapable=false) there
+    // is nothing to configure, so we hide it.
+    const hasSettings = store.get('isLiveCapable');
+    const views = ['status', 'components', 'schematic'];
+    if (phase === 'live' || phase === 'init') views.push('sensors', 'device');
+    if (phase === 'simulation') views.push('controls');
+    if (hasSettings) views.push('settings');
+    return views;
   },
 
   get connectionDisplay() {

--- a/tests/e2e/mobile-ui.spec.js
+++ b/tests/e2e/mobile-ui.spec.js
@@ -15,6 +15,39 @@ test.describe('Simulation-only mode overlays (GitHub Pages context)', () => {
   });
 });
 
+test.describe('Settings visibility on GitHub Pages', () => {
+  test('Settings nav is hidden when isLiveCapable is false', async ({ page }) => {
+    await page.goto('/playground/');
+    await page.waitForSelector('.sidebar-nav');
+    // We can't fake location.hostname reliably across browsers, so stub the
+    // store value after boot and re-fire the phase subscription to refresh
+    // nav visibility. Setting phase to the same value is a no-op in the
+    // store, so toggle through a throwaway value first.
+    await page.evaluate(async () => {
+      const { store } = await import('/playground/js/app-state.js');
+      store.set('isLiveCapable', false);
+      const phase = store.get('phase');
+      store.set('phase', '__refresh__');
+      store.set('phase', phase);
+    });
+    await page.waitForTimeout(200);
+    // The Settings anchor stays in the DOM (HTML unchanged) but must be hidden
+    await expect(page.locator('.sidebar-nav [data-view="settings"]')).toBeHidden();
+    await expect(page.locator('.bottom-nav [data-view="settings"]')).toBeHidden();
+    // Navigating directly via hash falls back to status
+    await page.evaluate(() => { window.location.hash = 'settings'; });
+    await page.waitForTimeout(200);
+    await expect(page.locator('#view-status')).toHaveClass(/active/);
+  });
+
+  test('Settings nav is visible on localhost (live-capable)', async ({ page }) => {
+    await page.goto('/playground/');
+    await page.waitForSelector('.sidebar-nav');
+    await page.waitForTimeout(200);
+    await expect(page.locator('.sidebar-nav [data-view="settings"]')).toBeVisible();
+  });
+});
+
 test.describe('Mobile: mode toggle visibility', () => {
   test('mode toggle is visible at mobile viewport width', async ({ page }) => {
     await page.setViewportSize(MOBILE);


### PR DESCRIPTION
## Summary
Filters the Settings nav entry and view out of \`derived.availableViews\` when \`store.get('isLiveCapable')\` is false. The GH Pages deployment sets \`isLiveCapable = false\` (via the existing hostname check in \`playground/js/main.js\`), so on \`*.github.io\` the bar now renders without Settings — on localhost and the cloud-deployed app it keeps it.

## Why
The Settings view contains three things: PWA install prompt, push-notification opt-in toggles, and account management (logout / add-device invitation). All three require a backing server:
- **PWA install** technically works on GH Pages but is driven from the same panel as the server-backed features, so the card is always in a confusing half-broken state.
- **Push notifications** require a VAPID key and a server that persists subscriptions — GH Pages has neither.
- **Account management** needs a passkey server to talk to.

On GH Pages the entire view is dead weight, so we hide it. No HTML is removed; only the nav visibility + route availability are gated, which means re-enabling later (or running locally) needs zero DOM work.

## Implementation
Single change in \`playground/js/app-state.js\` — the \`availableViews\` getter now reads \`isLiveCapable\` from the store and conditionally pushes \`'settings'\` onto the returned list:

\`\`\`js
get availableViews() {
  const phase = store.get('phase');
  const hasSettings = store.get('isLiveCapable');
  const views = ['status', 'components', 'schematic'];
  if (phase === 'live' || phase === 'init') views.push('sensors', 'device');
  if (phase === 'simulation') views.push('controls');
  if (hasSettings) views.push('settings');
  return views;
}
\`\`\`

The existing \`store.subscribe('phase', ...)\` in \`subscriptions.js\` already hides nav entries whose \`data-view\` isn't in \`availableViews\`, and \`navigation.js\` already falls back to \`#status\` when the current hash isn't available — so no other plumbing is needed. \`isLiveCapable\` is set before \`phase\` in \`main.js\`, so by the time the phase subscription fires, the flag is in place.

## Test plan
- [x] \`npx playwright test\` — 171 / 171 pass (added 2 new tests to \`mobile-ui.spec.js\`)
- [x] \`npm run test:unit\` — 468 / 468 pass
- [x] Added \`Settings visibility on GitHub Pages › Settings nav is hidden when isLiveCapable is false\` — goes via the store directly (reliable hostname faking isn't portable)
- [x] Added \`Settings visibility on GitHub Pages › Settings nav is visible on localhost (live-capable)\` — regression guard for the cloud/localhost path
- [ ] Reviewer: after deploy, open the published GH Pages URL and confirm the Settings nav entry is gone from both the sidebar and the bottom nav

🤖 Generated with [Claude Code](https://claude.com/claude-code)