### PR TITLE
Add browser favicon using existing PWA icons

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -7,6 +7,8 @@
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <link rel="manifest" href="manifest.webmanifest">
+  <link rel="icon" type="image/png" sizes="192x192" href="assets/icon-192.png">
+  <link rel="icon" type="image/png" sizes="512x512" href="assets/icon-512.png">
   <link rel="apple-touch-icon" href="assets/icon-192.png">
   <title>Helios Canopy — Thermal Simulation</title>
   <link rel="stylesheet" href="css/style.css">

--- a/playground/login.html
+++ b/playground/login.html
@@ -7,6 +7,8 @@
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <link rel="manifest" href="manifest.webmanifest">
+  <link rel="icon" type="image/png" sizes="192x192" href="assets/icon-192.png">
+  <link rel="icon" type="image/png" sizes="512x512" href="assets/icon-512.png">
   <link rel="apple-touch-icon" href="assets/icon-192.png">
   <title>Sign in — Helios Canopy</title>
   <link rel="stylesheet" href="css/style.css">


### PR DESCRIPTION
## Summary
Adds \`<link rel=\"icon\" type=\"image/png\">\` entries (192px + 512px) to \`playground/index.html\` and \`playground/login.html\`, reusing the existing PWA icons at \`playground/assets/icon-{192,512}.png\`. Both the GH Pages deploy and the cloud deploy at https://greenhouse.madekivi.fi now get a tab icon for free — no new assets, no build step, no server changes.

## Why
Both HTML files already had \`rel=\"apple-touch-icon\"\` for iOS home-screen install, but browsers use \`rel=\"icon\"\` for the browser tab / bookmark / history icon. Without it, Chrome/Firefox/Safari show the default page-with-fold icon in the tab, which looks unfinished next to real apps.

Reusing the PWA icons keeps the branding consistent everywhere:
- Android home screen (PWA install)
- iOS home screen (apple-touch-icon)
- Browser tab (this PR)
- Notifications

## No server changes needed
\`server/server.js\` already exempts \`/assets/icon-*.png\` from auth (line 416 of the current main), so the unauthenticated \`login.html\` can fetch its favicon before the user signs in. GH Pages serves everything statically so it's a non-issue there.

## Test plan
- [x] Verified \`<link rel=\"icon\">\` tags are present in both files (\`grep\`)
- [x] Verified the tags resolve correctly in Chrome DevTools — \`document.querySelectorAll('link[rel=\"icon\"]')\` returns the two entries with the expected \`sizes\` and \`href\`
- [x] \`npx playwright test\` — 171 / 171 pass (no test regressions from the HTML head change)
- [ ] Reviewer: after deploy, check that Chrome on Android shows the icon in the tab on both https://wnt.github.io/greenhouse-solar-heater/playground/ and https://greenhouse.madekivi.fi

🤖 Generated with [Claude Code](https://claude.com/claude-code)