### PR TITLE
Refactor solar charging exit logic to track tank rise instead of collector delta

### DIFF
--- a/playground/assets/bootstrap-history.json
+++ b/playground/assets/bootstrap-history.json
@@ -250,42 +250,42 @@
     {
       "time": 1320,
       "values": {
-        "t_tank_top": 11.4207,
-        "t_tank_bottom": 10.296,
-        "t_collector": 12.8057,
+        "t_tank_top": 11.441,
+        "t_tank_bottom": 10.2962,
+        "t_collector": 12.1863,
         "t_greenhouse": 10.7459,
         "t_outdoor": 9.1744
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 1380,
       "values": {
-        "t_tank_top": 11.3814,
-        "t_tank_bottom": 10.3348,
-        "t_collector": 13.5887,
+        "t_tank_top": 11.428,
+        "t_tank_bottom": 10.3363,
+        "t_collector": 12.1258,
         "t_greenhouse": 10.745,
         "t_outdoor": 9.1959
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 1440,
       "values": {
-        "t_tank_top": 11.3448,
-        "t_tank_bottom": 10.371,
-        "t_collector": 14.3635,
+        "t_tank_top": 11.4159,
+        "t_tank_bottom": 10.3745,
+        "t_collector": 12.1079,
         "t_greenhouse": 10.7449,
         "t_outdoor": 9.2175
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 1500,
       "values": {
-        "t_tank_top": 11.3107,
-        "t_tank_bottom": 10.4046,
-        "t_collector": 15.1302,
+        "t_tank_top": 11.4009,
+        "t_tank_bottom": 10.4109,
+        "t_collector": 12.2621,
         "t_greenhouse": 10.7456,
         "t_outdoor": 9.239
       },
@@ -294,9 +294,9 @@
     {
       "time": 1560,
       "values": {
-        "t_tank_top": 11.279,
-        "t_tank_bottom": 10.4358,
-        "t_collector": 15.889,
+        "t_tank_top": 11.3663,
+        "t_tank_bottom": 10.445,
+        "t_collector": 13.0719,
         "t_greenhouse": 10.7469,
         "t_outdoor": 9.2606
       },
@@ -305,9 +305,9 @@
     {
       "time": 1620,
       "values": {
-        "t_tank_top": 11.2495,
-        "t_tank_bottom": 10.4649,
-        "t_collector": 16.64,
+        "t_tank_top": 11.334,
+        "t_tank_bottom": 10.4768,
+        "t_collector": 13.8731,
         "t_greenhouse": 10.749,
         "t_outdoor": 9.2822
       },
@@ -316,9 +316,9 @@
     {
       "time": 1680,
       "values": {
-        "t_tank_top": 11.222,
-        "t_tank_bottom": 10.492,
-        "t_collector": 17.3834,
+        "t_tank_top": 11.304,
+        "t_tank_bottom": 10.5064,
+        "t_collector": 14.6657,
         "t_greenhouse": 10.7518,
         "t_outdoor": 9.3038
       },
@@ -327,9 +327,9 @@
     {
       "time": 1740,
       "values": {
-        "t_tank_top": 11.1964,
-        "t_tank_bottom": 10.5171,
-        "t_collector": 18.1192,
+        "t_tank_top": 11.276,
+        "t_tank_bottom": 10.5339,
+        "t_collector": 15.4498,
         "t_greenhouse": 10.7552,
         "t_outdoor": 9.3254
       },
@@ -338,9 +338,9 @@
     {
       "time": 1800,
       "values": {
-        "t_tank_top": 11.1725,
-        "t_tank_bottom": 10.5405,
-        "t_collector": 18.8477,
+        "t_tank_top": 11.25,
+        "t_tank_bottom": 10.5594,
+        "t_collector": 16.2258,
         "t_greenhouse": 10.7593,
         "t_outdoor": 9.347
       },
@@ -349,9 +349,9 @@
     {
       "time": 1860,
       "values": {
-        "t_tank_top": 11.1504,
-        "t_tank_bottom": 10.5623,
-        "t_collector": 19.5688,
+        "t_tank_top": 11.2258,
+        "t_tank_bottom": 10.5832,
+        "t_collector": 16.9935,
         "t_greenhouse": 10.764,
         "t_outdoor": 9.3686
       },
@@ -360,9 +360,9 @@
     {
       "time": 1920,
       "values": {
-        "t_tank_top": 11.1297,
-        "t_tank_bottom": 10.5825,
-        "t_collector": 20.2828,
+        "t_tank_top": 11.2032,
+        "t_tank_bottom": 10.6053,
+        "t_collector": 17.7533,
         "t_greenhouse": 10.7694,
         "t_outdoor": 9.3903
       },
@@ -371,42 +371,42 @@
     {
       "time": 1980,
       "values": {
-        "t_tank_top": 11.2915,
-        "t_tank_bottom": 10.6032,
-        "t_collector": 18.6704,
+        "t_tank_top": 11.1823,
+        "t_tank_bottom": 10.6259,
+        "t_collector": 18.5052,
         "t_greenhouse": 10.7754,
         "t_outdoor": 9.412
       },
-      "mode": "solar_charging"
+      "mode": "idle"
     },
     {
       "time": 2040,
       "values": {
-        "t_tank_top": 11.4992,
-        "t_tank_bottom": 10.6314,
-        "t_collector": 16.2621,
+        "t_tank_top": 11.1627,
+        "t_tank_bottom": 10.645,
+        "t_collector": 19.2493,
         "t_greenhouse": 10.7819,
         "t_outdoor": 9.4336
       },
-      "mode": "solar_charging"
+      "mode": "idle"
     },
     {
       "time": 2100,
       "values": {
-        "t_tank_top": 11.6203,
-        "t_tank_bottom": 10.6643,
-        "t_collector": 14.802,
+        "t_tank_top": 11.1445,
+        "t_tank_bottom": 10.6628,
+        "t_collector": 19.9859,
         "t_greenhouse": 10.7891,
         "t_outdoor": 9.4553
       },
-      "mode": "solar_charging"
+      "mode": "idle"
     },
     {
       "time": 2160,
       "values": {
-        "t_tank_top": 11.69,
-        "t_tank_bottom": 10.6993,
-        "t_collector": 13.9243,
+        "t_tank_top": 11.1463,
+        "t_tank_bottom": 10.6794,
+        "t_collector": 20.4817,
         "t_greenhouse": 10.7968,
         "t_outdoor": 9.477
       },
@@ -415,9 +415,9 @@
     {
       "time": 2220,
       "values": {
-        "t_tank_top": 11.7297,
-        "t_tank_bottom": 10.7349,
-        "t_collector": 13.404,
+        "t_tank_top": 11.4227,
+        "t_tank_bottom": 10.7011,
+        "t_collector": 17.4128,
         "t_greenhouse": 10.8051,
         "t_outdoor": 9.4987
       },
@@ -426,9 +426,9 @@
     {
       "time": 2280,
       "values": {
-        "t_tank_top": 11.7524,
-        "t_tank_bottom": 10.7703,
-        "t_collector": 13.1028,
+        "t_tank_top": 11.5873,
+        "t_tank_bottom": 10.7296,
+        "t_collector": 15.5458,
         "t_greenhouse": 10.8139,
         "t_outdoor": 9.5204
       },
@@ -437,9 +437,9 @@
     {
       "time": 2340,
       "values": {
-        "t_tank_top": 11.7658,
-        "t_tank_bottom": 10.805,
-        "t_collector": 12.9357,
+        "t_tank_top": 11.6849,
+        "t_tank_bottom": 10.7617,
+        "t_collector": 14.4173,
         "t_greenhouse": 10.8232,
         "t_outdoor": 9.5421
       },
@@ -448,9 +448,9 @@
     {
       "time": 2400,
       "values": {
-        "t_tank_top": 11.7749,
-        "t_tank_bottom": 10.839,
-        "t_collector": 12.8506,
+        "t_tank_top": 11.7427,
+        "t_tank_bottom": 10.7952,
+        "t_collector": 13.7424,
         "t_greenhouse": 10.833,
         "t_outdoor": 9.5639
       },
@@ -459,108 +459,108 @@
     {
       "time": 2460,
       "values": {
-        "t_tank_top": 11.7481,
-        "t_tank_bottom": 10.8715,
-        "t_collector": 13.5954,
+        "t_tank_top": 11.7775,
+        "t_tank_bottom": 10.8292,
+        "t_collector": 13.3458,
         "t_greenhouse": 10.8434,
         "t_outdoor": 9.5856
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 2520,
       "values": {
-        "t_tank_top": 11.7174,
-        "t_tank_bottom": 10.9017,
-        "t_collector": 14.4715,
+        "t_tank_top": 11.7993,
+        "t_tank_bottom": 10.863,
+        "t_collector": 13.1197,
         "t_greenhouse": 10.8542,
         "t_outdoor": 9.6073
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 2580,
       "values": {
-        "t_tank_top": 11.6888,
-        "t_tank_bottom": 10.9298,
-        "t_collector": 15.3375,
+        "t_tank_top": 11.8141,
+        "t_tank_bottom": 10.8961,
+        "t_collector": 12.9981,
         "t_greenhouse": 10.8656,
         "t_outdoor": 9.6291
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 2640,
       "values": {
-        "t_tank_top": 11.6622,
-        "t_tank_bottom": 10.9559,
-        "t_collector": 16.1936,
+        "t_tank_top": 11.8257,
+        "t_tank_bottom": 10.9286,
+        "t_collector": 12.9401,
         "t_greenhouse": 10.8773,
         "t_outdoor": 9.6509
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 2700,
       "values": {
-        "t_tank_top": 11.6374,
-        "t_tank_bottom": 10.9802,
-        "t_collector": 17.04,
+        "t_tank_top": 11.8362,
+        "t_tank_bottom": 10.9603,
+        "t_collector": 12.921,
         "t_greenhouse": 10.8896,
         "t_outdoor": 9.6726
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 2760,
       "values": {
-        "t_tank_top": 11.6144,
-        "t_tank_bottom": 11.0028,
-        "t_collector": 17.8767,
+        "t_tank_top": 11.8467,
+        "t_tank_bottom": 10.9912,
+        "t_collector": 12.9253,
         "t_greenhouse": 10.9023,
         "t_outdoor": 9.6944
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 2820,
       "values": {
-        "t_tank_top": 11.5929,
-        "t_tank_bottom": 11.0239,
-        "t_collector": 18.7041,
+        "t_tank_top": 11.858,
+        "t_tank_bottom": 11.0215,
+        "t_collector": 12.9437,
         "t_greenhouse": 10.9154,
         "t_outdoor": 9.7162
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 2880,
       "values": {
-        "t_tank_top": 11.5729,
-        "t_tank_bottom": 11.0434,
-        "t_collector": 19.5222,
+        "t_tank_top": 11.8704,
+        "t_tank_bottom": 11.0511,
+        "t_collector": 12.9705,
         "t_greenhouse": 10.9289,
         "t_outdoor": 9.738
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 2940,
       "values": {
-        "t_tank_top": 11.5542,
-        "t_tank_bottom": 11.0616,
-        "t_collector": 20.3311,
+        "t_tank_top": 11.884,
+        "t_tank_bottom": 11.0801,
+        "t_collector": 13.0022,
         "t_greenhouse": 10.9429,
         "t_outdoor": 9.7597
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 3000,
       "values": {
-        "t_tank_top": 11.5617,
-        "t_tank_bottom": 11.0785,
-        "t_collector": 20.8212,
+        "t_tank_top": 11.8989,
+        "t_tank_bottom": 11.1085,
+        "t_collector": 13.0366,
         "t_greenhouse": 10.9572,
         "t_outdoor": 9.7815
       },
@@ -569,9 +569,9 @@
     {
       "time": 3060,
       "values": {
-        "t_tank_top": 11.8362,
-        "t_tank_bottom": 11.1008,
-        "t_collector": 17.8314,
+        "t_tank_top": 11.915,
+        "t_tank_bottom": 11.1365,
+        "t_collector": 13.0726,
         "t_greenhouse": 10.9719,
         "t_outdoor": 9.8033
       },
@@ -580,9 +580,9 @@
     {
       "time": 3120,
       "values": {
-        "t_tank_top": 12.0015,
-        "t_tank_bottom": 11.1298,
-        "t_collector": 16.013,
+        "t_tank_top": 11.9324,
+        "t_tank_bottom": 11.1642,
+        "t_collector": 13.1093,
         "t_greenhouse": 10.9871,
         "t_outdoor": 9.8251
       },
@@ -591,9 +591,9 @@
     {
       "time": 3180,
       "values": {
-        "t_tank_top": 12.1012,
-        "t_tank_bottom": 11.1624,
-        "t_collector": 14.9143,
+        "t_tank_top": 11.9508,
+        "t_tank_bottom": 11.1914,
+        "t_collector": 13.1464,
         "t_greenhouse": 11.0026,
         "t_outdoor": 9.8469
       },
@@ -602,9 +602,9 @@
     {
       "time": 3240,
       "values": {
-        "t_tank_top": 12.1619,
-        "t_tank_bottom": 11.1965,
-        "t_collector": 14.2576,
+        "t_tank_top": 11.9702,
+        "t_tank_bottom": 11.2184,
+        "t_collector": 13.1835,
         "t_greenhouse": 11.0184,
         "t_outdoor": 9.8688
       },
@@ -613,9 +613,9 @@
     {
       "time": 3300,
       "values": {
-        "t_tank_top": 12.1999,
-        "t_tank_bottom": 11.2312,
-        "t_collector": 13.8723,
+        "t_tank_top": 11.9906,
+        "t_tank_bottom": 11.2452,
+        "t_collector": 13.2206,
         "t_greenhouse": 11.0346,
         "t_outdoor": 9.8906
       },
@@ -624,9 +624,9 @@
     {
       "time": 3360,
       "values": {
-        "t_tank_top": 12.2251,
-        "t_tank_bottom": 11.2657,
-        "t_collector": 13.6533,
+        "t_tank_top": 12.0118,
+        "t_tank_bottom": 11.2717,
+        "t_collector": 13.2575,
         "t_greenhouse": 11.0512,
         "t_outdoor": 9.9124
       },
@@ -635,9 +635,9 @@
     {
       "time": 3420,
       "values": {
-        "t_tank_top": 12.2433,
-        "t_tank_bottom": 11.2997,
-        "t_collector": 13.5361,
+        "t_tank_top": 12.0338,
+        "t_tank_bottom": 11.298,
+        "t_collector": 13.2942,
         "t_greenhouse": 11.0681,
         "t_outdoor": 9.9342
       },
@@ -646,9 +646,9 @@
     {
       "time": 3480,
       "values": {
-        "t_tank_top": 12.2582,
-        "t_tank_bottom": 11.3331,
-        "t_collector": 13.4811,
+        "t_tank_top": 12.0565,
+        "t_tank_bottom": 11.3242,
+        "t_collector": 13.3307,
         "t_greenhouse": 11.0853,
         "t_outdoor": 9.956
       },
@@ -657,9 +657,9 @@
     {
       "time": 3540,
       "values": {
-        "t_tank_top": 12.2718,
-        "t_tank_bottom": 11.3659,
-        "t_collector": 13.464,
+        "t_tank_top": 12.0799,
+        "t_tank_bottom": 11.3503,
+        "t_collector": 13.3671,
         "t_greenhouse": 11.1028,
         "t_outdoor": 9.9778
       },
@@ -668,9 +668,9 @@
     {
       "time": 3600,
       "values": {
-        "t_tank_top": 12.2853,
-        "t_tank_bottom": 11.3979,
-        "t_collector": 13.4697,
+        "t_tank_top": 12.1038,
+        "t_tank_bottom": 11.3763,
+        "t_collector": 13.4034,
         "t_greenhouse": 11.1206,
         "t_outdoor": 9.9996
       },
@@ -679,9 +679,9 @@
     {
       "time": 3660,
       "values": {
-        "t_tank_top": 12.2995,
-        "t_tank_bottom": 11.4293,
-        "t_collector": 13.4893,
+        "t_tank_top": 12.1283,
+        "t_tank_bottom": 11.4023,
+        "t_collector": 13.4395,
         "t_greenhouse": 11.1388,
         "t_outdoor": 10.0215
       },
@@ -690,9 +690,9 @@
     {
       "time": 3720,
       "values": {
-        "t_tank_top": 12.3147,
-        "t_tank_bottom": 11.4601,
-        "t_collector": 13.5171,
+        "t_tank_top": 12.1532,
+        "t_tank_bottom": 11.4282,
+        "t_collector": 13.4755,
         "t_greenhouse": 11.1572,
         "t_outdoor": 10.0433
       },
@@ -701,9 +701,9 @@
     {
       "time": 3780,
       "values": {
-        "t_tank_top": 12.331,
-        "t_tank_bottom": 11.4904,
-        "t_collector": 13.5497,
+        "t_tank_top": 12.1786,
+        "t_tank_bottom": 11.454,
+        "t_collector": 13.5114,
         "t_greenhouse": 11.1759,
         "t_outdoor": 10.0651
       },
@@ -712,9 +712,9 @@
     {
       "time": 3840,
       "values": {
-        "t_tank_top": 12.3484,
-        "t_tank_bottom": 11.5202,
-        "t_collector": 13.5851,
+        "t_tank_top": 12.2045,
+        "t_tank_bottom": 11.4799,
+        "t_collector": 13.5473,
         "t_greenhouse": 11.1949,
         "t_outdoor": 10.0869
       },
@@ -723,9 +723,9 @@
     {
       "time": 3900,
       "values": {
-        "t_tank_top": 12.367,
-        "t_tank_bottom": 11.5496,
-        "t_collector": 13.622,
+        "t_tank_top": 12.2307,
+        "t_tank_bottom": 11.5058,
+        "t_collector": 13.583,
         "t_greenhouse": 11.2142,
         "t_outdoor": 10.1087
       },
@@ -734,9 +734,9 @@
     {
       "time": 3960,
       "values": {
-        "t_tank_top": 12.3866,
-        "t_tank_bottom": 11.5786,
-        "t_collector": 13.6596,
+        "t_tank_top": 12.2572,
+        "t_tank_bottom": 11.5317,
+        "t_collector": 13.6188,
         "t_greenhouse": 11.2338,
         "t_outdoor": 10.1305
       },
@@ -745,9 +745,9 @@
     {
       "time": 4020,
       "values": {
-        "t_tank_top": 12.4073,
-        "t_tank_bottom": 11.6073,
-        "t_collector": 13.6976,
+        "t_tank_top": 12.2841,
+        "t_tank_bottom": 11.5576,
+        "t_collector": 13.6545,
         "t_greenhouse": 11.2536,
         "t_outdoor": 10.1523
       },
@@ -756,9 +756,9 @@
     {
       "time": 4080,
       "values": {
-        "t_tank_top": 12.4289,
-        "t_tank_bottom": 11.6357,
-        "t_collector": 13.7356,
+        "t_tank_top": 12.3113,
+        "t_tank_bottom": 11.5835,
+        "t_collector": 13.6902,
         "t_greenhouse": 11.2736,
         "t_outdoor": 10.1741
       },
@@ -767,9 +767,9 @@
     {
       "time": 4140,
       "values": {
-        "t_tank_top": 12.4514,
-        "t_tank_bottom": 11.664,
-        "t_collector": 13.7736,
+        "t_tank_top": 12.3387,
+        "t_tank_bottom": 11.6095,
+        "t_collector": 13.7258,
         "t_greenhouse": 11.2939,
         "t_outdoor": 10.1959
       },
@@ -778,9 +778,9 @@
     {
       "time": 4200,
       "values": {
-        "t_tank_top": 12.4746,
-        "t_tank_bottom": 11.692,
-        "t_collector": 13.8115,
+        "t_tank_top": 12.3665,
+        "t_tank_bottom": 11.6356,
+        "t_collector": 13.7615,
         "t_greenhouse": 11.3144,
         "t_outdoor": 10.2177
       },
@@ -789,9 +789,9 @@
     {
       "time": 4260,
       "values": {
-        "t_tank_top": 12.4986,
-        "t_tank_bottom": 11.7199,
-        "t_collector": 13.8492,
+        "t_tank_top": 12.3944,
+        "t_tank_bottom": 11.6617,
+        "t_collector": 13.7972,
         "t_greenhouse": 11.3352,
         "t_outdoor": 10.2395
       },
@@ -800,9 +800,9 @@
     {
       "time": 4320,
       "values": {
-        "t_tank_top": 12.5232,
-        "t_tank_bottom": 11.7476,
-        "t_collector": 13.8868,
+        "t_tank_top": 12.4226,
+        "t_tank_bottom": 11.6879,
+        "t_collector": 13.8329,
         "t_greenhouse": 11.3562,
         "t_outdoor": 10.2613
       },
@@ -811,9 +811,9 @@
     {
       "time": 4380,
       "values": {
-        "t_tank_top": 12.5484,
-        "t_tank_bottom": 11.7752,
-        "t_collector": 13.9242,
+        "t_tank_top": 12.451,
+        "t_tank_bottom": 11.7142,
+        "t_collector": 13.8687,
         "t_greenhouse": 11.3774,
         "t_outdoor": 10.2831
       },
@@ -822,9 +822,9 @@
     {
       "time": 4440,
       "values": {
-        "t_tank_top": 12.5742,
-        "t_tank_bottom": 11.8028,
-        "t_collector": 13.9615,
+        "t_tank_top": 12.4796,
+        "t_tank_bottom": 11.7405,
+        "t_collector": 13.9045,
         "t_greenhouse": 11.3988,
         "t_outdoor": 10.3049
       },
@@ -833,9 +833,9 @@
     {
       "time": 4500,
       "values": {
-        "t_tank_top": 12.6005,
-        "t_tank_bottom": 11.8303,
-        "t_collector": 13.9987,
+        "t_tank_top": 12.5085,
+        "t_tank_bottom": 11.7669,
+        "t_collector": 13.9403,
         "t_greenhouse": 11.4205,
         "t_outdoor": 10.3267
       },
@@ -844,9 +844,9 @@
     {
       "time": 4560,
       "values": {
-        "t_tank_top": 12.6272,
-        "t_tank_bottom": 11.8578,
-        "t_collector": 14.0358,
+        "t_tank_top": 12.5374,
+        "t_tank_bottom": 11.7934,
+        "t_collector": 13.9761,
         "t_greenhouse": 11.4423,
         "t_outdoor": 10.3484
       },
@@ -855,9 +855,9 @@
     {
       "time": 4620,
       "values": {
-        "t_tank_top": 12.6543,
-        "t_tank_bottom": 11.8852,
-        "t_collector": 14.0727,
+        "t_tank_top": 12.5666,
+        "t_tank_bottom": 11.82,
+        "t_collector": 14.012,
         "t_greenhouse": 11.4643,
         "t_outdoor": 10.3702
       },
@@ -866,9 +866,9 @@
     {
       "time": 4680,
       "values": {
-        "t_tank_top": 12.6818,
-        "t_tank_bottom": 11.9127,
-        "t_collector": 14.1096,
+        "t_tank_top": 12.5959,
+        "t_tank_bottom": 11.8467,
+        "t_collector": 14.048,
         "t_greenhouse": 11.4865,
         "t_outdoor": 10.3919
       },
@@ -877,9 +877,9 @@
     {
       "time": 4740,
       "values": {
-        "t_tank_top": 12.7097,
-        "t_tank_bottom": 11.9401,
-        "t_collector": 14.1465,
+        "t_tank_top": 12.6254,
+        "t_tank_bottom": 11.8735,
+        "t_collector": 14.084,
         "t_greenhouse": 11.5089,
         "t_outdoor": 10.4137
       },
@@ -888,9 +888,9 @@
     {
       "time": 4800,
       "values": {
-        "t_tank_top": 12.7379,
-        "t_tank_bottom": 11.9676,
-        "t_collector": 14.1833,
+        "t_tank_top": 12.6551,
+        "t_tank_bottom": 11.9004,
+        "t_collector": 14.12,
         "t_greenhouse": 11.5315,
         "t_outdoor": 10.4354
       },
@@ -899,9 +899,9 @@
     {
       "time": 4860,
       "values": {
-        "t_tank_top": 12.7664,
-        "t_tank_bottom": 11.9951,
-        "t_collector": 14.2201,
+        "t_tank_top": 12.6849,
+        "t_tank_bottom": 11.9274,
+        "t_collector": 14.1562,
         "t_greenhouse": 11.5543,
         "t_outdoor": 10.4571
       },
@@ -910,9 +910,9 @@
     {
       "time": 4920,
       "values": {
-        "t_tank_top": 12.7951,
-        "t_tank_bottom": 12.0227,
-        "t_collector": 14.2569,
+        "t_tank_top": 12.7148,
+        "t_tank_bottom": 11.9545,
+        "t_collector": 14.1923,
         "t_greenhouse": 11.5772,
         "t_outdoor": 10.4789
       },
@@ -921,9 +921,9 @@
     {
       "time": 4980,
       "values": {
-        "t_tank_top": 12.8242,
-        "t_tank_bottom": 12.0502,
-        "t_collector": 14.2936,
+        "t_tank_top": 12.7449,
+        "t_tank_bottom": 11.9817,
+        "t_collector": 14.2286,
         "t_greenhouse": 11.6003,
         "t_outdoor": 10.5006
       },
@@ -932,9 +932,9 @@
     {
       "time": 5040,
       "values": {
-        "t_tank_top": 12.8534,
-        "t_tank_bottom": 12.0779,
-        "t_collector": 14.3304,
+        "t_tank_top": 12.7751,
+        "t_tank_bottom": 12.009,
+        "t_collector": 14.2649,
         "t_greenhouse": 11.6236,
         "t_outdoor": 10.5223
       },
@@ -943,9 +943,9 @@
     {
       "time": 5100,
       "values": {
-        "t_tank_top": 12.8829,
-        "t_tank_bottom": 12.1056,
-        "t_collector": 14.3672,
+        "t_tank_top": 12.8054,
+        "t_tank_bottom": 12.0364,
+        "t_collector": 14.3013,
         "t_greenhouse": 11.647,
         "t_outdoor": 10.544
       },
@@ -954,9 +954,9 @@
     {
       "time": 5160,
       "values": {
-        "t_tank_top": 12.9126,
-        "t_tank_bottom": 12.1334,
-        "t_collector": 14.4039,
+        "t_tank_top": 12.8359,
+        "t_tank_bottom": 12.0639,
+        "t_collector": 14.3377,
         "t_greenhouse": 11.6705,
         "t_outdoor": 10.5657
       },
@@ -965,9 +965,9 @@
     {
       "time": 5220,
       "values": {
-        "t_tank_top": 12.9426,
-        "t_tank_bottom": 12.1612,
-        "t_collector": 14.4408,
+        "t_tank_top": 12.8665,
+        "t_tank_bottom": 12.0915,
+        "t_collector": 14.3742,
         "t_greenhouse": 11.6942,
         "t_outdoor": 10.5873
       },
@@ -976,9 +976,9 @@
     {
       "time": 5280,
       "values": {
-        "t_tank_top": 12.9727,
-        "t_tank_bottom": 12.1891,
-        "t_collector": 14.4776,
+        "t_tank_top": 12.8972,
+        "t_tank_bottom": 12.1192,
+        "t_collector": 14.4108,
         "t_greenhouse": 11.7181,
         "t_outdoor": 10.609
       },
@@ -987,9 +987,9 @@
     {
       "time": 5340,
       "values": {
-        "t_tank_top": 13.0029,
-        "t_tank_bottom": 12.2171,
-        "t_collector": 14.5145,
+        "t_tank_top": 12.928,
+        "t_tank_bottom": 12.147,
+        "t_collector": 14.4474,
         "t_greenhouse": 11.7421,
         "t_outdoor": 10.6306
       },
@@ -998,9 +998,9 @@
     {
       "time": 5400,
       "values": {
-        "t_tank_top": 13.0334,
-        "t_tank_bottom": 12.2452,
-        "t_collector": 14.5514,
+        "t_tank_top": 12.959,
+        "t_tank_bottom": 12.175,
+        "t_collector": 14.4841,
         "t_greenhouse": 11.7662,
         "t_outdoor": 10.6523
       },
@@ -1009,9 +1009,9 @@
     {
       "time": 5460,
       "values": {
-        "t_tank_top": 13.064,
-        "t_tank_bottom": 12.2734,
-        "t_collector": 14.5883,
+        "t_tank_top": 12.9901,
+        "t_tank_bottom": 12.203,
+        "t_collector": 14.5209,
         "t_greenhouse": 11.7905,
         "t_outdoor": 10.6739
       },
@@ -1020,9 +1020,9 @@
     {
       "time": 5520,
       "values": {
-        "t_tank_top": 13.0948,
-        "t_tank_bottom": 12.3016,
-        "t_collector": 14.6253,
+        "t_tank_top": 13.0212,
+        "t_tank_bottom": 12.2311,
+        "t_collector": 14.5577,
         "t_greenhouse": 11.8148,
         "t_outdoor": 10.6955
       },
@@ -1031,9 +1031,9 @@
     {
       "time": 5580,
       "values": {
-        "t_tank_top": 13.1257,
-        "t_tank_bottom": 12.33,
-        "t_collector": 14.6624,
+        "t_tank_top": 13.0525,
+        "t_tank_bottom": 12.2594,
+        "t_collector": 14.5946,
         "t_greenhouse": 11.8393,
         "t_outdoor": 10.7171
       },
@@ -1042,9 +1042,9 @@
     {
       "time": 5640,
       "values": {
-        "t_tank_top": 13.1567,
-        "t_tank_bottom": 12.3584,
-        "t_collector": 14.6995,
+        "t_tank_top": 13.0839,
+        "t_tank_bottom": 12.2878,
+        "t_collector": 14.6316,
         "t_greenhouse": 11.8639,
         "t_outdoor": 10.7387
       },
@@ -1053,9 +1053,9 @@
     {
       "time": 5700,
       "values": {
-        "t_tank_top": 13.1879,
-        "t_tank_bottom": 12.387,
-        "t_collector": 14.7366,
+        "t_tank_top": 13.1154,
+        "t_tank_bottom": 12.3162,
+        "t_collector": 14.6687,
         "t_greenhouse": 11.8887,
         "t_outdoor": 10.7603
       },
@@ -1064,9 +1064,9 @@
     {
       "time": 5760,
       "values": {
-        "t_tank_top": 13.2193,
-        "t_tank_bottom": 12.4156,
-        "t_collector": 14.7738,
+        "t_tank_top": 13.147,
+        "t_tank_bottom": 12.3448,
+        "t_collector": 14.7058,
         "t_greenhouse": 11.9135,
         "t_outdoor": 10.7818
       },
@@ -1075,9 +1075,9 @@
     {
       "time": 5820,
       "values": {
-        "t_tank_top": 13.2507,
-        "t_tank_bottom": 12.4443,
-        "t_collector": 14.811,
+        "t_tank_top": 13.1787,
+        "t_tank_bottom": 12.3735,
+        "t_collector": 14.743,
         "t_greenhouse": 11.9384,
         "t_outdoor": 10.8034
       },
@@ -1086,9 +1086,9 @@
     {
       "time": 5880,
       "values": {
-        "t_tank_top": 13.2823,
-        "t_tank_bottom": 12.4731,
-        "t_collector": 14.8483,
+        "t_tank_top": 13.2105,
+        "t_tank_bottom": 12.4023,
+        "t_collector": 14.7802,
         "t_greenhouse": 11.9635,
         "t_outdoor": 10.8249
       },
@@ -1097,9 +1097,9 @@
     {
       "time": 5940,
       "values": {
-        "t_tank_top": 13.314,
-        "t_tank_bottom": 12.5021,
-        "t_collector": 14.8857,
+        "t_tank_top": 13.2424,
+        "t_tank_bottom": 12.4312,
+        "t_collector": 14.8175,
         "t_greenhouse": 11.9886,
         "t_outdoor": 10.8464
       },
@@ -1108,9 +1108,9 @@
     {
       "time": 6000,
       "values": {
-        "t_tank_top": 13.3458,
-        "t_tank_bottom": 12.5311,
-        "t_collector": 14.9231,
+        "t_tank_top": 13.2744,
+        "t_tank_bottom": 12.4602,
+        "t_collector": 14.8549,
         "t_greenhouse": 12.0139,
         "t_outdoor": 10.8679
       },
@@ -1119,9 +1119,9 @@
     {
       "time": 6060,
       "values": {
-        "t_tank_top": 13.3778,
-        "t_tank_bottom": 12.5602,
-        "t_collector": 14.9606,
+        "t_tank_top": 13.3065,
+        "t_tank_bottom": 12.4893,
+        "t_collector": 14.8924,
         "t_greenhouse": 12.0392,
         "t_outdoor": 10.8894
       },
@@ -1130,9 +1130,9 @@
     {
       "time": 6120,
       "values": {
-        "t_tank_top": 13.4098,
-        "t_tank_bottom": 12.5894,
-        "t_collector": 14.9981,
+        "t_tank_top": 13.3387,
+        "t_tank_bottom": 12.5185,
+        "t_collector": 14.9299,
         "t_greenhouse": 12.0646,
         "t_outdoor": 10.9108
       },
@@ -1141,9 +1141,9 @@
     {
       "time": 6180,
       "values": {
-        "t_tank_top": 13.442,
-        "t_tank_bottom": 12.6187,
-        "t_collector": 15.0357,
+        "t_tank_top": 13.371,
+        "t_tank_bottom": 12.5479,
+        "t_collector": 14.9675,
         "t_greenhouse": 12.0901,
         "t_outdoor": 10.9323
       },
@@ -1152,9 +1152,9 @@
     {
       "time": 6240,
       "values": {
-        "t_tank_top": 13.4742,
-        "t_tank_bottom": 12.6482,
-        "t_collector": 15.0734,
+        "t_tank_top": 13.4034,
+        "t_tank_bottom": 12.5773,
+        "t_collector": 15.0052,
         "t_greenhouse": 12.1157,
         "t_outdoor": 10.9537
       },
@@ -1163,9 +1163,9 @@
     {
       "time": 6300,
       "values": {
-        "t_tank_top": 13.5066,
-        "t_tank_bottom": 12.6777,
-        "t_collector": 15.1111,
+        "t_tank_top": 13.4359,
+        "t_tank_bottom": 12.6068,
+        "t_collector": 15.0429,
         "t_greenhouse": 12.1414,
         "t_outdoor": 10.9751
       },
@@ -1174,9 +1174,9 @@
     {
       "time": 6360,
       "values": {
-        "t_tank_top": 13.5391,
-        "t_tank_bottom": 12.7073,
-        "t_collector": 15.1489,
+        "t_tank_top": 13.4685,
+        "t_tank_bottom": 12.6365,
+        "t_collector": 15.0807,
         "t_greenhouse": 12.1671,
         "t_outdoor": 10.9965
       },
@@ -1185,9 +1185,9 @@
     {
       "time": 6420,
       "values": {
-        "t_tank_top": 13.5716,
-        "t_tank_bottom": 12.737,
-        "t_collector": 15.1867,
+        "t_tank_top": 13.5012,
+        "t_tank_bottom": 12.6662,
+        "t_collector": 15.1185,
         "t_greenhouse": 12.1929,
         "t_outdoor": 11.0179
       },
@@ -1196,9 +1196,9 @@
     {
       "time": 6480,
       "values": {
-        "t_tank_top": 13.6043,
-        "t_tank_bottom": 12.7669,
-        "t_collector": 15.2246,
+        "t_tank_top": 13.534,
+        "t_tank_bottom": 12.6961,
+        "t_collector": 15.1564,
         "t_greenhouse": 12.2188,
         "t_outdoor": 11.0392
       },
@@ -1207,9 +1207,9 @@
     {
       "time": 6540,
       "values": {
-        "t_tank_top": 13.6371,
-        "t_tank_bottom": 12.7968,
-        "t_collector": 15.2626,
+        "t_tank_top": 13.5669,
+        "t_tank_bottom": 12.726,
+        "t_collector": 15.1944,
         "t_greenhouse": 12.2448,
         "t_outdoor": 11.0605
       },
@@ -1218,9 +1218,9 @@
     {
       "time": 6600,
       "values": {
-        "t_tank_top": 13.6699,
-        "t_tank_bottom": 12.8268,
-        "t_collector": 15.3006,
+        "t_tank_top": 13.5998,
+        "t_tank_bottom": 12.7561,
+        "t_collector": 15.2325,
         "t_greenhouse": 12.2708,
         "t_outdoor": 11.0818
       },
@@ -1229,9 +1229,9 @@
     {
       "time": 6660,
       "values": {
-        "t_tank_top": 13.7029,
-        "t_tank_bottom": 12.8569,
-        "t_collector": 15.3387,
+        "t_tank_top": 13.6329,
+        "t_tank_bottom": 12.7863,
+        "t_collector": 15.2706,
         "t_greenhouse": 12.2968,
         "t_outdoor": 11.1031
       },
@@ -1240,9 +1240,9 @@
     {
       "time": 6720,
       "values": {
-        "t_tank_top": 13.7359,
-        "t_tank_bottom": 12.8872,
-        "t_collector": 15.3769,
+        "t_tank_top": 13.666,
+        "t_tank_bottom": 12.8165,
+        "t_collector": 15.3087,
         "t_greenhouse": 12.323,
         "t_outdoor": 11.1244
       },
@@ -1251,9 +1251,9 @@
     {
       "time": 6780,
       "values": {
-        "t_tank_top": 13.7691,
-        "t_tank_bottom": 12.9175,
-        "t_collector": 15.4151,
+        "t_tank_top": 13.6992,
+        "t_tank_bottom": 12.8469,
+        "t_collector": 15.347,
         "t_greenhouse": 12.3492,
         "t_outdoor": 11.1456
       },
@@ -1262,9 +1262,9 @@
     {
       "time": 6840,
       "values": {
-        "t_tank_top": 13.8023,
-        "t_tank_bottom": 12.9479,
-        "t_collector": 15.4533,
+        "t_tank_top": 13.7326,
+        "t_tank_bottom": 12.8774,
+        "t_collector": 15.3853,
         "t_greenhouse": 12.3754,
         "t_outdoor": 11.1669
       },
@@ -1273,9 +1273,9 @@
     {
       "time": 6900,
       "values": {
-        "t_tank_top": 13.8357,
-        "t_tank_bottom": 12.9785,
-        "t_collector": 15.4916,
+        "t_tank_top": 13.766,
+        "t_tank_bottom": 12.9079,
+        "t_collector": 15.4236,
         "t_greenhouse": 12.4017,
         "t_outdoor": 11.1881
       },
@@ -1284,9 +1284,9 @@
     {
       "time": 6960,
       "values": {
-        "t_tank_top": 13.8691,
-        "t_tank_bottom": 13.0091,
-        "t_collector": 15.53,
+        "t_tank_top": 13.7995,
+        "t_tank_bottom": 12.9386,
+        "t_collector": 15.462,
         "t_greenhouse": 12.4281,
         "t_outdoor": 11.2093
       },
@@ -1295,9 +1295,9 @@
     {
       "time": 7020,
       "values": {
-        "t_tank_top": 13.9026,
-        "t_tank_bottom": 13.0398,
-        "t_collector": 15.5685,
+        "t_tank_top": 13.833,
+        "t_tank_bottom": 12.9694,
+        "t_collector": 15.5005,
         "t_greenhouse": 12.4545,
         "t_outdoor": 11.2304
       },
@@ -1306,9 +1306,9 @@
     {
       "time": 7080,
       "values": {
-        "t_tank_top": 13.9362,
-        "t_tank_bottom": 13.0706,
-        "t_collector": 15.6069,
+        "t_tank_top": 13.8667,
+        "t_tank_bottom": 13.0002,
+        "t_collector": 15.5391,
         "t_greenhouse": 12.4809,
         "t_outdoor": 11.2515
       },
@@ -1317,9 +1317,9 @@
     {
       "time": 7140,
       "values": {
-        "t_tank_top": 13.9699,
-        "t_tank_bottom": 13.1016,
-        "t_collector": 15.6455,
+        "t_tank_top": 13.9005,
+        "t_tank_bottom": 13.0312,
+        "t_collector": 15.5776,
         "t_greenhouse": 12.5074,
         "t_outdoor": 11.2727
       },
@@ -1328,9 +1328,9 @@
     {
       "time": 7200,
       "values": {
-        "t_tank_top": 14.0037,
-        "t_tank_bottom": 13.1326,
-        "t_collector": 15.6841,
+        "t_tank_top": 13.9343,
+        "t_tank_bottom": 13.0623,
+        "t_collector": 15.6163,
         "t_greenhouse": 12.5339,
         "t_outdoor": 11.2937
       },
@@ -1339,9 +1339,9 @@
     {
       "time": 7260,
       "values": {
-        "t_tank_top": 14.0375,
-        "t_tank_bottom": 13.1637,
-        "t_collector": 15.7228,
+        "t_tank_top": 13.9682,
+        "t_tank_bottom": 13.0934,
+        "t_collector": 15.655,
         "t_greenhouse": 12.5605,
         "t_outdoor": 11.3148
       },
@@ -1350,9 +1350,9 @@
     {
       "time": 7320,
       "values": {
-        "t_tank_top": 14.0715,
-        "t_tank_bottom": 13.1949,
-        "t_collector": 15.7615,
+        "t_tank_top": 14.0022,
+        "t_tank_bottom": 13.1247,
+        "t_collector": 15.6938,
         "t_greenhouse": 12.587,
         "t_outdoor": 11.3358
       },
@@ -1361,9 +1361,9 @@
     {
       "time": 7380,
       "values": {
-        "t_tank_top": 14.1055,
-        "t_tank_bottom": 13.2262,
-        "t_collector": 15.8003,
+        "t_tank_top": 14.0363,
+        "t_tank_bottom": 13.1561,
+        "t_collector": 15.7326,
         "t_greenhouse": 12.6137,
         "t_outdoor": 11.3569
       },
@@ -1372,9 +1372,9 @@
     {
       "time": 7440,
       "values": {
-        "t_tank_top": 14.1396,
-        "t_tank_bottom": 13.2577,
-        "t_collector": 15.8391,
+        "t_tank_top": 14.0705,
+        "t_tank_bottom": 13.1875,
+        "t_collector": 15.7714,
         "t_greenhouse": 12.6403,
         "t_outdoor": 11.3778
       },
@@ -1383,9 +1383,9 @@
     {
       "time": 7500,
       "values": {
-        "t_tank_top": 14.1738,
-        "t_tank_bottom": 13.2892,
-        "t_collector": 15.878,
+        "t_tank_top": 14.1047,
+        "t_tank_bottom": 13.2191,
+        "t_collector": 15.8104,
         "t_greenhouse": 12.667,
         "t_outdoor": 11.3988
       },
@@ -1394,9 +1394,9 @@
     {
       "time": 7560,
       "values": {
-        "t_tank_top": 14.2081,
-        "t_tank_bottom": 13.3208,
-        "t_collector": 15.9169,
+        "t_tank_top": 14.1391,
+        "t_tank_bottom": 13.2507,
+        "t_collector": 15.8494,
         "t_greenhouse": 12.6937,
         "t_outdoor": 11.4197
       },
@@ -1405,9 +1405,9 @@
     {
       "time": 7620,
       "values": {
-        "t_tank_top": 14.2424,
-        "t_tank_bottom": 13.3524,
-        "t_collector": 15.9559,
+        "t_tank_top": 14.1735,
+        "t_tank_bottom": 13.2824,
+        "t_collector": 15.8884,
         "t_greenhouse": 12.7204,
         "t_outdoor": 11.4406
       },
@@ -1416,9 +1416,9 @@
     {
       "time": 7680,
       "values": {
-        "t_tank_top": 14.2769,
-        "t_tank_bottom": 13.3842,
-        "t_collector": 15.9949,
+        "t_tank_top": 14.208,
+        "t_tank_bottom": 13.3143,
+        "t_collector": 15.9275,
         "t_greenhouse": 12.7472,
         "t_outdoor": 11.4615
       },
@@ -1427,9 +1427,9 @@
     {
       "time": 7740,
       "values": {
-        "t_tank_top": 14.3114,
-        "t_tank_bottom": 13.4161,
-        "t_collector": 16.034,
+        "t_tank_top": 14.2425,
+        "t_tank_bottom": 13.3462,
+        "t_collector": 15.9666,
         "t_greenhouse": 12.774,
         "t_outdoor": 11.4824
       },
@@ -1438,9 +1438,9 @@
     {
       "time": 7800,
       "values": {
-        "t_tank_top": 14.346,
-        "t_tank_bottom": 13.4481,
-        "t_collector": 16.0732,
+        "t_tank_top": 14.2772,
+        "t_tank_bottom": 13.3782,
+        "t_collector": 16.0058,
         "t_greenhouse": 12.8007,
         "t_outdoor": 11.5032
       },
@@ -1449,9 +1449,9 @@
     {
       "time": 7860,
       "values": {
-        "t_tank_top": 14.3806,
-        "t_tank_bottom": 13.4802,
-        "t_collector": 16.1124,
+        "t_tank_top": 14.3119,
+        "t_tank_bottom": 13.4103,
+        "t_collector": 16.045,
         "t_greenhouse": 12.8275,
         "t_outdoor": 11.524
       },
@@ -1460,9 +1460,9 @@
     {
       "time": 7920,
       "values": {
-        "t_tank_top": 14.4154,
-        "t_tank_bottom": 13.5123,
-        "t_collector": 16.1516,
+        "t_tank_top": 14.3467,
+        "t_tank_bottom": 13.4426,
+        "t_collector": 16.0843,
         "t_greenhouse": 12.8544,
         "t_outdoor": 11.5447
       },
@@ -1471,9 +1471,9 @@
     {
       "time": 7980,
       "values": {
-        "t_tank_top": 14.4502,
-        "t_tank_bottom": 13.5446,
-        "t_collector": 16.1909,
+        "t_tank_top": 14.3816,
+        "t_tank_bottom": 13.4749,
+        "t_collector": 16.1237,
         "t_greenhouse": 12.8812,
         "t_outdoor": 11.5655
       },
@@ -1482,9 +1482,9 @@
     {
       "time": 8040,
       "values": {
-        "t_tank_top": 14.4851,
-        "t_tank_bottom": 13.5769,
-        "t_collector": 16.2303,
+        "t_tank_top": 14.4165,
+        "t_tank_bottom": 13.5072,
+        "t_collector": 16.1631,
         "t_greenhouse": 12.908,
         "t_outdoor": 11.5862
       },
@@ -1493,9 +1493,9 @@
     {
       "time": 8100,
       "values": {
-        "t_tank_top": 14.5201,
-        "t_tank_bottom": 13.6093,
-        "t_collector": 16.2696,
+        "t_tank_top": 14.4516,
+        "t_tank_bottom": 13.5397,
+        "t_collector": 16.2025,
         "t_greenhouse": 12.9349,
         "t_outdoor": 11.6069
       },
@@ -1504,9 +1504,9 @@
     {
       "time": 8160,
       "values": {
-        "t_tank_top": 14.5552,
-        "t_tank_bottom": 13.6419,
-        "t_collector": 16.3091,
+        "t_tank_top": 14.4867,
+        "t_tank_bottom": 13.5723,
+        "t_collector": 16.242,
         "t_greenhouse": 12.9618,
         "t_outdoor": 11.6275
       },
@@ -1515,9 +1515,9 @@
     {
       "time": 8220,
       "values": {
-        "t_tank_top": 14.5903,
-        "t_tank_bottom": 13.6745,
-        "t_collector": 16.3486,
+        "t_tank_top": 14.5219,
+        "t_tank_bottom": 13.605,
+        "t_collector": 16.2815,
         "t_greenhouse": 12.9886,
         "t_outdoor": 11.6481
       },
@@ -1526,9 +1526,9 @@
     {
       "time": 8280,
       "values": {
-        "t_tank_top": 14.6255,
-        "t_tank_bottom": 13.7072,
-        "t_collector": 16.3881,
+        "t_tank_top": 14.5571,
+        "t_tank_bottom": 13.6377,
+        "t_collector": 16.3211,
         "t_greenhouse": 13.0155,
         "t_outdoor": 11.6687
       },
@@ -1537,9 +1537,9 @@
     {
       "time": 8340,
       "values": {
-        "t_tank_top": 14.6608,
-        "t_tank_bottom": 13.7399,
-        "t_collector": 16.4277,
+        "t_tank_top": 14.5924,
+        "t_tank_bottom": 13.6705,
+        "t_collector": 16.3607,
         "t_greenhouse": 13.0424,
         "t_outdoor": 11.6892
       },
@@ -1548,9 +1548,9 @@
     {
       "time": 8400,
       "values": {
-        "t_tank_top": 14.6961,
-        "t_tank_bottom": 13.7728,
-        "t_collector": 16.4673,
+        "t_tank_top": 14.6278,
+        "t_tank_bottom": 13.7035,
+        "t_collector": 16.4004,
         "t_greenhouse": 13.0692,
         "t_outdoor": 11.7098
       },
@@ -1559,9 +1559,9 @@
     {
       "time": 8460,
       "values": {
-        "t_tank_top": 14.7315,
-        "t_tank_bottom": 13.8058,
-        "t_collector": 16.507,
+        "t_tank_top": 14.6633,
+        "t_tank_bottom": 13.7365,
+        "t_collector": 16.4401,
         "t_greenhouse": 13.0961,
         "t_outdoor": 11.7302
       },
@@ -1570,9 +1570,9 @@
     {
       "time": 8520,
       "values": {
-        "t_tank_top": 14.767,
-        "t_tank_bottom": 13.8388,
-        "t_collector": 16.5467,
+        "t_tank_top": 14.6989,
+        "t_tank_bottom": 13.7696,
+        "t_collector": 16.4798,
         "t_greenhouse": 13.123,
         "t_outdoor": 11.7507
       },
@@ -1581,9 +1581,9 @@
     {
       "time": 8580,
       "values": {
-        "t_tank_top": 14.8026,
-        "t_tank_bottom": 13.872,
-        "t_collector": 16.5864,
+        "t_tank_top": 14.7345,
+        "t_tank_bottom": 13.8027,
+        "t_collector": 16.5196,
         "t_greenhouse": 13.1498,
         "t_outdoor": 11.7711
       },
@@ -1592,9 +1592,9 @@
     {
       "time": 8640,
       "values": {
-        "t_tank_top": 14.8382,
-        "t_tank_bottom": 13.9052,
-        "t_collector": 16.6262,
+        "t_tank_top": 14.7702,
+        "t_tank_bottom": 13.836,
+        "t_collector": 16.5595,
         "t_greenhouse": 13.1767,
         "t_outdoor": 11.7915
       },
@@ -1603,9 +1603,9 @@
     {
       "time": 8700,
       "values": {
-        "t_tank_top": 14.8739,
-        "t_tank_bottom": 13.9385,
-        "t_collector": 16.666,
+        "t_tank_top": 14.8059,
+        "t_tank_bottom": 13.8694,
+        "t_collector": 16.5994,
         "t_greenhouse": 13.2035,
         "t_outdoor": 11.8119
       },
@@ -1614,9 +1614,9 @@
     {
       "time": 8760,
       "values": {
-        "t_tank_top": 14.9097,
-        "t_tank_bottom": 13.9719,
-        "t_collector": 16.7059,
+        "t_tank_top": 14.8417,
+        "t_tank_bottom": 13.9028,
+        "t_collector": 16.6393,
         "t_greenhouse": 13.2304,
         "t_outdoor": 11.8322
       },
@@ -1625,9 +1625,9 @@
     {
       "time": 8820,
       "values": {
-        "t_tank_top": 14.9455,
-        "t_tank_bottom": 14.0053,
-        "t_collector": 16.7458,
+        "t_tank_top": 14.8776,
+        "t_tank_bottom": 13.9363,
+        "t_collector": 16.6792,
         "t_greenhouse": 13.2572,
         "t_outdoor": 11.8524
       },
@@ -1636,9 +1636,9 @@
     {
       "time": 8880,
       "values": {
-        "t_tank_top": 14.9815,
-        "t_tank_bottom": 14.0389,
-        "t_collector": 16.7858,
+        "t_tank_top": 14.9136,
+        "t_tank_bottom": 13.9699,
+        "t_collector": 16.7192,
         "t_greenhouse": 13.284,
         "t_outdoor": 11.8727
       },
@@ -1647,9 +1647,9 @@
     {
       "time": 8940,
       "values": {
-        "t_tank_top": 15.0174,
-        "t_tank_bottom": 14.0725,
-        "t_collector": 16.8258,
+        "t_tank_top": 14.9496,
+        "t_tank_bottom": 14.0036,
+        "t_collector": 16.7593,
         "t_greenhouse": 13.3108,
         "t_outdoor": 11.8929
       },
@@ -1658,9 +1658,9 @@
     {
       "time": 9000,
       "values": {
-        "t_tank_top": 15.0535,
-        "t_tank_bottom": 14.1063,
-        "t_collector": 16.8658,
+        "t_tank_top": 14.9857,
+        "t_tank_bottom": 14.0374,
+        "t_collector": 16.7994,
         "t_greenhouse": 13.3376,
         "t_outdoor": 11.9131
       },
@@ -1669,9 +1669,9 @@
     {
       "time": 9060,
       "values": {
-        "t_tank_top": 15.0896,
-        "t_tank_bottom": 14.1401,
-        "t_collector": 16.9059,
+        "t_tank_top": 15.0219,
+        "t_tank_bottom": 14.0712,
+        "t_collector": 16.8395,
         "t_greenhouse": 13.3644,
         "t_outdoor": 11.9332
       },
@@ -1680,9 +1680,9 @@
     {
       "time": 9120,
       "values": {
-        "t_tank_top": 15.1258,
-        "t_tank_bottom": 14.1739,
-        "t_collector": 16.946,
+        "t_tank_top": 15.0581,
+        "t_tank_bottom": 14.1052,
+        "t_collector": 16.8796,
         "t_greenhouse": 13.3911,
         "t_outdoor": 11.9533
       },
@@ -1691,9 +1691,9 @@
     {
       "time": 9180,
       "values": {
-        "t_tank_top": 15.162,
-        "t_tank_bottom": 14.2079,
-        "t_collector": 16.9861,
+        "t_tank_top": 15.0944,
+        "t_tank_bottom": 14.1392,
+        "t_collector": 16.9198,
         "t_greenhouse": 13.4179,
         "t_outdoor": 11.9734
       },
@@ -1702,9 +1702,9 @@
     {
       "time": 9240,
       "values": {
-        "t_tank_top": 15.1983,
-        "t_tank_bottom": 14.2419,
-        "t_collector": 17.0263,
+        "t_tank_top": 15.1307,
+        "t_tank_bottom": 14.1733,
+        "t_collector": 16.96,
         "t_greenhouse": 13.4446,
         "t_outdoor": 11.9934
       },
@@ -1713,9 +1713,9 @@
     {
       "time": 9300,
       "values": {
-        "t_tank_top": 15.2347,
-        "t_tank_bottom": 14.2761,
-        "t_collector": 17.0665,
+        "t_tank_top": 15.1671,
+        "t_tank_bottom": 14.2074,
+        "t_collector": 17.0003,
         "t_greenhouse": 13.4713,
         "t_outdoor": 12.0134
       },
@@ -1724,9 +1724,9 @@
     {
       "time": 9360,
       "values": {
-        "t_tank_top": 15.2711,
-        "t_tank_bottom": 14.3103,
-        "t_collector": 17.1067,
+        "t_tank_top": 15.2036,
+        "t_tank_bottom": 14.2417,
+        "t_collector": 17.0406,
         "t_greenhouse": 13.498,
         "t_outdoor": 12.0334
       },
@@ -1735,9 +1735,9 @@
     {
       "time": 9420,
       "values": {
-        "t_tank_top": 15.3076,
-        "t_tank_bottom": 14.3445,
-        "t_collector": 17.147,
+        "t_tank_top": 15.2401,
+        "t_tank_bottom": 14.276,
+        "t_collector": 17.0809,
         "t_greenhouse": 13.5246,
         "t_outdoor": 12.0533
       },
@@ -1746,9 +1746,9 @@
     {
       "time": 9480,
       "values": {
-        "t_tank_top": 15.3441,
-        "t_tank_bottom": 14.3789,
-        "t_collector": 17.1873,
+        "t_tank_top": 15.2767,
+        "t_tank_bottom": 14.3104,
+        "t_collector": 17.1213,
         "t_greenhouse": 13.5513,
         "t_outdoor": 12.0731
       },
@@ -1757,9 +1757,9 @@
     {
       "time": 9540,
       "values": {
-        "t_tank_top": 15.3807,
-        "t_tank_bottom": 14.4133,
-        "t_collector": 17.2277,
+        "t_tank_top": 15.3134,
+        "t_tank_bottom": 14.3449,
+        "t_collector": 17.1617,
         "t_greenhouse": 13.5779,
         "t_outdoor": 12.093
       },
@@ -1768,9 +1768,9 @@
     {
       "time": 9600,
       "values": {
-        "t_tank_top": 15.4174,
-        "t_tank_bottom": 14.4478,
-        "t_collector": 17.2681,
+        "t_tank_top": 15.3501,
+        "t_tank_bottom": 14.3794,
+        "t_collector": 17.2021,
         "t_greenhouse": 13.6044,
         "t_outdoor": 12.1128
       },
@@ -1779,9 +1779,9 @@
     {
       "time": 9660,
       "values": {
-        "t_tank_top": 15.4541,
-        "t_tank_bottom": 14.4824,
-        "t_collector": 17.3085,
+        "t_tank_top": 15.3869,
+        "t_tank_bottom": 14.4141,
+        "t_collector": 17.2425,
         "t_greenhouse": 13.631,
         "t_outdoor": 12.1325
       },
@@ -1790,9 +1790,9 @@
     {
       "time": 9720,
       "values": {
-        "t_tank_top": 15.4909,
-        "t_tank_bottom": 14.5171,
-        "t_collector": 17.3489,
+        "t_tank_top": 15.4237,
+        "t_tank_bottom": 14.4488,
+        "t_collector": 17.283,
         "t_greenhouse": 13.6575,
         "t_outdoor": 12.1522
       },
@@ -1801,9 +1801,9 @@
     {
       "time": 9780,
       "values": {
-        "t_tank_top": 15.5278,
-        "t_tank_bottom": 14.5518,
-        "t_collector": 17.3894,
+        "t_tank_top": 15.4606,
+        "t_tank_bottom": 14.4836,
+        "t_collector": 17.3235,
         "t_greenhouse": 13.684,
         "t_outdoor": 12.1719
       },
@@ -1812,9 +1812,9 @@
     {
       "time": 9840,
       "values": {
-        "t_tank_top": 15.5647,
-        "t_tank_bottom": 14.5866,
-        "t_collector": 17.4299,
+        "t_tank_top": 15.4976,
+        "t_tank_bottom": 14.5184,
+        "t_collector": 17.3641,
         "t_greenhouse": 13.7105,
         "t_outdoor": 12.1915
       },
@@ -1823,9 +1823,9 @@
     {
       "time": 9900,
       "values": {
-        "t_tank_top": 15.6016,
-        "t_tank_bottom": 14.6215,
-        "t_collector": 17.4704,
+        "t_tank_top": 15.5346,
+        "t_tank_bottom": 14.5533,
+        "t_collector": 17.4047,
         "t_greenhouse": 13.7369,
         "t_outdoor": 12.2111
       },
@@ -1834,9 +1834,9 @@
     {
       "time": 9960,
       "values": {
-        "t_tank_top": 15.6387,
-        "t_tank_bottom": 14.6564,
-        "t_collector": 17.5109,
+        "t_tank_top": 15.5717,
+        "t_tank_bottom": 14.5883,
+        "t_collector": 17.4453,
         "t_greenhouse": 13.7633,
         "t_outdoor": 12.2307
       },
@@ -1845,9 +1845,9 @@
     {
       "time": 10020,
       "values": {
-        "t_tank_top": 15.6757,
-        "t_tank_bottom": 14.6914,
-        "t_collector": 17.5515,
+        "t_tank_top": 15.6088,
+        "t_tank_bottom": 14.6234,
+        "t_collector": 17.4859,
         "t_greenhouse": 13.7896,
         "t_outdoor": 12.2502
       },
@@ -1856,9 +1856,9 @@
     {
       "time": 10080,
       "values": {
-        "t_tank_top": 15.7129,
-        "t_tank_bottom": 14.7265,
-        "t_collector": 17.5921,
+        "t_tank_top": 15.646,
+        "t_tank_bottom": 14.6585,
+        "t_collector": 17.5265,
         "t_greenhouse": 13.8159,
         "t_outdoor": 12.2696
       },
@@ -1867,9 +1867,9 @@
     {
       "time": 10140,
       "values": {
-        "t_tank_top": 15.7501,
-        "t_tank_bottom": 14.7617,
-        "t_collector": 17.6327,
+        "t_tank_top": 15.6832,
+        "t_tank_bottom": 14.6938,
+        "t_collector": 17.5672,
         "t_greenhouse": 13.8422,
         "t_outdoor": 12.289
       },
@@ -1878,9 +1878,9 @@
     {
       "time": 10200,
       "values": {
-        "t_tank_top": 15.7873,
-        "t_tank_bottom": 14.7969,
-        "t_collector": 17.6734,
+        "t_tank_top": 15.7205,
+        "t_tank_bottom": 14.729,
+        "t_collector": 17.6079,
         "t_greenhouse": 13.8685,
         "t_outdoor": 12.3084
       },
@@ -1889,9 +1889,9 @@
     {
       "time": 10260,
       "values": {
-        "t_tank_top": 15.8246,
-        "t_tank_bottom": 14.8322,
-        "t_collector": 17.7141,
+        "t_tank_top": 15.7578,
+        "t_tank_bottom": 14.7644,
+        "t_collector": 17.6486,
         "t_greenhouse": 13.8947,
         "t_outdoor": 12.3278
       },
@@ -1900,9 +1900,9 @@
     {
       "time": 10320,
       "values": {
-        "t_tank_top": 15.8619,
-        "t_tank_bottom": 14.8676,
-        "t_collector": 17.7548,
+        "t_tank_top": 15.7952,
+        "t_tank_bottom": 14.7998,
+        "t_collector": 17.6894,
         "t_greenhouse": 13.9208,
         "t_outdoor": 12.347
       },
@@ -1911,9 +1911,9 @@
     {
       "time": 10380,
       "values": {
-        "t_tank_top": 15.8993,
-        "t_tank_bottom": 14.903,
-        "t_collector": 17.7955,
+        "t_tank_top": 15.8327,
+        "t_tank_bottom": 14.8353,
+        "t_collector": 17.7301,
         "t_greenhouse": 13.9469,
         "t_outdoor": 12.3663
       },
@@ -1922,9 +1922,9 @@
     {
       "time": 10440,
       "values": {
-        "t_tank_top": 15.9368,
-        "t_tank_bottom": 14.9386,
-        "t_collector": 17.8362,
+        "t_tank_top": 15.8702,
+        "t_tank_bottom": 14.8709,
+        "t_collector": 17.7709,
         "t_greenhouse": 13.973,
         "t_outdoor": 12.3855
       },
@@ -1933,9 +1933,9 @@
     {
       "time": 10500,
       "values": {
-        "t_tank_top": 15.9743,
-        "t_tank_bottom": 14.9741,
-        "t_collector": 17.877,
+        "t_tank_top": 15.9077,
+        "t_tank_bottom": 14.9065,
+        "t_collector": 17.8118,
         "t_greenhouse": 13.9991,
         "t_outdoor": 12.4046
       },
@@ -1944,9 +1944,9 @@
     {
       "time": 10560,
       "values": {
-        "t_tank_top": 16.0118,
-        "t_tank_bottom": 15.0098,
-        "t_collector": 17.9178,
+        "t_tank_top": 15.9453,
+        "t_tank_bottom": 14.9422,
+        "t_collector": 17.8526,
         "t_greenhouse": 14.0251,
         "t_outdoor": 12.4237
       },
@@ -1955,9 +1955,9 @@
     {
       "time": 10620,
       "values": {
-        "t_tank_top": 16.0494,
-        "t_tank_bottom": 15.0455,
-        "t_collector": 17.9586,
+        "t_tank_top": 15.983,
+        "t_tank_bottom": 14.9779,
+        "t_collector": 17.8934,
         "t_greenhouse": 14.051,
         "t_outdoor": 12.4428
       },
@@ -1966,9 +1966,9 @@
     {
       "time": 10680,
       "values": {
-        "t_tank_top": 16.0871,
-        "t_tank_bottom": 15.0813,
-        "t_collector": 17.9994,
+        "t_tank_top": 16.0207,
+        "t_tank_bottom": 15.0138,
+        "t_collector": 17.9343,
         "t_greenhouse": 14.0769,
         "t_outdoor": 12.4618
       },
@@ -1977,9 +1977,9 @@
     {
       "time": 10740,
       "values": {
-        "t_tank_top": 16.1248,
-        "t_tank_bottom": 15.1171,
-        "t_collector": 18.0403,
+        "t_tank_top": 16.0584,
+        "t_tank_bottom": 15.0496,
+        "t_collector": 17.9752,
         "t_greenhouse": 14.1028,
         "t_outdoor": 12.4808
       },
@@ -1988,9 +1988,9 @@
     {
       "time": 10800,
       "values": {
-        "t_tank_top": 16.1625,
-        "t_tank_bottom": 15.153,
-        "t_collector": 18.0811,
+        "t_tank_top": 16.0962,
+        "t_tank_bottom": 15.0856,
+        "t_collector": 18.0161,
         "t_greenhouse": 14.1286,
         "t_outdoor": 12.4997
       },
@@ -1999,9 +1999,9 @@
     {
       "time": 10860,
       "values": {
-        "t_tank_top": 16.2003,
-        "t_tank_bottom": 15.189,
-        "t_collector": 18.122,
+        "t_tank_top": 16.1341,
+        "t_tank_bottom": 15.1216,
+        "t_collector": 18.0571,
         "t_greenhouse": 14.1543,
         "t_outdoor": 12.5186
       },
@@ -2010,9 +2010,9 @@
     {
       "time": 10920,
       "values": {
-        "t_tank_top": 16.2382,
-        "t_tank_bottom": 15.225,
-        "t_collector": 18.1629,
+        "t_tank_top": 16.1719,
+        "t_tank_bottom": 15.1577,
+        "t_collector": 18.098,
         "t_greenhouse": 14.18,
         "t_outdoor": 12.5374
       },
@@ -2021,9 +2021,9 @@
     {
       "time": 10980,
       "values": {
-        "t_tank_top": 16.2761,
-        "t_tank_bottom": 15.2611,
-        "t_collector": 18.2038,
+        "t_tank_top": 16.2099,
+        "t_tank_bottom": 15.1938,
+        "t_collector": 18.139,
         "t_greenhouse": 14.2057,
         "t_outdoor": 12.5562
       },
@@ -2032,9 +2032,9 @@
     {
       "time": 11040,
       "values": {
-        "t_tank_top": 16.314,
-        "t_tank_bottom": 15.2972,
-        "t_collector": 18.2448,
+        "t_tank_top": 16.2479,
+        "t_tank_bottom": 15.23,
+        "t_collector": 18.1799,
         "t_greenhouse": 14.2313,
         "t_outdoor": 12.5749
       },
@@ -2043,9 +2043,9 @@
     {
       "time": 11100,
       "values": {
-        "t_tank_top": 16.352,
-        "t_tank_bottom": 15.3335,
-        "t_collector": 18.2857,
+        "t_tank_top": 16.2859,
+        "t_tank_bottom": 15.2663,
+        "t_collector": 18.2209,
         "t_greenhouse": 14.2569,
         "t_outdoor": 12.5936
       },
@@ -2054,9 +2054,9 @@
     {
       "time": 11160,
       "values": {
-        "t_tank_top": 16.39,
-        "t_tank_bottom": 15.3697,
-        "t_collector": 18.3267,
+        "t_tank_top": 16.3239,
+        "t_tank_bottom": 15.3026,
+        "t_collector": 18.2619,
         "t_greenhouse": 14.2824,
         "t_outdoor": 12.6122
       },
@@ -2065,9 +2065,9 @@
     {
       "time": 11220,
       "values": {
-        "t_tank_top": 16.428,
-        "t_tank_bottom": 15.4061,
-        "t_collector": 18.3676,
+        "t_tank_top": 16.3621,
+        "t_tank_bottom": 15.339,
+        "t_collector": 18.3029,
         "t_greenhouse": 14.3078,
         "t_outdoor": 12.6308
       },
@@ -2076,9 +2076,9 @@
     {
       "time": 11280,
       "values": {
-        "t_tank_top": 16.4661,
-        "t_tank_bottom": 15.4425,
-        "t_collector": 18.4086,
+        "t_tank_top": 16.4002,
+        "t_tank_bottom": 15.3754,
+        "t_collector": 18.344,
         "t_greenhouse": 14.3332,
         "t_outdoor": 12.6493
       },
@@ -2087,9 +2087,9 @@
     {
       "time": 11340,
       "values": {
-        "t_tank_top": 16.5043,
-        "t_tank_bottom": 15.4789,
-        "t_collector": 18.4496,
+        "t_tank_top": 16.4384,
+        "t_tank_bottom": 15.4119,
+        "t_collector": 18.385,
         "t_greenhouse": 14.3586,
         "t_outdoor": 12.6678
       },
@@ -2098,9 +2098,9 @@
     {
       "time": 11400,
       "values": {
-        "t_tank_top": 16.5425,
-        "t_tank_bottom": 15.5154,
-        "t_collector": 18.4906,
+        "t_tank_top": 16.4766,
+        "t_tank_bottom": 15.4485,
+        "t_collector": 18.4261,
         "t_greenhouse": 14.3839,
         "t_outdoor": 12.6862
       },
@@ -2109,9 +2109,9 @@
     {
       "time": 11460,
       "values": {
-        "t_tank_top": 16.5807,
-        "t_tank_bottom": 15.552,
-        "t_collector": 18.5316,
+        "t_tank_top": 16.5149,
+        "t_tank_bottom": 15.4851,
+        "t_collector": 18.4671,
         "t_greenhouse": 14.4091,
         "t_outdoor": 12.7046
       },
@@ -2120,9 +2120,9 @@
     {
       "time": 11520,
       "values": {
-        "t_tank_top": 16.619,
-        "t_tank_bottom": 15.5886,
-        "t_collector": 18.5727,
+        "t_tank_top": 16.5532,
+        "t_tank_bottom": 15.5218,
+        "t_collector": 18.5082,
         "t_greenhouse": 14.4342,
         "t_outdoor": 12.7229
       },
@@ -2131,9 +2131,9 @@
     {
       "time": 11580,
       "values": {
-        "t_tank_top": 16.6573,
-        "t_tank_bottom": 15.6253,
-        "t_collector": 18.6137,
+        "t_tank_top": 16.5916,
+        "t_tank_bottom": 15.5585,
+        "t_collector": 18.5493,
         "t_greenhouse": 14.4594,
         "t_outdoor": 12.7412
       },
@@ -2142,9 +2142,9 @@
     {
       "time": 11640,
       "values": {
-        "t_tank_top": 16.6956,
-        "t_tank_bottom": 15.662,
-        "t_collector": 18.6547,
+        "t_tank_top": 16.63,
+        "t_tank_bottom": 15.5953,
+        "t_collector": 18.5904,
         "t_greenhouse": 14.4844,
         "t_outdoor": 12.7594
       },
@@ -2153,9 +2153,9 @@
     {
       "time": 11700,
       "values": {
-        "t_tank_top": 16.734,
-        "t_tank_bottom": 15.6988,
-        "t_collector": 18.6958,
+        "t_tank_top": 16.6684,
+        "t_tank_bottom": 15.6322,
+        "t_collector": 18.6315,
         "t_greenhouse": 14.5094,
         "t_outdoor": 12.7775
       },
@@ -2164,9 +2164,9 @@
     {
       "time": 11760,
       "values": {
-        "t_tank_top": 16.7724,
-        "t_tank_bottom": 15.7357,
-        "t_collector": 18.7369,
+        "t_tank_top": 16.7069,
+        "t_tank_bottom": 15.669,
+        "t_collector": 18.6726,
         "t_greenhouse": 14.5343,
         "t_outdoor": 12.7957
       },
@@ -2175,9 +2175,9 @@
     {
       "time": 11820,
       "values": {
-        "t_tank_top": 16.8109,
-        "t_tank_bottom": 15.7726,
-        "t_collector": 18.7779,
+        "t_tank_top": 16.7454,
+        "t_tank_bottom": 15.706,
+        "t_collector": 18.7137,
         "t_greenhouse": 14.5592,
         "t_outdoor": 12.8137
       },
@@ -2186,9 +2186,9 @@
     {
       "time": 11880,
       "values": {
-        "t_tank_top": 16.8494,
-        "t_tank_bottom": 15.8095,
-        "t_collector": 18.819,
+        "t_tank_top": 16.7839,
+        "t_tank_bottom": 15.743,
+        "t_collector": 18.7548,
         "t_greenhouse": 14.584,
         "t_outdoor": 12.8317
       },
@@ -2197,9 +2197,9 @@
     {
       "time": 11940,
       "values": {
-        "t_tank_top": 16.8879,
-        "t_tank_bottom": 15.8465,
-        "t_collector": 18.8601,
+        "t_tank_top": 16.8225,
+        "t_tank_bottom": 15.78,
+        "t_collector": 18.7959,
         "t_greenhouse": 14.6088,
         "t_outdoor": 12.8497
       },
@@ -2208,9 +2208,9 @@
     {
       "time": 12000,
       "values": {
-        "t_tank_top": 16.9265,
-        "t_tank_bottom": 15.8836,
-        "t_collector": 18.9012,
+        "t_tank_top": 16.8611,
+        "t_tank_bottom": 15.8172,
+        "t_collector": 18.8371,
         "t_greenhouse": 14.6334,
         "t_outdoor": 12.8676
       },
@@ -2219,9 +2219,9 @@
     {
       "time": 12060,
       "values": {
-        "t_tank_top": 16.9651,
-        "t_tank_bottom": 15.9207,
-        "t_collector": 18.9422,
+        "t_tank_top": 16.8998,
+        "t_tank_bottom": 15.8543,
+        "t_collector": 18.8782,
         "t_greenhouse": 14.6581,
         "t_outdoor": 12.8854
       },
@@ -2230,9 +2230,9 @@
     {
       "time": 12120,
       "values": {
-        "t_tank_top": 17.0037,
-        "t_tank_bottom": 15.9579,
-        "t_collector": 18.9833,
+        "t_tank_top": 16.9384,
+        "t_tank_bottom": 15.8915,
+        "t_collector": 18.9193,
         "t_greenhouse": 14.6826,
         "t_outdoor": 12.9032
       },
@@ -2241,9 +2241,9 @@
     {
       "time": 12180,
       "values": {
-        "t_tank_top": 17.0424,
-        "t_tank_bottom": 15.9951,
-        "t_collector": 19.0244,
+        "t_tank_top": 16.9772,
+        "t_tank_bottom": 15.9288,
+        "t_collector": 18.9605,
         "t_greenhouse": 14.7071,
         "t_outdoor": 12.921
       },
@@ -2252,9 +2252,9 @@
     {
       "time": 12240,
       "values": {
-        "t_tank_top": 17.0811,
-        "t_tank_bottom": 16.0323,
-        "t_collector": 19.0655,
+        "t_tank_top": 17.0159,
+        "t_tank_bottom": 15.9661,
+        "t_collector": 19.0016,
         "t_greenhouse": 14.7315,
         "t_outdoor": 12.9386
       },
@@ -2263,9 +2263,9 @@
     {
       "time": 12300,
       "values": {
-        "t_tank_top": 17.1198,
-        "t_tank_bottom": 16.0696,
-        "t_collector": 19.1066,
+        "t_tank_top": 17.0547,
+        "t_tank_bottom": 16.0034,
+        "t_collector": 19.0428,
         "t_greenhouse": 14.7559,
         "t_outdoor": 12.9563
       },
@@ -2274,9 +2274,9 @@
     {
       "time": 12360,
       "values": {
-        "t_tank_top": 17.1586,
-        "t_tank_bottom": 16.107,
-        "t_collector": 19.1477,
+        "t_tank_top": 17.0935,
+        "t_tank_bottom": 16.0408,
+        "t_collector": 19.0839,
         "t_greenhouse": 14.7802,
         "t_outdoor": 12.9738
       },
@@ -2285,9 +2285,9 @@
     {
       "time": 12420,
       "values": {
-        "t_tank_top": 17.1974,
-        "t_tank_bottom": 16.1444,
-        "t_collector": 19.1888,
+        "t_tank_top": 17.1323,
+        "t_tank_bottom": 16.0783,
+        "t_collector": 19.125,
         "t_greenhouse": 14.8044,
         "t_outdoor": 12.9913
       },
@@ -2296,9 +2296,9 @@
     {
       "time": 12480,
       "values": {
-        "t_tank_top": 17.2362,
-        "t_tank_bottom": 16.1818,
-        "t_collector": 19.2299,
+        "t_tank_top": 17.1712,
+        "t_tank_bottom": 16.1158,
+        "t_collector": 19.1662,
         "t_greenhouse": 14.8285,
         "t_outdoor": 13.0088
       },
@@ -2307,9 +2307,9 @@
     {
       "time": 12540,
       "values": {
-        "t_tank_top": 17.275,
-        "t_tank_bottom": 16.2193,
-        "t_collector": 19.271,
+        "t_tank_top": 17.2101,
+        "t_tank_bottom": 16.1533,
+        "t_collector": 19.2073,
         "t_greenhouse": 14.8526,
         "t_outdoor": 13.0262
       },
@@ -2318,9 +2318,9 @@
     {
       "time": 12600,
       "values": {
-        "t_tank_top": 17.3139,
-        "t_tank_bottom": 16.2569,
-        "t_collector": 19.3121,
+        "t_tank_top": 17.249,
+        "t_tank_bottom": 16.1909,
+        "t_collector": 19.2484,
         "t_greenhouse": 14.8766,
         "t_outdoor": 13.0435
       },
@@ -2329,9 +2329,9 @@
     {
       "time": 12660,
       "values": {
-        "t_tank_top": 17.3528,
-        "t_tank_bottom": 16.2945,
-        "t_collector": 19.3532,
+        "t_tank_top": 17.288,
+        "t_tank_bottom": 16.2285,
+        "t_collector": 19.2896,
         "t_greenhouse": 14.9006,
         "t_outdoor": 13.0608
       },
@@ -2340,9 +2340,9 @@
     {
       "time": 12720,
       "values": {
-        "t_tank_top": 17.3918,
-        "t_tank_bottom": 16.3321,
-        "t_collector": 19.3942,
+        "t_tank_top": 17.3269,
+        "t_tank_bottom": 16.2662,
+        "t_collector": 19.3307,
         "t_greenhouse": 14.9244,
         "t_outdoor": 13.078
       },
@@ -2351,9 +2351,9 @@
     {
       "time": 12780,
       "values": {
-        "t_tank_top": 17.4307,
-        "t_tank_bottom": 16.3698,
-        "t_collector": 19.4353,
+        "t_tank_top": 17.366,
+        "t_tank_bottom": 16.3039,
+        "t_collector": 19.3718,
         "t_greenhouse": 14.9482,
         "t_outdoor": 13.0952
       },
@@ -2362,9 +2362,9 @@
     {
       "time": 12840,
       "values": {
-        "t_tank_top": 17.4697,
-        "t_tank_bottom": 16.4075,
-        "t_collector": 19.4764,
+        "t_tank_top": 17.405,
+        "t_tank_bottom": 16.3417,
+        "t_collector": 19.4129,
         "t_greenhouse": 14.9719,
         "t_outdoor": 13.1123
       },
@@ -2373,9 +2373,9 @@
     {
       "time": 12900,
       "values": {
-        "t_tank_top": 17.5087,
-        "t_tank_bottom": 16.4452,
-        "t_collector": 19.5175,
+        "t_tank_top": 17.444,
+        "t_tank_bottom": 16.3795,
+        "t_collector": 19.4541,
         "t_greenhouse": 14.9956,
         "t_outdoor": 13.1293
       },
@@ -2384,9 +2384,9 @@
     {
       "time": 12960,
       "values": {
-        "t_tank_top": 17.5478,
-        "t_tank_bottom": 16.483,
-        "t_collector": 19.5585,
+        "t_tank_top": 17.4831,
+        "t_tank_bottom": 16.4174,
+        "t_collector": 19.4952,
         "t_greenhouse": 15.0192,
         "t_outdoor": 13.1463
       },
@@ -2395,9 +2395,9 @@
     {
       "time": 13020,
       "values": {
-        "t_tank_top": 17.5868,
-        "t_tank_bottom": 16.5209,
-        "t_collector": 19.5996,
+        "t_tank_top": 17.5222,
+        "t_tank_bottom": 16.4553,
+        "t_collector": 19.5363,
         "t_greenhouse": 15.0426,
         "t_outdoor": 13.1632
       },
@@ -2406,9 +2406,9 @@
     {
       "time": 13080,
       "values": {
-        "t_tank_top": 17.6259,
-        "t_tank_bottom": 16.5588,
-        "t_collector": 19.6406,
+        "t_tank_top": 17.5614,
+        "t_tank_bottom": 16.4932,
+        "t_collector": 19.5773,
         "t_greenhouse": 15.0661,
         "t_outdoor": 13.1801
       },
@@ -2417,9 +2417,9 @@
     {
       "time": 13140,
       "values": {
-        "t_tank_top": 17.665,
-        "t_tank_bottom": 16.5967,
-        "t_collector": 19.6816,
+        "t_tank_top": 17.6005,
+        "t_tank_bottom": 16.5311,
+        "t_collector": 19.6184,
         "t_greenhouse": 15.0894,
         "t_outdoor": 13.1969
       },
@@ -2428,9 +2428,9 @@
     {
       "time": 13200,
       "values": {
-        "t_tank_top": 17.7041,
-        "t_tank_bottom": 16.6346,
-        "t_collector": 19.7227,
+        "t_tank_top": 17.6397,
+        "t_tank_bottom": 16.5692,
+        "t_collector": 19.6595,
         "t_greenhouse": 15.1127,
         "t_outdoor": 13.2137
       },
@@ -2439,9 +2439,9 @@
     {
       "time": 13260,
       "values": {
-        "t_tank_top": 17.7433,
-        "t_tank_bottom": 16.6726,
-        "t_collector": 19.7637,
+        "t_tank_top": 17.6789,
+        "t_tank_bottom": 16.6072,
+        "t_collector": 19.7006,
         "t_greenhouse": 15.1359,
         "t_outdoor": 13.2303
       },
@@ -2450,9 +2450,9 @@
     {
       "time": 13320,
       "values": {
-        "t_tank_top": 17.7824,
-        "t_tank_bottom": 16.7107,
-        "t_collector": 19.8047,
+        "t_tank_top": 17.7181,
+        "t_tank_bottom": 16.6453,
+        "t_collector": 19.7416,
         "t_greenhouse": 15.159,
         "t_outdoor": 13.247
       },
@@ -2461,9 +2461,9 @@
     {
       "time": 13380,
       "values": {
-        "t_tank_top": 17.8216,
-        "t_tank_bottom": 16.7488,
-        "t_collector": 19.8457,
+        "t_tank_top": 17.7573,
+        "t_tank_bottom": 16.6834,
+        "t_collector": 19.7827,
         "t_greenhouse": 15.182,
         "t_outdoor": 13.2635
       },
@@ -2472,9 +2472,9 @@
     {
       "time": 13440,
       "values": {
-        "t_tank_top": 17.8608,
-        "t_tank_bottom": 16.7869,
-        "t_collector": 19.8867,
+        "t_tank_top": 17.7966,
+        "t_tank_bottom": 16.7216,
+        "t_collector": 19.8237,
         "t_greenhouse": 15.205,
         "t_outdoor": 13.28
       },
@@ -2483,9 +2483,9 @@
     {
       "time": 13500,
       "values": {
-        "t_tank_top": 17.9001,
-        "t_tank_bottom": 16.825,
-        "t_collector": 19.9277,
+        "t_tank_top": 17.8359,
+        "t_tank_bottom": 16.7598,
+        "t_collector": 19.8647,
         "t_greenhouse": 15.2279,
         "t_outdoor": 13.2965
       },
@@ -2494,9 +2494,9 @@
     {
       "time": 13560,
       "values": {
-        "t_tank_top": 17.9393,
-        "t_tank_bottom": 16.8632,
-        "t_collector": 19.9686,
+        "t_tank_top": 17.8752,
+        "t_tank_bottom": 16.798,
+        "t_collector": 19.9057,
         "t_greenhouse": 15.2507,
         "t_outdoor": 13.3128
       },
@@ -2505,9 +2505,9 @@
     {
       "time": 13620,
       "values": {
-        "t_tank_top": 17.9786,
-        "t_tank_bottom": 16.9014,
-        "t_collector": 20.0096,
+        "t_tank_top": 17.9145,
+        "t_tank_bottom": 16.8363,
+        "t_collector": 19.9467,
         "t_greenhouse": 15.2734,
         "t_outdoor": 13.3291
       },
@@ -2516,9 +2516,9 @@
     {
       "time": 13680,
       "values": {
-        "t_tank_top": 18.0179,
-        "t_tank_bottom": 16.9397,
-        "t_collector": 20.0505,
+        "t_tank_top": 17.9538,
+        "t_tank_bottom": 16.8746,
+        "t_collector": 19.9877,
         "t_greenhouse": 15.296,
         "t_outdoor": 13.3454
       },
@@ -2527,9 +2527,9 @@
     {
       "time": 13740,
       "values": {
-        "t_tank_top": 18.0572,
-        "t_tank_bottom": 16.978,
-        "t_collector": 20.0914,
+        "t_tank_top": 17.9931,
+        "t_tank_bottom": 16.9129,
+        "t_collector": 20.0286,
         "t_greenhouse": 15.3186,
         "t_outdoor": 13.3616
       },
@@ -2538,9 +2538,9 @@
     {
       "time": 13800,
       "values": {
-        "t_tank_top": 18.0965,
-        "t_tank_bottom": 17.0163,
-        "t_collector": 20.1323,
+        "t_tank_top": 18.0325,
+        "t_tank_bottom": 16.9513,
+        "t_collector": 20.0696,
         "t_greenhouse": 15.3411,
         "t_outdoor": 13.3777
       },
@@ -2549,9 +2549,9 @@
     {
       "time": 13860,
       "values": {
-        "t_tank_top": 18.1358,
-        "t_tank_bottom": 17.0546,
-        "t_collector": 20.1732,
+        "t_tank_top": 18.0719,
+        "t_tank_bottom": 16.9897,
+        "t_collector": 20.1105,
         "t_greenhouse": 15.3634,
         "t_outdoor": 13.3937
       },
@@ -2560,9 +2560,9 @@
     {
       "time": 13920,
       "values": {
-        "t_tank_top": 18.1751,
-        "t_tank_bottom": 17.093,
-        "t_collector": 20.214,
+        "t_tank_top": 18.1112,
+        "t_tank_bottom": 17.0281,
+        "t_collector": 20.1514,
         "t_greenhouse": 15.3858,
         "t_outdoor": 13.4097
       },
@@ -2571,9 +2571,9 @@
     {
       "time": 13980,
       "values": {
-        "t_tank_top": 18.2145,
-        "t_tank_bottom": 17.1314,
-        "t_collector": 20.2549,
+        "t_tank_top": 18.1506,
+        "t_tank_bottom": 17.0665,
+        "t_collector": 20.1923,
         "t_greenhouse": 15.408,
         "t_outdoor": 13.4257
       },
@@ -2582,9 +2582,9 @@
     {
       "time": 14040,
       "values": {
-        "t_tank_top": 18.2538,
-        "t_tank_bottom": 17.1699,
-        "t_collector": 20.2957,
+        "t_tank_top": 18.1901,
+        "t_tank_bottom": 17.105,
+        "t_collector": 20.2332,
         "t_greenhouse": 15.4301,
         "t_outdoor": 13.4415
       },
@@ -2593,9 +2593,9 @@
     {
       "time": 14100,
       "values": {
-        "t_tank_top": 18.2932,
-        "t_tank_bottom": 17.2083,
-        "t_collector": 20.3365,
+        "t_tank_top": 18.2295,
+        "t_tank_bottom": 17.1436,
+        "t_collector": 20.274,
         "t_greenhouse": 15.4522,
         "t_outdoor": 13.4573
       },
@@ -2604,9 +2604,9 @@
     {
       "time": 14160,
       "values": {
-        "t_tank_top": 18.3326,
-        "t_tank_bottom": 17.2468,
-        "t_collector": 20.3773,
+        "t_tank_top": 18.2689,
+        "t_tank_bottom": 17.1821,
+        "t_collector": 20.3149,
         "t_greenhouse": 15.4741,
         "t_outdoor": 13.473
       },
@@ -2615,9 +2615,9 @@
     {
       "time": 14220,
       "values": {
-        "t_tank_top": 18.372,
-        "t_tank_bottom": 17.2854,
-        "t_collector": 20.4181,
+        "t_tank_top": 18.3084,
+        "t_tank_bottom": 17.2207,
+        "t_collector": 20.3557,
         "t_greenhouse": 15.496,
         "t_outdoor": 13.4887
       },
@@ -2626,9 +2626,9 @@
     {
       "time": 14280,
       "values": {
-        "t_tank_top": 18.4114,
-        "t_tank_bottom": 17.3239,
-        "t_collector": 20.4588,
+        "t_tank_top": 18.3478,
+        "t_tank_bottom": 17.2593,
+        "t_collector": 20.3965,
         "t_greenhouse": 15.5178,
         "t_outdoor": 13.5043
       },
@@ -2637,9 +2637,9 @@
     {
       "time": 14340,
       "values": {
-        "t_tank_top": 18.4508,
-        "t_tank_bottom": 17.3625,
-        "t_collector": 20.4996,
+        "t_tank_top": 18.3873,
+        "t_tank_bottom": 17.2979,
+        "t_collector": 20.4372,
         "t_greenhouse": 15.5395,
         "t_outdoor": 13.5198
       },
@@ -2648,9 +2648,9 @@
     {
       "time": 14400,
       "values": {
-        "t_tank_top": 18.4903,
-        "t_tank_bottom": 17.4011,
-        "t_collector": 20.5403,
+        "t_tank_top": 18.4268,
+        "t_tank_bottom": 17.3366,
+        "t_collector": 20.478,
         "t_greenhouse": 15.5612,
         "t_outdoor": 13.5353
       },
@@ -2659,9 +2659,9 @@
     {
       "time": 14460,
       "values": {
-        "t_tank_top": 18.5297,
-        "t_tank_bottom": 17.4398,
-        "t_collector": 20.5809,
+        "t_tank_top": 18.4662,
+        "t_tank_bottom": 17.3753,
+        "t_collector": 20.5187,
         "t_greenhouse": 15.5827,
         "t_outdoor": 13.5507
       },
@@ -2670,9 +2670,9 @@
     {
       "time": 14520,
       "values": {
-        "t_tank_top": 18.5692,
-        "t_tank_bottom": 17.4784,
-        "t_collector": 20.6216,
+        "t_tank_top": 18.5057,
+        "t_tank_bottom": 17.414,
+        "t_collector": 20.5594,
         "t_greenhouse": 15.6042,
         "t_outdoor": 13.566
       },
@@ -2681,9 +2681,9 @@
     {
       "time": 14580,
       "values": {
-        "t_tank_top": 18.6086,
-        "t_tank_bottom": 17.5171,
-        "t_collector": 20.6622,
+        "t_tank_top": 18.5452,
+        "t_tank_bottom": 17.4527,
+        "t_collector": 20.6001,
         "t_greenhouse": 15.6255,
         "t_outdoor": 13.5813
       },
@@ -2692,9 +2692,9 @@
     {
       "time": 14640,
       "values": {
-        "t_tank_top": 18.6481,
-        "t_tank_bottom": 17.5558,
-        "t_collector": 20.7028,
+        "t_tank_top": 18.5847,
+        "t_tank_bottom": 17.4915,
+        "t_collector": 20.6407,
         "t_greenhouse": 15.6468,
         "t_outdoor": 13.5964
       },
@@ -2703,9 +2703,9 @@
     {
       "time": 14700,
       "values": {
-        "t_tank_top": 18.6875,
-        "t_tank_bottom": 17.5946,
-        "t_collector": 20.7434,
+        "t_tank_top": 18.6242,
+        "t_tank_bottom": 17.5302,
+        "t_collector": 20.6814,
         "t_greenhouse": 15.668,
         "t_outdoor": 13.6116
       },
@@ -2714,9 +2714,9 @@
     {
       "time": 14760,
       "values": {
-        "t_tank_top": 18.727,
-        "t_tank_bottom": 17.6333,
-        "t_collector": 20.784,
+        "t_tank_top": 18.6637,
+        "t_tank_bottom": 17.569,
+        "t_collector": 20.722,
         "t_greenhouse": 15.6891,
         "t_outdoor": 13.6266
       },
@@ -2725,9 +2725,9 @@
     {
       "time": 14820,
       "values": {
-        "t_tank_top": 18.7665,
-        "t_tank_bottom": 17.6721,
-        "t_collector": 20.8245,
+        "t_tank_top": 18.7033,
+        "t_tank_bottom": 17.6079,
+        "t_collector": 20.7625,
         "t_greenhouse": 15.7101,
         "t_outdoor": 13.6416
       },
@@ -2736,9 +2736,9 @@
     {
       "time": 14880,
       "values": {
-        "t_tank_top": 18.8059,
-        "t_tank_bottom": 17.7109,
-        "t_collector": 20.865,
+        "t_tank_top": 18.7428,
+        "t_tank_bottom": 17.6467,
+        "t_collector": 20.8031,
         "t_greenhouse": 15.731,
         "t_outdoor": 13.6565
       },
@@ -2747,9 +2747,9 @@
     {
       "time": 14940,
       "values": {
-        "t_tank_top": 18.8454,
-        "t_tank_bottom": 17.7497,
-        "t_collector": 20.9055,
+        "t_tank_top": 18.7823,
+        "t_tank_bottom": 17.6856,
+        "t_collector": 20.8436,
         "t_greenhouse": 15.7518,
         "t_outdoor": 13.6714
       },
@@ -2758,9 +2758,9 @@
     {
       "time": 15000,
       "values": {
-        "t_tank_top": 18.8849,
-        "t_tank_bottom": 17.7886,
-        "t_collector": 20.9459,
+        "t_tank_top": 18.8218,
+        "t_tank_bottom": 17.7245,
+        "t_collector": 20.8841,
         "t_greenhouse": 15.7725,
         "t_outdoor": 13.6861
       },
@@ -2769,9 +2769,9 @@
     {
       "time": 15060,
       "values": {
-        "t_tank_top": 18.9244,
-        "t_tank_bottom": 17.8274,
-        "t_collector": 20.9863,
+        "t_tank_top": 18.8614,
+        "t_tank_bottom": 17.7634,
+        "t_collector": 20.9245,
         "t_greenhouse": 15.7931,
         "t_outdoor": 13.7008
       },
@@ -2780,9 +2780,9 @@
     {
       "time": 15120,
       "values": {
-        "t_tank_top": 18.9639,
-        "t_tank_bottom": 17.8663,
-        "t_collector": 21.0267,
+        "t_tank_top": 18.9009,
+        "t_tank_bottom": 17.8023,
+        "t_collector": 20.9649,
         "t_greenhouse": 15.8137,
         "t_outdoor": 13.7155
       },
@@ -2791,9 +2791,9 @@
     {
       "time": 15180,
       "values": {
-        "t_tank_top": 19.0033,
-        "t_tank_bottom": 17.9052,
-        "t_collector": 21.067,
+        "t_tank_top": 18.9404,
+        "t_tank_bottom": 17.8412,
+        "t_collector": 21.0053,
         "t_greenhouse": 15.8341,
         "t_outdoor": 13.73
       },
@@ -2802,9 +2802,9 @@
     {
       "time": 15240,
       "values": {
-        "t_tank_top": 19.0428,
-        "t_tank_bottom": 17.9441,
-        "t_collector": 21.1073,
+        "t_tank_top": 18.98,
+        "t_tank_bottom": 17.8802,
+        "t_collector": 21.0457,
         "t_greenhouse": 15.8545,
         "t_outdoor": 13.7445
       },
@@ -2813,9 +2813,9 @@
     {
       "time": 15300,
       "values": {
-        "t_tank_top": 19.0823,
-        "t_tank_bottom": 17.983,
-        "t_collector": 21.1476,
+        "t_tank_top": 19.0195,
+        "t_tank_bottom": 17.9192,
+        "t_collector": 21.086,
         "t_greenhouse": 15.8747,
         "t_outdoor": 13.759
       },
@@ -2824,9 +2824,9 @@
     {
       "time": 15360,
       "values": {
-        "t_tank_top": 19.1218,
-        "t_tank_bottom": 18.022,
-        "t_collector": 21.1879,
+        "t_tank_top": 19.059,
+        "t_tank_bottom": 17.9582,
+        "t_collector": 21.1263,
         "t_greenhouse": 15.8949,
         "t_outdoor": 13.7733
       },
@@ -2835,9 +2835,9 @@
     {
       "time": 15420,
       "values": {
-        "t_tank_top": 19.1613,
-        "t_tank_bottom": 18.0609,
-        "t_collector": 21.2281,
+        "t_tank_top": 19.0985,
+        "t_tank_bottom": 17.9972,
+        "t_collector": 21.1666,
         "t_greenhouse": 15.915,
         "t_outdoor": 13.7876
       },
@@ -2846,9 +2846,9 @@
     {
       "time": 15480,
       "values": {
-        "t_tank_top": 19.2007,
-        "t_tank_bottom": 18.0999,
-        "t_collector": 21.2683,
+        "t_tank_top": 19.138,
+        "t_tank_bottom": 18.0362,
+        "t_collector": 21.2068,
         "t_greenhouse": 15.9349,
         "t_outdoor": 13.8018
       },
@@ -2857,9 +2857,9 @@
     {
       "time": 15540,
       "values": {
-        "t_tank_top": 19.2402,
-        "t_tank_bottom": 18.1389,
-        "t_collector": 21.3084,
+        "t_tank_top": 19.1776,
+        "t_tank_bottom": 18.0752,
+        "t_collector": 21.247,
         "t_greenhouse": 15.9548,
         "t_outdoor": 13.8159
       },
@@ -2868,9 +2868,9 @@
     {
       "time": 15600,
       "values": {
-        "t_tank_top": 19.2797,
-        "t_tank_bottom": 18.1779,
-        "t_collector": 21.3485,
+        "t_tank_top": 19.2171,
+        "t_tank_bottom": 18.1143,
+        "t_collector": 21.2871,
         "t_greenhouse": 15.9746,
         "t_outdoor": 13.83
       },
@@ -2879,9 +2879,9 @@
     {
       "time": 15660,
       "values": {
-        "t_tank_top": 19.3191,
-        "t_tank_bottom": 18.2169,
-        "t_collector": 21.3886,
+        "t_tank_top": 19.2566,
+        "t_tank_bottom": 18.1533,
+        "t_collector": 21.3272,
         "t_greenhouse": 15.9943,
         "t_outdoor": 13.844
       },
@@ -2890,9 +2890,9 @@
     {
       "time": 15720,
       "values": {
-        "t_tank_top": 19.3586,
-        "t_tank_bottom": 18.2559,
-        "t_collector": 21.4286,
+        "t_tank_top": 19.2961,
+        "t_tank_bottom": 18.1924,
+        "t_collector": 21.3673,
         "t_greenhouse": 16.0139,
         "t_outdoor": 13.8579
       },
@@ -2901,9 +2901,9 @@
     {
       "time": 15780,
       "values": {
-        "t_tank_top": 19.3981,
-        "t_tank_bottom": 18.295,
-        "t_collector": 21.4686,
+        "t_tank_top": 19.3356,
+        "t_tank_bottom": 18.2315,
+        "t_collector": 21.4074,
         "t_greenhouse": 16.0333,
         "t_outdoor": 13.8717
       },
@@ -2912,9 +2912,9 @@
     {
       "time": 15840,
       "values": {
-        "t_tank_top": 19.4375,
-        "t_tank_bottom": 18.334,
-        "t_collector": 21.5086,
+        "t_tank_top": 19.3751,
+        "t_tank_bottom": 18.2706,
+        "t_collector": 21.4474,
         "t_greenhouse": 16.0527,
         "t_outdoor": 13.8855
       },
@@ -2923,9 +2923,9 @@
     {
       "time": 15900,
       "values": {
-        "t_tank_top": 19.4769,
-        "t_tank_bottom": 18.3731,
-        "t_collector": 21.5485,
+        "t_tank_top": 19.4145,
+        "t_tank_bottom": 18.3097,
+        "t_collector": 21.4873,
         "t_greenhouse": 16.072,
         "t_outdoor": 13.8992
       },
@@ -2934,9 +2934,9 @@
     {
       "time": 15960,
       "values": {
-        "t_tank_top": 19.5164,
-        "t_tank_bottom": 18.4122,
-        "t_collector": 21.5884,
+        "t_tank_top": 19.454,
+        "t_tank_bottom": 18.3488,
+        "t_collector": 21.5272,
         "t_greenhouse": 16.0912,
         "t_outdoor": 13.9128
       },
@@ -2945,9 +2945,9 @@
     {
       "time": 16020,
       "values": {
-        "t_tank_top": 19.5558,
-        "t_tank_bottom": 18.4512,
-        "t_collector": 21.6282,
+        "t_tank_top": 19.4935,
+        "t_tank_bottom": 18.3879,
+        "t_collector": 21.5671,
         "t_greenhouse": 16.1103,
         "t_outdoor": 13.9264
       },
@@ -2956,9 +2956,9 @@
     {
       "time": 16080,
       "values": {
-        "t_tank_top": 19.5952,
-        "t_tank_bottom": 18.4903,
-        "t_collector": 21.668,
+        "t_tank_top": 19.5329,
+        "t_tank_bottom": 18.4271,
+        "t_collector": 21.607,
         "t_greenhouse": 16.1293,
         "t_outdoor": 13.9398
       },
@@ -2967,9 +2967,9 @@
     {
       "time": 16140,
       "values": {
-        "t_tank_top": 19.6346,
-        "t_tank_bottom": 18.5294,
-        "t_collector": 21.7077,
+        "t_tank_top": 19.5724,
+        "t_tank_bottom": 18.4662,
+        "t_collector": 21.6468,
         "t_greenhouse": 16.1482,
         "t_outdoor": 13.9532
       },
@@ -2978,9 +2978,9 @@
     {
       "time": 16200,
       "values": {
-        "t_tank_top": 19.674,
-        "t_tank_bottom": 18.5685,
-        "t_collector": 21.7475,
+        "t_tank_top": 19.6118,
+        "t_tank_bottom": 18.5054,
+        "t_collector": 21.6865,
         "t_greenhouse": 16.167,
         "t_outdoor": 13.9665
       },
@@ -2989,9 +2989,9 @@
     {
       "time": 16260,
       "values": {
-        "t_tank_top": 19.7134,
-        "t_tank_bottom": 18.6076,
-        "t_collector": 21.7871,
+        "t_tank_top": 19.6512,
+        "t_tank_bottom": 18.5445,
+        "t_collector": 21.7262,
         "t_greenhouse": 16.1857,
         "t_outdoor": 13.9798
       },
@@ -3000,9 +3000,9 @@
     {
       "time": 16320,
       "values": {
-        "t_tank_top": 19.7527,
-        "t_tank_bottom": 18.6468,
-        "t_collector": 21.8267,
+        "t_tank_top": 19.6906,
+        "t_tank_bottom": 18.5837,
+        "t_collector": 21.7659,
         "t_greenhouse": 16.2043,
         "t_outdoor": 13.993
       },
@@ -3011,9 +3011,9 @@
     {
       "time": 16380,
       "values": {
-        "t_tank_top": 19.7921,
-        "t_tank_bottom": 18.6859,
-        "t_collector": 21.8663,
+        "t_tank_top": 19.73,
+        "t_tank_bottom": 18.6228,
+        "t_collector": 21.8055,
         "t_greenhouse": 16.2228,
         "t_outdoor": 14.0061
       },
@@ -3022,9 +3022,9 @@
     {
       "time": 16440,
       "values": {
-        "t_tank_top": 19.8314,
-        "t_tank_bottom": 18.725,
-        "t_collector": 21.9059,
+        "t_tank_top": 19.7694,
+        "t_tank_bottom": 18.662,
+        "t_collector": 21.8451,
         "t_greenhouse": 16.2412,
         "t_outdoor": 14.0191
       },
@@ -3033,9 +3033,9 @@
     {
       "time": 16500,
       "values": {
-        "t_tank_top": 19.8707,
-        "t_tank_bottom": 18.7641,
-        "t_collector": 21.9453,
+        "t_tank_top": 19.8088,
+        "t_tank_bottom": 18.7012,
+        "t_collector": 21.8846,
         "t_greenhouse": 16.2594,
         "t_outdoor": 14.032
       },
@@ -3044,9 +3044,9 @@
     {
       "time": 16560,
       "values": {
-        "t_tank_top": 19.91,
-        "t_tank_bottom": 18.8033,
-        "t_collector": 21.9848,
+        "t_tank_top": 19.8481,
+        "t_tank_bottom": 18.7403,
+        "t_collector": 21.9241,
         "t_greenhouse": 16.2776,
         "t_outdoor": 14.0449
       },
@@ -3055,9 +3055,9 @@
     {
       "time": 16620,
       "values": {
-        "t_tank_top": 19.9493,
-        "t_tank_bottom": 18.8424,
-        "t_collector": 22.0242,
+        "t_tank_top": 19.8875,
+        "t_tank_bottom": 18.7795,
+        "t_collector": 21.9635,
         "t_greenhouse": 16.2957,
         "t_outdoor": 14.0577
       },
@@ -3066,9 +3066,9 @@
     {
       "time": 16680,
       "values": {
-        "t_tank_top": 19.9886,
-        "t_tank_bottom": 18.8815,
-        "t_collector": 22.0635,
+        "t_tank_top": 19.9268,
+        "t_tank_bottom": 18.8187,
+        "t_collector": 22.0029,
         "t_greenhouse": 16.3137,
         "t_outdoor": 14.0704
       },
@@ -3077,9 +3077,9 @@
     {
       "time": 16740,
       "values": {
-        "t_tank_top": 20.0279,
-        "t_tank_bottom": 18.9207,
-        "t_collector": 22.1028,
+        "t_tank_top": 19.9661,
+        "t_tank_bottom": 18.8579,
+        "t_collector": 22.0423,
         "t_greenhouse": 16.3315,
         "t_outdoor": 14.083
       },
@@ -3088,9 +3088,9 @@
     {
       "time": 16800,
       "values": {
-        "t_tank_top": 20.0671,
-        "t_tank_bottom": 18.9598,
-        "t_collector": 22.1421,
+        "t_tank_top": 20.0054,
+        "t_tank_bottom": 18.8971,
+        "t_collector": 22.0816,
         "t_greenhouse": 16.3493,
         "t_outdoor": 14.0956
       },
@@ -3099,9 +3099,9 @@
     {
       "time": 16860,
       "values": {
-        "t_tank_top": 20.1063,
-        "t_tank_bottom": 18.9989,
-        "t_collector": 22.1813,
+        "t_tank_top": 20.0447,
+        "t_tank_bottom": 18.9362,
+        "t_collector": 22.1208,
         "t_greenhouse": 16.367,
         "t_outdoor": 14.108
       },
@@ -3110,9 +3110,9 @@
     {
       "time": 16920,
       "values": {
-        "t_tank_top": 20.1455,
-        "t_tank_bottom": 19.0381,
-        "t_collector": 22.2204,
+        "t_tank_top": 20.0839,
+        "t_tank_bottom": 18.9754,
+        "t_collector": 22.16,
         "t_greenhouse": 16.3845,
         "t_outdoor": 14.1204
       },
@@ -3121,9 +3121,9 @@
     {
       "time": 16980,
       "values": {
-        "t_tank_top": 20.1847,
-        "t_tank_bottom": 19.0772,
-        "t_collector": 22.2595,
+        "t_tank_top": 20.1231,
+        "t_tank_bottom": 19.0146,
+        "t_collector": 22.1991,
         "t_greenhouse": 16.402,
         "t_outdoor": 14.1327
       },
@@ -3132,9 +3132,9 @@
     {
       "time": 17040,
       "values": {
-        "t_tank_top": 20.2239,
-        "t_tank_bottom": 19.1163,
-        "t_collector": 22.2985,
+        "t_tank_top": 20.1624,
+        "t_tank_bottom": 19.0538,
+        "t_collector": 22.2382,
         "t_greenhouse": 16.4193,
         "t_outdoor": 14.145
       },
@@ -3143,9 +3143,9 @@
     {
       "time": 17100,
       "values": {
-        "t_tank_top": 20.263,
-        "t_tank_bottom": 19.1554,
-        "t_collector": 22.3375,
+        "t_tank_top": 20.2015,
+        "t_tank_bottom": 19.0929,
+        "t_collector": 22.2772,
         "t_greenhouse": 16.4366,
         "t_outdoor": 14.1571
       },
@@ -3154,9 +3154,9 @@
     {
       "time": 17160,
       "values": {
-        "t_tank_top": 20.3022,
-        "t_tank_bottom": 19.1946,
-        "t_collector": 22.3765,
+        "t_tank_top": 20.2407,
+        "t_tank_bottom": 19.1321,
+        "t_collector": 22.3162,
         "t_greenhouse": 16.4537,
         "t_outdoor": 14.1692
       },
@@ -3165,9 +3165,9 @@
     {
       "time": 17220,
       "values": {
-        "t_tank_top": 20.3413,
-        "t_tank_bottom": 19.2337,
-        "t_collector": 22.4154,
+        "t_tank_top": 20.2799,
+        "t_tank_bottom": 19.1713,
+        "t_collector": 22.3552,
         "t_greenhouse": 16.4707,
         "t_outdoor": 14.1812
       },
@@ -3176,9 +3176,9 @@
     {
       "time": 17280,
       "values": {
-        "t_tank_top": 20.3803,
-        "t_tank_bottom": 19.2728,
-        "t_collector": 22.4542,
+        "t_tank_top": 20.319,
+        "t_tank_bottom": 19.2104,
+        "t_collector": 22.394,
         "t_greenhouse": 16.4876,
         "t_outdoor": 14.1932
       },
@@ -3187,9 +3187,9 @@
     {
       "time": 17340,
       "values": {
-        "t_tank_top": 20.4194,
-        "t_tank_bottom": 19.3119,
-        "t_collector": 22.493,
+        "t_tank_top": 20.3581,
+        "t_tank_bottom": 19.2496,
+        "t_collector": 22.4328,
         "t_greenhouse": 16.5045,
         "t_outdoor": 14.205
       },
@@ -3198,9 +3198,9 @@
     {
       "time": 17400,
       "values": {
-        "t_tank_top": 20.4584,
-        "t_tank_bottom": 19.351,
-        "t_collector": 22.5317,
+        "t_tank_top": 20.3972,
+        "t_tank_bottom": 19.2887,
+        "t_collector": 22.4716,
         "t_greenhouse": 16.5212,
         "t_outdoor": 14.2168
       },
@@ -3209,9 +3209,9 @@
     {
       "time": 17460,
       "values": {
-        "t_tank_top": 20.4974,
-        "t_tank_bottom": 19.3901,
-        "t_collector": 22.5703,
+        "t_tank_top": 20.4362,
+        "t_tank_bottom": 19.3279,
+        "t_collector": 22.5103,
         "t_greenhouse": 16.5378,
         "t_outdoor": 14.2284
       },
@@ -3220,9 +3220,9 @@
     {
       "time": 17520,
       "values": {
-        "t_tank_top": 20.5364,
-        "t_tank_bottom": 19.4292,
-        "t_collector": 22.6089,
+        "t_tank_top": 20.4752,
+        "t_tank_bottom": 19.367,
+        "t_collector": 22.549,
         "t_greenhouse": 16.5542,
         "t_outdoor": 14.24
       },
@@ -3231,9 +3231,9 @@
     {
       "time": 17580,
       "values": {
-        "t_tank_top": 20.5754,
-        "t_tank_bottom": 19.4683,
-        "t_collector": 22.6475,
+        "t_tank_top": 20.5142,
+        "t_tank_bottom": 19.4061,
+        "t_collector": 22.5876,
         "t_greenhouse": 16.5706,
         "t_outdoor": 14.2516
       },
@@ -3242,9 +3242,9 @@
     {
       "time": 17640,
       "values": {
-        "t_tank_top": 20.6143,
-        "t_tank_bottom": 19.5074,
-        "t_collector": 22.686,
+        "t_tank_top": 20.5532,
+        "t_tank_bottom": 19.4453,
+        "t_collector": 22.6261,
         "t_greenhouse": 16.5869,
         "t_outdoor": 14.263
       },
@@ -3253,9 +3253,9 @@
     {
       "time": 17700,
       "values": {
-        "t_tank_top": 20.6532,
-        "t_tank_bottom": 19.5464,
-        "t_collector": 22.7244,
+        "t_tank_top": 20.5922,
+        "t_tank_bottom": 19.4844,
+        "t_collector": 22.6646,
         "t_greenhouse": 16.6031,
         "t_outdoor": 14.2744
       },
@@ -3264,9 +3264,9 @@
     {
       "time": 17760,
       "values": {
-        "t_tank_top": 20.6921,
-        "t_tank_bottom": 19.5855,
-        "t_collector": 22.7628,
+        "t_tank_top": 20.6311,
+        "t_tank_bottom": 19.5235,
+        "t_collector": 22.703,
         "t_greenhouse": 16.6191,
         "t_outdoor": 14.2856
       },
@@ -3275,9 +3275,9 @@
     {
       "time": 17820,
       "values": {
-        "t_tank_top": 20.7309,
-        "t_tank_bottom": 19.6245,
-        "t_collector": 22.8011,
+        "t_tank_top": 20.67,
+        "t_tank_bottom": 19.5626,
+        "t_collector": 22.7413,
         "t_greenhouse": 16.635,
         "t_outdoor": 14.2968
       },
@@ -3286,9 +3286,9 @@
     {
       "time": 17880,
       "values": {
-        "t_tank_top": 20.7698,
-        "t_tank_bottom": 19.6635,
-        "t_collector": 22.8393,
+        "t_tank_top": 20.7088,
+        "t_tank_bottom": 19.6016,
+        "t_collector": 22.7796,
         "t_greenhouse": 16.6509,
         "t_outdoor": 14.308
       },
@@ -3297,9 +3297,9 @@
     {
       "time": 17940,
       "values": {
-        "t_tank_top": 20.8086,
-        "t_tank_bottom": 19.7026,
-        "t_collector": 22.8775,
+        "t_tank_top": 20.7477,
+        "t_tank_bottom": 19.6407,
+        "t_collector": 22.8178,
         "t_greenhouse": 16.6666,
         "t_outdoor": 14.319
       },
@@ -3308,9 +3308,9 @@
     {
       "time": 18000,
       "values": {
-        "t_tank_top": 20.8473,
-        "t_tank_bottom": 19.7416,
-        "t_collector": 22.9157,
+        "t_tank_top": 20.7865,
+        "t_tank_bottom": 19.6797,
+        "t_collector": 22.856,
         "t_greenhouse": 16.6822,
         "t_outdoor": 14.3299
       },
@@ -3319,9 +3319,9 @@
     {
       "time": 18060,
       "values": {
-        "t_tank_top": 20.886,
-        "t_tank_bottom": 19.7806,
-        "t_collector": 22.9537,
+        "t_tank_top": 20.8252,
+        "t_tank_bottom": 19.7188,
+        "t_collector": 22.8941,
         "t_greenhouse": 16.6977,
         "t_outdoor": 14.3408
       },
@@ -3330,9 +3330,9 @@
     {
       "time": 18120,
       "values": {
-        "t_tank_top": 20.9247,
-        "t_tank_bottom": 19.8195,
-        "t_collector": 22.9917,
+        "t_tank_top": 20.864,
+        "t_tank_bottom": 19.7578,
+        "t_collector": 22.9322,
         "t_greenhouse": 16.7131,
         "t_outdoor": 14.3516
       },
@@ -3341,9 +3341,9 @@
     {
       "time": 18180,
       "values": {
-        "t_tank_top": 20.9634,
-        "t_tank_bottom": 19.8585,
-        "t_collector": 23.0296,
+        "t_tank_top": 20.9027,
+        "t_tank_bottom": 19.7968,
+        "t_collector": 22.9701,
         "t_greenhouse": 16.7283,
         "t_outdoor": 14.3623
       },
@@ -3352,9 +3352,9 @@
     {
       "time": 18240,
       "values": {
-        "t_tank_top": 21.002,
-        "t_tank_bottom": 19.8975,
-        "t_collector": 23.0675,
+        "t_tank_top": 20.9414,
+        "t_tank_bottom": 19.8358,
+        "t_collector": 23.0081,
         "t_greenhouse": 16.7435,
         "t_outdoor": 14.3729
       },
@@ -3363,9 +3363,9 @@
     {
       "time": 18300,
       "values": {
-        "t_tank_top": 21.0406,
-        "t_tank_bottom": 19.9364,
-        "t_collector": 23.1053,
+        "t_tank_top": 20.98,
+        "t_tank_bottom": 19.8748,
+        "t_collector": 23.0459,
         "t_greenhouse": 16.7586,
         "t_outdoor": 14.3835
       },
@@ -3374,9 +3374,9 @@
     {
       "time": 18360,
       "values": {
-        "t_tank_top": 21.0792,
-        "t_tank_bottom": 19.9753,
-        "t_collector": 23.1431,
+        "t_tank_top": 21.0186,
+        "t_tank_bottom": 19.9137,
+        "t_collector": 23.0837,
         "t_greenhouse": 16.7735,
         "t_outdoor": 14.3939
       },
@@ -3385,9 +3385,9 @@
     {
       "time": 18420,
       "values": {
-        "t_tank_top": 21.1177,
-        "t_tank_bottom": 20.0142,
-        "t_collector": 23.1807,
+        "t_tank_top": 21.0572,
+        "t_tank_bottom": 19.9527,
+        "t_collector": 23.1214,
         "t_greenhouse": 16.7883,
         "t_outdoor": 14.4043
       },
@@ -3396,9 +3396,9 @@
     {
       "time": 18480,
       "values": {
-        "t_tank_top": 21.1562,
-        "t_tank_bottom": 20.0531,
-        "t_collector": 23.2183,
+        "t_tank_top": 21.0957,
+        "t_tank_bottom": 19.9916,
+        "t_collector": 23.159,
         "t_greenhouse": 16.803,
         "t_outdoor": 14.4146
       },
@@ -3407,9 +3407,9 @@
     {
       "time": 18540,
       "values": {
-        "t_tank_top": 21.1947,
-        "t_tank_bottom": 20.0919,
-        "t_collector": 23.2559,
+        "t_tank_top": 21.1342,
+        "t_tank_bottom": 20.0305,
+        "t_collector": 23.1966,
         "t_greenhouse": 16.8176,
         "t_outdoor": 14.4248
       },
@@ -3418,9 +3418,9 @@
     {
       "time": 18600,
       "values": {
-        "t_tank_top": 21.2331,
-        "t_tank_bottom": 20.1308,
-        "t_collector": 23.2933,
+        "t_tank_top": 21.1727,
+        "t_tank_bottom": 20.0694,
+        "t_collector": 23.2341,
         "t_greenhouse": 16.8321,
         "t_outdoor": 14.4349
       },
@@ -3429,9 +3429,9 @@
     {
       "time": 18660,
       "values": {
-        "t_tank_top": 21.2715,
-        "t_tank_bottom": 20.1696,
-        "t_collector": 23.3307,
+        "t_tank_top": 21.2111,
+        "t_tank_bottom": 20.1083,
+        "t_collector": 23.2716,
         "t_greenhouse": 16.8464,
         "t_outdoor": 14.4449
       },
@@ -3440,9 +3440,9 @@
     {
       "time": 18720,
       "values": {
-        "t_tank_top": 21.3098,
-        "t_tank_bottom": 20.2084,
-        "t_collector": 23.3681,
+        "t_tank_top": 21.2495,
+        "t_tank_bottom": 20.1471,
+        "t_collector": 23.309,
         "t_greenhouse": 16.8607,
         "t_outdoor": 14.4549
       },
@@ -3451,9 +3451,9 @@
     {
       "time": 18780,
       "values": {
-        "t_tank_top": 21.3481,
-        "t_tank_bottom": 20.2472,
-        "t_collector": 23.4053,
+        "t_tank_top": 21.2878,
+        "t_tank_bottom": 20.186,
+        "t_collector": 23.3463,
         "t_greenhouse": 16.8748,
         "t_outdoor": 14.4647
       },
@@ -3462,9 +3462,9 @@
     {
       "time": 18840,
       "values": {
-        "t_tank_top": 21.3864,
-        "t_tank_bottom": 20.286,
-        "t_collector": 23.4425,
+        "t_tank_top": 21.3261,
+        "t_tank_bottom": 20.2248,
+        "t_collector": 23.3835,
         "t_greenhouse": 16.8889,
         "t_outdoor": 14.4745
       },
@@ -3473,9 +3473,9 @@
     {
       "time": 18900,
       "values": {
-        "t_tank_top": 21.4246,
-        "t_tank_bottom": 20.3247,
-        "t_collector": 23.4796,
+        "t_tank_top": 21.3644,
+        "t_tank_bottom": 20.2635,
+        "t_collector": 23.4206,
         "t_greenhouse": 16.9028,
         "t_outdoor": 14.4842
       },
@@ -3484,9 +3484,9 @@
     {
       "time": 18960,
       "values": {
-        "t_tank_top": 21.4628,
-        "t_tank_bottom": 20.3634,
-        "t_collector": 23.5167,
+        "t_tank_top": 21.4026,
+        "t_tank_bottom": 20.3023,
+        "t_collector": 23.4577,
         "t_greenhouse": 16.9165,
         "t_outdoor": 14.4938
       },
@@ -3495,9 +3495,9 @@
     {
       "time": 19020,
       "values": {
-        "t_tank_top": 21.5009,
-        "t_tank_bottom": 20.4021,
-        "t_collector": 23.5537,
+        "t_tank_top": 21.4408,
+        "t_tank_bottom": 20.341,
+        "t_collector": 23.4948,
         "t_greenhouse": 16.9302,
         "t_outdoor": 14.5033
       },
@@ -3506,9 +3506,9 @@
     {
       "time": 19080,
       "values": {
-        "t_tank_top": 21.539,
-        "t_tank_bottom": 20.4408,
-        "t_collector": 23.5906,
+        "t_tank_top": 21.479,
+        "t_tank_bottom": 20.3797,
+        "t_collector": 23.5317,
         "t_greenhouse": 16.9438,
         "t_outdoor": 14.5128
       },
@@ -3517,9 +3517,9 @@
     {
       "time": 19140,
       "values": {
-        "t_tank_top": 21.5771,
-        "t_tank_bottom": 20.4794,
-        "t_collector": 23.6274,
+        "t_tank_top": 21.5171,
+        "t_tank_bottom": 20.4184,
+        "t_collector": 23.5686,
         "t_greenhouse": 16.9572,
         "t_outdoor": 14.5221
       },
@@ -3528,9 +3528,9 @@
     {
       "time": 19200,
       "values": {
-        "t_tank_top": 21.6151,
-        "t_tank_bottom": 20.518,
-        "t_collector": 23.6641,
+        "t_tank_top": 21.5551,
+        "t_tank_bottom": 20.4571,
+        "t_collector": 23.6054,
         "t_greenhouse": 16.9705,
         "t_outdoor": 14.5314
       },
@@ -3539,9 +3539,9 @@
     {
       "time": 19260,
       "values": {
-        "t_tank_top": 21.6531,
-        "t_tank_bottom": 20.5566,
-        "t_collector": 23.7008,
+        "t_tank_top": 21.5931,
+        "t_tank_bottom": 20.4957,
+        "t_collector": 23.6421,
         "t_greenhouse": 16.9837,
         "t_outdoor": 14.5406
       },
@@ -3550,9 +3550,9 @@
     {
       "time": 19320,
       "values": {
-        "t_tank_top": 21.691,
-        "t_tank_bottom": 20.5952,
-        "t_collector": 23.7374,
+        "t_tank_top": 21.6311,
+        "t_tank_bottom": 20.5343,
+        "t_collector": 23.6787,
         "t_greenhouse": 16.9968,
         "t_outdoor": 14.5497
       },
@@ -3561,9 +3561,9 @@
     {
       "time": 19380,
       "values": {
-        "t_tank_top": 21.7289,
-        "t_tank_bottom": 20.6337,
-        "t_collector": 23.7739,
+        "t_tank_top": 21.669,
+        "t_tank_bottom": 20.5729,
+        "t_collector": 23.7153,
         "t_greenhouse": 17.0098,
         "t_outdoor": 14.5587
       },
@@ -3572,9 +3572,9 @@
     {
       "time": 19440,
       "values": {
-        "t_tank_top": 21.7667,
-        "t_tank_bottom": 20.6722,
-        "t_collector": 23.8104,
+        "t_tank_top": 21.7069,
+        "t_tank_bottom": 20.6115,
+        "t_collector": 23.7518,
         "t_greenhouse": 17.0227,
         "t_outdoor": 14.5676
       },
@@ -3583,9 +3583,9 @@
     {
       "time": 19500,
       "values": {
-        "t_tank_top": 21.8045,
-        "t_tank_bottom": 20.7107,
-        "t_collector": 23.8467,
+        "t_tank_top": 21.7447,
+        "t_tank_bottom": 20.65,
+        "t_collector": 23.7882,
         "t_greenhouse": 17.0354,
         "t_outdoor": 14.5764
       },
@@ -3594,9 +3594,9 @@
     {
       "time": 19560,
       "values": {
-        "t_tank_top": 21.8422,
-        "t_tank_bottom": 20.7492,
-        "t_collector": 23.883,
+        "t_tank_top": 21.7825,
+        "t_tank_bottom": 20.6885,
+        "t_collector": 23.8245,
         "t_greenhouse": 17.048,
         "t_outdoor": 14.5852
       },
@@ -3605,9 +3605,9 @@
     {
       "time": 19620,
       "values": {
-        "t_tank_top": 21.8799,
-        "t_tank_bottom": 20.7876,
-        "t_collector": 23.9192,
+        "t_tank_top": 21.8203,
+        "t_tank_bottom": 20.727,
+        "t_collector": 23.8608,
         "t_greenhouse": 17.0605,
         "t_outdoor": 14.5938
       },
@@ -3616,9 +3616,9 @@
     {
       "time": 19680,
       "values": {
-        "t_tank_top": 21.9176,
-        "t_tank_bottom": 20.826,
-        "t_collector": 23.9554,
+        "t_tank_top": 21.858,
+        "t_tank_bottom": 20.7654,
+        "t_collector": 23.8969,
         "t_greenhouse": 17.0729,
         "t_outdoor": 14.6024
       },
@@ -3627,9 +3627,9 @@
     {
       "time": 19740,
       "values": {
-        "t_tank_top": 21.9552,
-        "t_tank_bottom": 20.8643,
-        "t_collector": 23.9914,
+        "t_tank_top": 21.8956,
+        "t_tank_bottom": 20.8038,
+        "t_collector": 23.933,
         "t_greenhouse": 17.0851,
         "t_outdoor": 14.6109
       },
@@ -3638,9 +3638,9 @@
     {
       "time": 19800,
       "values": {
-        "t_tank_top": 21.9927,
-        "t_tank_bottom": 20.9027,
-        "t_collector": 24.0274,
+        "t_tank_top": 21.9332,
+        "t_tank_bottom": 20.8422,
+        "t_collector": 23.969,
         "t_greenhouse": 17.0973,
         "t_outdoor": 14.6193
       },
@@ -3649,9 +3649,9 @@
     {
       "time": 19860,
       "values": {
-        "t_tank_top": 22.0302,
-        "t_tank_bottom": 20.941,
-        "t_collector": 24.0633,
+        "t_tank_top": 21.9707,
+        "t_tank_bottom": 20.8805,
+        "t_collector": 24.005,
         "t_greenhouse": 17.1093,
         "t_outdoor": 14.6276
       },
@@ -3660,9 +3660,9 @@
     {
       "time": 19920,
       "values": {
-        "t_tank_top": 22.0677,
-        "t_tank_bottom": 20.9792,
-        "t_collector": 24.0991,
+        "t_tank_top": 22.0082,
+        "t_tank_bottom": 20.9188,
+        "t_collector": 24.0408,
         "t_greenhouse": 17.1212,
         "t_outdoor": 14.6358
       },
@@ -3671,9 +3671,9 @@
     {
       "time": 19980,
       "values": {
-        "t_tank_top": 22.1051,
-        "t_tank_bottom": 21.0174,
-        "t_collector": 24.1348,
+        "t_tank_top": 22.0457,
+        "t_tank_bottom": 20.9571,
+        "t_collector": 24.0766,
         "t_greenhouse": 17.133,
         "t_outdoor": 14.6439
       },
@@ -3682,9 +3682,9 @@
     {
       "time": 20040,
       "values": {
-        "t_tank_top": 22.1424,
-        "t_tank_bottom": 21.0556,
-        "t_collector": 24.1705,
+        "t_tank_top": 22.083,
+        "t_tank_bottom": 20.9953,
+        "t_collector": 24.1123,
         "t_greenhouse": 17.1446,
         "t_outdoor": 14.652
       },
@@ -3693,9 +3693,9 @@
     {
       "time": 20100,
       "values": {
-        "t_tank_top": 22.1797,
-        "t_tank_bottom": 21.0938,
-        "t_collector": 24.206,
+        "t_tank_top": 22.1204,
+        "t_tank_bottom": 21.0335,
+        "t_collector": 24.1479,
         "t_greenhouse": 17.1562,
         "t_outdoor": 14.6599
       },
@@ -3704,9 +3704,9 @@
     {
       "time": 20160,
       "values": {
-        "t_tank_top": 22.2169,
-        "t_tank_bottom": 21.1319,
-        "t_collector": 24.2415,
+        "t_tank_top": 22.1577,
+        "t_tank_bottom": 21.0717,
+        "t_collector": 24.1834,
         "t_greenhouse": 17.1676,
         "t_outdoor": 14.6678
       },
@@ -3715,9 +3715,9 @@
     {
       "time": 20220,
       "values": {
-        "t_tank_top": 22.2541,
-        "t_tank_bottom": 21.17,
-        "t_collector": 24.2769,
+        "t_tank_top": 22.1949,
+        "t_tank_bottom": 21.1098,
+        "t_collector": 24.2188,
         "t_greenhouse": 17.1789,
         "t_outdoor": 14.6755
       },
@@ -3726,9 +3726,9 @@
     {
       "time": 20280,
       "values": {
-        "t_tank_top": 22.2913,
-        "t_tank_bottom": 21.2081,
-        "t_collector": 24.3122,
+        "t_tank_top": 22.2321,
+        "t_tank_bottom": 21.1479,
+        "t_collector": 24.2541,
         "t_greenhouse": 17.1901,
         "t_outdoor": 14.6832
       },
@@ -3737,9 +3737,9 @@
     {
       "time": 20340,
       "values": {
-        "t_tank_top": 22.3283,
-        "t_tank_bottom": 21.2461,
-        "t_collector": 24.3474,
+        "t_tank_top": 22.2692,
+        "t_tank_bottom": 21.1859,
+        "t_collector": 24.2894,
         "t_greenhouse": 17.2011,
         "t_outdoor": 14.6908
       },
@@ -3748,9 +3748,9 @@
     {
       "time": 20400,
       "values": {
-        "t_tank_top": 22.3653,
-        "t_tank_bottom": 21.284,
-        "t_collector": 24.3825,
+        "t_tank_top": 22.3062,
+        "t_tank_bottom": 21.224,
+        "t_collector": 24.3246,
         "t_greenhouse": 17.212,
         "t_outdoor": 14.6983
       },
@@ -3759,9 +3759,9 @@
     {
       "time": 20460,
       "values": {
-        "t_tank_top": 22.4023,
-        "t_tank_bottom": 21.322,
-        "t_collector": 24.4176,
+        "t_tank_top": 22.3432,
+        "t_tank_bottom": 21.2619,
+        "t_collector": 24.3597,
         "t_greenhouse": 17.2229,
         "t_outdoor": 14.7058
       },
@@ -3770,9 +3770,9 @@
     {
       "time": 20520,
       "values": {
-        "t_tank_top": 22.4392,
-        "t_tank_bottom": 21.3599,
-        "t_collector": 24.4525,
+        "t_tank_top": 22.3802,
+        "t_tank_bottom": 21.2999,
+        "t_collector": 24.3946,
         "t_greenhouse": 17.2335,
         "t_outdoor": 14.7131
       },
@@ -3781,9 +3781,9 @@
     {
       "time": 20580,
       "values": {
-        "t_tank_top": 22.4761,
-        "t_tank_bottom": 21.3977,
-        "t_collector": 24.4874,
+        "t_tank_top": 22.4171,
+        "t_tank_bottom": 21.3378,
+        "t_collector": 24.4296,
         "t_greenhouse": 17.2441,
         "t_outdoor": 14.7203
       },
@@ -3792,9 +3792,9 @@
     {
       "time": 20640,
       "values": {
-        "t_tank_top": 22.5129,
-        "t_tank_bottom": 21.4355,
-        "t_collector": 24.5222,
+        "t_tank_top": 22.4539,
+        "t_tank_bottom": 21.3756,
+        "t_collector": 24.4644,
         "t_greenhouse": 17.2545,
         "t_outdoor": 14.7275
       },
@@ -3803,9 +3803,9 @@
     {
       "time": 20700,
       "values": {
-        "t_tank_top": 22.5496,
-        "t_tank_bottom": 21.4733,
-        "t_collector": 24.5568,
+        "t_tank_top": 22.4907,
+        "t_tank_bottom": 21.4134,
+        "t_collector": 24.4991,
         "t_greenhouse": 17.2649,
         "t_outdoor": 14.7345
       },
@@ -3814,9 +3814,9 @@
     {
       "time": 20760,
       "values": {
-        "t_tank_top": 22.5863,
-        "t_tank_bottom": 21.511,
-        "t_collector": 24.5914,
+        "t_tank_top": 22.5274,
+        "t_tank_bottom": 21.4512,
+        "t_collector": 24.5337,
         "t_greenhouse": 17.2751,
         "t_outdoor": 14.7415
       },
@@ -3825,9 +3825,9 @@
     {
       "time": 20820,
       "values": {
-        "t_tank_top": 22.6229,
-        "t_tank_bottom": 21.5487,
-        "t_collector": 24.6259,
+        "t_tank_top": 22.5641,
+        "t_tank_bottom": 21.4889,
+        "t_collector": 24.5683,
         "t_greenhouse": 17.2851,
         "t_outdoor": 14.7484
       },
@@ -3836,9 +3836,9 @@
     {
       "time": 20880,
       "values": {
-        "t_tank_top": 22.6594,
-        "t_tank_bottom": 21.5863,
-        "t_collector": 24.6604,
+        "t_tank_top": 22.6006,
+        "t_tank_bottom": 21.5266,
+        "t_collector": 24.6027,
         "t_greenhouse": 17.2951,
         "t_outdoor": 14.7552
       },
@@ -3847,9 +3847,9 @@
     {
       "time": 20940,
       "values": {
-        "t_tank_top": 22.6959,
-        "t_tank_bottom": 21.6239,
-        "t_collector": 24.6947,
+        "t_tank_top": 22.6372,
+        "t_tank_bottom": 21.5643,
+        "t_collector": 24.6371,
         "t_greenhouse": 17.3049,
         "t_outdoor": 14.7619
       },
@@ -3858,9 +3858,9 @@
     {
       "time": 21000,
       "values": {
-        "t_tank_top": 22.7323,
-        "t_tank_bottom": 21.6615,
-        "t_collector": 24.7289,
+        "t_tank_top": 22.6736,
+        "t_tank_bottom": 21.6019,
+        "t_collector": 24.6714,
         "t_greenhouse": 17.3146,
         "t_outdoor": 14.7685
       },
@@ -3869,9 +3869,9 @@
     {
       "time": 21060,
       "values": {
-        "t_tank_top": 22.7687,
-        "t_tank_bottom": 21.699,
-        "t_collector": 24.763,
+        "t_tank_top": 22.7101,
+        "t_tank_bottom": 21.6394,
+        "t_collector": 24.7055,
         "t_greenhouse": 17.3242,
         "t_outdoor": 14.775
       },
@@ -3880,9 +3880,9 @@
     {
       "time": 21120,
       "values": {
-        "t_tank_top": 22.805,
-        "t_tank_bottom": 21.7365,
-        "t_collector": 24.7971,
+        "t_tank_top": 22.7464,
+        "t_tank_bottom": 21.6769,
+        "t_collector": 24.7396,
         "t_greenhouse": 17.3337,
         "t_outdoor": 14.7814
       },
@@ -3891,9 +3891,9 @@
     {
       "time": 21180,
       "values": {
-        "t_tank_top": 22.8412,
-        "t_tank_bottom": 21.7739,
-        "t_collector": 24.831,
+        "t_tank_top": 22.7827,
+        "t_tank_bottom": 21.7144,
+        "t_collector": 24.7736,
         "t_greenhouse": 17.343,
         "t_outdoor": 14.7878
       },
@@ -3902,9 +3902,9 @@
     {
       "time": 21240,
       "values": {
-        "t_tank_top": 22.8774,
-        "t_tank_bottom": 21.8113,
-        "t_collector": 24.8649,
+        "t_tank_top": 22.8189,
+        "t_tank_bottom": 21.7518,
+        "t_collector": 24.8075,
         "t_greenhouse": 17.3522,
         "t_outdoor": 14.794
       },
@@ -3913,9 +3913,9 @@
     {
       "time": 21300,
       "values": {
-        "t_tank_top": 22.9135,
-        "t_tank_bottom": 21.8486,
-        "t_collector": 24.8986,
+        "t_tank_top": 22.855,
+        "t_tank_bottom": 21.7892,
+        "t_collector": 24.8413,
         "t_greenhouse": 17.3613,
         "t_outdoor": 14.8001
       },
@@ -3924,9 +3924,9 @@
     {
       "time": 21360,
       "values": {
-        "t_tank_top": 22.9496,
-        "t_tank_bottom": 21.8858,
-        "t_collector": 24.9323,
+        "t_tank_top": 22.8911,
+        "t_tank_bottom": 21.8265,
+        "t_collector": 24.875,
         "t_greenhouse": 17.3702,
         "t_outdoor": 14.8062
       },
@@ -3935,9 +3935,9 @@
     {
       "time": 21420,
       "values": {
-        "t_tank_top": 22.9855,
-        "t_tank_bottom": 21.9231,
-        "t_collector": 24.9659,
+        "t_tank_top": 22.9271,
+        "t_tank_bottom": 21.8637,
+        "t_collector": 24.9086,
         "t_greenhouse": 17.3791,
         "t_outdoor": 14.8122
       },
@@ -3946,9 +3946,9 @@
     {
       "time": 21480,
       "values": {
-        "t_tank_top": 23.0214,
-        "t_tank_bottom": 21.9602,
-        "t_collector": 24.9993,
+        "t_tank_top": 22.9631,
+        "t_tank_bottom": 21.901,
+        "t_collector": 24.9421,
         "t_greenhouse": 17.3878,
         "t_outdoor": 14.8181
       },
@@ -3957,9 +3957,9 @@
     {
       "time": 21540,
       "values": {
-        "t_tank_top": 23.0573,
-        "t_tank_bottom": 21.9974,
-        "t_collector": 25.0327,
+        "t_tank_top": 22.999,
+        "t_tank_bottom": 21.9381,
+        "t_collector": 24.9755,
         "t_greenhouse": 17.3963,
         "t_outdoor": 14.8238
       },
@@ -3968,9 +3968,9 @@
     {
       "time": 21600,
       "values": {
-        "t_tank_top": 23.0931,
-        "t_tank_bottom": 22.0344,
-        "t_collector": 25.066,
+        "t_tank_top": 23.0348,
+        "t_tank_bottom": 21.9752,
+        "t_collector": 25.0088,
         "t_greenhouse": 17.4048,
         "t_outdoor": 14.8295
       },
@@ -3979,9 +3979,9 @@
     {
       "time": 21660,
       "values": {
-        "t_tank_top": 23.1288,
-        "t_tank_bottom": 22.0715,
-        "t_collector": 25.0991,
+        "t_tank_top": 23.0705,
+        "t_tank_bottom": 22.0123,
+        "t_collector": 25.0421,
         "t_greenhouse": 17.4131,
         "t_outdoor": 14.8351
       },
@@ -3990,9 +3990,9 @@
     {
       "time": 21720,
       "values": {
-        "t_tank_top": 23.1644,
-        "t_tank_bottom": 22.1084,
-        "t_collector": 25.1322,
+        "t_tank_top": 23.1062,
+        "t_tank_bottom": 22.0493,
+        "t_collector": 25.0752,
         "t_greenhouse": 17.4213,
         "t_outdoor": 14.8406
       },
@@ -4001,9 +4001,9 @@
     {
       "time": 21780,
       "values": {
-        "t_tank_top": 23.2,
-        "t_tank_bottom": 22.1453,
-        "t_collector": 25.1652,
+        "t_tank_top": 23.1418,
+        "t_tank_bottom": 22.0863,
+        "t_collector": 25.1082,
         "t_greenhouse": 17.4294,
         "t_outdoor": 14.8461
       },
@@ -4012,9 +4012,9 @@
     {
       "time": 21840,
       "values": {
-        "t_tank_top": 23.2355,
-        "t_tank_bottom": 22.1822,
-        "t_collector": 25.1981,
+        "t_tank_top": 23.1774,
+        "t_tank_bottom": 22.1232,
+        "t_collector": 25.1411,
         "t_greenhouse": 17.4374,
         "t_outdoor": 14.8514
       },
@@ -4023,9 +4023,9 @@
     {
       "time": 21900,
       "values": {
-        "t_tank_top": 23.2709,
-        "t_tank_bottom": 22.219,
-        "t_collector": 25.2308,
+        "t_tank_top": 23.2128,
+        "t_tank_bottom": 22.16,
+        "t_collector": 25.1739,
         "t_greenhouse": 17.4452,
         "t_outdoor": 14.8566
       },
@@ -4034,9 +4034,9 @@
     {
       "time": 21960,
       "values": {
-        "t_tank_top": 23.3062,
-        "t_tank_bottom": 22.2558,
-        "t_collector": 25.2635,
+        "t_tank_top": 23.2482,
+        "t_tank_bottom": 22.1968,
+        "t_collector": 25.2066,
         "t_greenhouse": 17.4529,
         "t_outdoor": 14.8618
       },
@@ -4045,9 +4045,9 @@
     {
       "time": 22020,
       "values": {
-        "t_tank_top": 23.3415,
-        "t_tank_bottom": 22.2925,
-        "t_collector": 25.2961,
+        "t_tank_top": 23.2836,
+        "t_tank_bottom": 22.2336,
+        "t_collector": 25.2392,
         "t_greenhouse": 17.4604,
         "t_outdoor": 14.8668
       },
@@ -4056,9 +4056,9 @@
     {
       "time": 22080,
       "values": {
-        "t_tank_top": 23.3767,
-        "t_tank_bottom": 22.3291,
-        "t_collector": 25.3285,
+        "t_tank_top": 23.3188,
+        "t_tank_bottom": 22.2702,
+        "t_collector": 25.2717,
         "t_greenhouse": 17.4679,
         "t_outdoor": 14.8718
       },
@@ -4067,9 +4067,9 @@
     {
       "time": 22140,
       "values": {
-        "t_tank_top": 23.4119,
-        "t_tank_bottom": 22.3657,
-        "t_collector": 25.3609,
+        "t_tank_top": 23.354,
+        "t_tank_bottom": 22.3069,
+        "t_collector": 25.3041,
         "t_greenhouse": 17.4752,
         "t_outdoor": 14.8766
       },
@@ -4078,9 +4078,9 @@
     {
       "time": 22200,
       "values": {
-        "t_tank_top": 23.4469,
-        "t_tank_bottom": 22.4022,
-        "t_collector": 25.3931,
+        "t_tank_top": 23.3891,
+        "t_tank_bottom": 22.3434,
+        "t_collector": 25.3364,
         "t_greenhouse": 17.4824,
         "t_outdoor": 14.8814
       },
@@ -4089,9 +4089,9 @@
     {
       "time": 22260,
       "values": {
-        "t_tank_top": 23.4819,
-        "t_tank_bottom": 22.4387,
-        "t_collector": 25.4253,
+        "t_tank_top": 23.4241,
+        "t_tank_bottom": 22.38,
+        "t_collector": 25.3686,
         "t_greenhouse": 17.4895,
         "t_outdoor": 14.8861
       },
@@ -4100,9 +4100,9 @@
     {
       "time": 22320,
       "values": {
-        "t_tank_top": 23.5168,
-        "t_tank_bottom": 22.4751,
-        "t_collector": 25.4573,
+        "t_tank_top": 23.4591,
+        "t_tank_bottom": 22.4164,
+        "t_collector": 25.4007,
         "t_greenhouse": 17.4964,
         "t_outdoor": 14.8907
       },
@@ -4111,9 +4111,9 @@
     {
       "time": 22380,
       "values": {
-        "t_tank_top": 23.5517,
-        "t_tank_bottom": 22.5115,
-        "t_collector": 25.4893,
+        "t_tank_top": 23.4939,
+        "t_tank_bottom": 22.4528,
+        "t_collector": 25.4327,
         "t_greenhouse": 17.5032,
         "t_outdoor": 14.8952
       },
@@ -4122,9 +4122,9 @@
     {
       "time": 22440,
       "values": {
-        "t_tank_top": 23.5864,
-        "t_tank_bottom": 22.5478,
-        "t_collector": 25.5211,
+        "t_tank_top": 23.5287,
+        "t_tank_bottom": 22.4892,
+        "t_collector": 25.4646,
         "t_greenhouse": 17.5099,
         "t_outdoor": 14.8996
       },
@@ -4133,9 +4133,9 @@
     {
       "time": 22500,
       "values": {
-        "t_tank_top": 23.6211,
-        "t_tank_bottom": 22.584,
-        "t_collector": 25.5528,
+        "t_tank_top": 23.5635,
+        "t_tank_bottom": 22.5254,
+        "t_collector": 25.4963,
         "t_greenhouse": 17.5164,
         "t_outdoor": 14.9039
       },
@@ -4144,9 +4144,9 @@
     {
       "time": 22560,
       "values": {
-        "t_tank_top": 23.6557,
-        "t_tank_bottom": 22.6202,
-        "t_collector": 25.5845,
+        "t_tank_top": 23.5981,
+        "t_tank_bottom": 22.5616,
+        "t_collector": 25.528,
         "t_greenhouse": 17.5229,
         "t_outdoor": 14.9081
       },
@@ -4155,9 +4155,9 @@
     {
       "time": 22620,
       "values": {
-        "t_tank_top": 23.6902,
-        "t_tank_bottom": 22.6563,
-        "t_collector": 25.616,
+        "t_tank_top": 23.6327,
+        "t_tank_bottom": 22.5978,
+        "t_collector": 25.5596,
         "t_greenhouse": 17.5291,
         "t_outdoor": 14.9122
       },
@@ -4166,9 +4166,9 @@
     {
       "time": 22680,
       "values": {
-        "t_tank_top": 23.7247,
-        "t_tank_bottom": 22.6923,
-        "t_collector": 25.6474,
+        "t_tank_top": 23.6672,
+        "t_tank_bottom": 22.6339,
+        "t_collector": 25.591,
         "t_greenhouse": 17.5353,
         "t_outdoor": 14.9162
       },
@@ -4177,9 +4177,9 @@
     {
       "time": 22740,
       "values": {
-        "t_tank_top": 23.7591,
-        "t_tank_bottom": 22.7283,
-        "t_collector": 25.6787,
+        "t_tank_top": 23.7016,
+        "t_tank_bottom": 22.6699,
+        "t_collector": 25.6223,
         "t_greenhouse": 17.5414,
         "t_outdoor": 14.9201
       },
@@ -4188,9 +4188,9 @@
     {
       "time": 22800,
       "values": {
-        "t_tank_top": 23.7934,
-        "t_tank_bottom": 22.7643,
-        "t_collector": 25.7099,
+        "t_tank_top": 23.7359,
+        "t_tank_bottom": 22.7059,
+        "t_collector": 25.6536,
         "t_greenhouse": 17.5473,
         "t_outdoor": 14.924
       },
@@ -4199,9 +4199,9 @@
     {
       "time": 22860,
       "values": {
-        "t_tank_top": 23.8276,
-        "t_tank_bottom": 22.8001,
-        "t_collector": 25.7409,
+        "t_tank_top": 23.7702,
+        "t_tank_bottom": 22.7418,
+        "t_collector": 25.6847,
         "t_greenhouse": 17.553,
         "t_outdoor": 14.9277
       },
@@ -4210,9 +4210,9 @@
     {
       "time": 22920,
       "values": {
-        "t_tank_top": 23.8617,
-        "t_tank_bottom": 22.8359,
-        "t_collector": 25.7719,
+        "t_tank_top": 23.8043,
+        "t_tank_bottom": 22.7776,
+        "t_collector": 25.7157,
         "t_greenhouse": 17.5587,
         "t_outdoor": 14.9314
       },
@@ -4221,9 +4221,9 @@
     {
       "time": 22980,
       "values": {
-        "t_tank_top": 23.8957,
-        "t_tank_bottom": 22.8717,
-        "t_collector": 25.8028,
+        "t_tank_top": 23.8384,
+        "t_tank_bottom": 22.8134,
+        "t_collector": 25.7466,
         "t_greenhouse": 17.5642,
         "t_outdoor": 14.9349
       },
@@ -4232,9 +4232,9 @@
     {
       "time": 23040,
       "values": {
-        "t_tank_top": 23.9297,
-        "t_tank_bottom": 22.9073,
-        "t_collector": 25.8335,
+        "t_tank_top": 23.8724,
+        "t_tank_bottom": 22.8491,
+        "t_collector": 25.7774,
         "t_greenhouse": 17.5696,
         "t_outdoor": 14.9384
       },
@@ -4243,9 +4243,9 @@
     {
       "time": 23100,
       "values": {
-        "t_tank_top": 23.9636,
-        "t_tank_bottom": 22.9429,
-        "t_collector": 25.8641,
+        "t_tank_top": 23.9064,
+        "t_tank_bottom": 22.8848,
+        "t_collector": 25.8081,
         "t_greenhouse": 17.5749,
         "t_outdoor": 14.9418
       },
@@ -4254,9 +4254,9 @@
     {
       "time": 23160,
       "values": {
-        "t_tank_top": 23.9974,
-        "t_tank_bottom": 22.9785,
-        "t_collector": 25.8947,
+        "t_tank_top": 23.9402,
+        "t_tank_bottom": 22.9203,
+        "t_collector": 25.8386,
         "t_greenhouse": 17.58,
         "t_outdoor": 14.945
       },
@@ -4265,9 +4265,9 @@
     {
       "time": 23220,
       "values": {
-        "t_tank_top": 24.0311,
-        "t_tank_bottom": 23.0139,
-        "t_collector": 25.9251,
+        "t_tank_top": 23.974,
+        "t_tank_bottom": 22.9558,
+        "t_collector": 25.8691,
         "t_greenhouse": 17.585,
         "t_outdoor": 14.9482
       },
@@ -4276,9 +4276,9 @@
     {
       "time": 23280,
       "values": {
-        "t_tank_top": 24.0647,
-        "t_tank_bottom": 23.0493,
-        "t_collector": 25.9554,
+        "t_tank_top": 24.0076,
+        "t_tank_bottom": 22.9913,
+        "t_collector": 25.8994,
         "t_greenhouse": 17.5899,
         "t_outdoor": 14.9513
       },
@@ -4287,9 +4287,9 @@
     {
       "time": 23340,
       "values": {
-        "t_tank_top": 24.0983,
-        "t_tank_bottom": 23.0846,
-        "t_collector": 25.9855,
+        "t_tank_top": 24.0412,
+        "t_tank_bottom": 23.0267,
+        "t_collector": 25.9296,
         "t_greenhouse": 17.5946,
         "t_outdoor": 14.9543
       },
@@ -4298,9 +4298,9 @@
     {
       "time": 23400,
       "values": {
-        "t_tank_top": 24.1317,
-        "t_tank_bottom": 23.1199,
-        "t_collector": 26.0156,
+        "t_tank_top": 24.0747,
+        "t_tank_bottom": 23.062,
+        "t_collector": 25.9597,
         "t_greenhouse": 17.5993,
         "t_outdoor": 14.9572
       },
@@ -4309,9 +4309,9 @@
     {
       "time": 23460,
       "values": {
-        "t_tank_top": 24.1651,
-        "t_tank_bottom": 23.1551,
-        "t_collector": 26.0456,
+        "t_tank_top": 24.1081,
+        "t_tank_bottom": 23.0972,
+        "t_collector": 25.9897,
         "t_greenhouse": 17.6037,
         "t_outdoor": 14.96
       },
@@ -4320,9 +4320,9 @@
     {
       "time": 23520,
       "values": {
-        "t_tank_top": 24.1984,
-        "t_tank_bottom": 23.1902,
-        "t_collector": 26.0754,
+        "t_tank_top": 24.1415,
+        "t_tank_bottom": 23.1324,
+        "t_collector": 26.0196,
         "t_greenhouse": 17.6081,
         "t_outdoor": 14.9627
       },
@@ -4331,9 +4331,9 @@
     {
       "time": 23580,
       "values": {
-        "t_tank_top": 24.2316,
-        "t_tank_bottom": 23.2253,
-        "t_collector": 26.1051,
+        "t_tank_top": 24.1747,
+        "t_tank_bottom": 23.1675,
+        "t_collector": 26.0493,
         "t_greenhouse": 17.6123,
         "t_outdoor": 14.9653
       },
@@ -4342,9 +4342,9 @@
     {
       "time": 23640,
       "values": {
-        "t_tank_top": 24.2647,
-        "t_tank_bottom": 23.2603,
-        "t_collector": 26.1347,
+        "t_tank_top": 24.2079,
+        "t_tank_bottom": 23.2025,
+        "t_collector": 26.079,
         "t_greenhouse": 17.6164,
         "t_outdoor": 14.9678
       },
@@ -4353,9 +4353,9 @@
     {
       "time": 23700,
       "values": {
-        "t_tank_top": 24.2977,
-        "t_tank_bottom": 23.2952,
-        "t_collector": 26.1642,
+        "t_tank_top": 24.2409,
+        "t_tank_bottom": 23.2374,
+        "t_collector": 26.1085,
         "t_greenhouse": 17.6204,
         "t_outdoor": 14.9702
       },
@@ -4364,9 +4364,9 @@
     {
       "time": 23760,
       "values": {
-        "t_tank_top": 24.3307,
-        "t_tank_bottom": 23.33,
-        "t_collector": 26.1936,
+        "t_tank_top": 24.2739,
+        "t_tank_bottom": 23.2723,
+        "t_collector": 26.1379,
         "t_greenhouse": 17.6242,
         "t_outdoor": 14.9726
       },
@@ -4375,9 +4375,9 @@
     {
       "time": 23820,
       "values": {
-        "t_tank_top": 24.3635,
-        "t_tank_bottom": 23.3648,
-        "t_collector": 26.2228,
+        "t_tank_top": 24.3068,
+        "t_tank_bottom": 23.3071,
+        "t_collector": 26.1672,
         "t_greenhouse": 17.6279,
         "t_outdoor": 14.9748
       },
@@ -4386,9 +4386,9 @@
     {
       "time": 23880,
       "values": {
-        "t_tank_top": 24.3963,
-        "t_tank_bottom": 23.3994,
-        "t_collector": 26.2519,
+        "t_tank_top": 24.3396,
+        "t_tank_bottom": 23.3418,
+        "t_collector": 26.1964,
         "t_greenhouse": 17.6315,
         "t_outdoor": 14.9769
       },
@@ -4397,9 +4397,9 @@
     {
       "time": 23940,
       "values": {
-        "t_tank_top": 24.4289,
-        "t_tank_bottom": 23.4341,
-        "t_collector": 26.281,
+        "t_tank_top": 24.3723,
+        "t_tank_bottom": 23.3765,
+        "t_collector": 26.2254,
         "t_greenhouse": 17.635,
         "t_outdoor": 14.979
       },
@@ -4408,9 +4408,9 @@
     {
       "time": 24000,
       "values": {
-        "t_tank_top": 24.4615,
-        "t_tank_bottom": 23.4686,
-        "t_collector": 26.3098,
+        "t_tank_top": 24.4049,
+        "t_tank_bottom": 23.4111,
+        "t_collector": 26.2543,
         "t_greenhouse": 17.6383,
         "t_outdoor": 14.9809
       },
@@ -4419,9 +4419,9 @@
     {
       "time": 24060,
       "values": {
-        "t_tank_top": 24.494,
-        "t_tank_bottom": 23.5031,
-        "t_collector": 26.3386,
+        "t_tank_top": 24.4374,
+        "t_tank_bottom": 23.4456,
+        "t_collector": 26.2832,
         "t_greenhouse": 17.6415,
         "t_outdoor": 14.9828
       },
@@ -4430,9 +4430,9 @@
     {
       "time": 24120,
       "values": {
-        "t_tank_top": 24.5264,
-        "t_tank_bottom": 23.5374,
-        "t_collector": 26.3673,
+        "t_tank_top": 24.4699,
+        "t_tank_bottom": 23.48,
+        "t_collector": 26.3118,
         "t_greenhouse": 17.6445,
         "t_outdoor": 14.9846
       },
@@ -4441,9 +4441,9 @@
     {
       "time": 24180,
       "values": {
-        "t_tank_top": 24.5587,
-        "t_tank_bottom": 23.5717,
-        "t_collector": 26.3958,
+        "t_tank_top": 24.5022,
+        "t_tank_bottom": 23.5143,
+        "t_collector": 26.3404,
         "t_greenhouse": 17.6474,
         "t_outdoor": 14.9862
       },
@@ -4452,9 +4452,9 @@
     {
       "time": 24240,
       "values": {
-        "t_tank_top": 24.5909,
-        "t_tank_bottom": 23.606,
-        "t_collector": 26.4242,
+        "t_tank_top": 24.5344,
+        "t_tank_bottom": 23.5486,
+        "t_collector": 26.3689,
         "t_greenhouse": 17.6502,
         "t_outdoor": 14.9878
       },
@@ -4463,9 +4463,9 @@
     {
       "time": 24300,
       "values": {
-        "t_tank_top": 24.623,
-        "t_tank_bottom": 23.6401,
-        "t_collector": 26.4525,
+        "t_tank_top": 24.5666,
+        "t_tank_bottom": 23.5828,
+        "t_collector": 26.3972,
         "t_greenhouse": 17.6529,
         "t_outdoor": 14.9893
       },
@@ -4474,9 +4474,9 @@
     {
       "time": 24360,
       "values": {
-        "t_tank_top": 24.655,
-        "t_tank_bottom": 23.6742,
-        "t_collector": 26.4806,
+        "t_tank_top": 24.5987,
+        "t_tank_bottom": 23.6169,
+        "t_collector": 26.4254,
         "t_greenhouse": 17.6554,
         "t_outdoor": 14.9907
       },
@@ -4485,9 +4485,9 @@
     {
       "time": 24420,
       "values": {
-        "t_tank_top": 24.6869,
-        "t_tank_bottom": 23.7082,
-        "t_collector": 26.5087,
+        "t_tank_top": 24.6306,
+        "t_tank_bottom": 23.651,
+        "t_collector": 26.4535,
         "t_greenhouse": 17.6578,
         "t_outdoor": 14.9919
       },
@@ -4496,9 +4496,9 @@
     {
       "time": 24480,
       "values": {
-        "t_tank_top": 24.7188,
-        "t_tank_bottom": 23.7421,
-        "t_collector": 26.5366,
+        "t_tank_top": 24.6625,
+        "t_tank_bottom": 23.6849,
+        "t_collector": 26.4814,
         "t_greenhouse": 17.6601,
         "t_outdoor": 14.9931
       },
@@ -4507,9 +4507,9 @@
     {
       "time": 24540,
       "values": {
-        "t_tank_top": 24.7505,
-        "t_tank_bottom": 23.776,
-        "t_collector": 26.5644,
+        "t_tank_top": 24.6942,
+        "t_tank_bottom": 23.7188,
+        "t_collector": 26.5093,
         "t_greenhouse": 17.6622,
         "t_outdoor": 14.9942
       },
@@ -4518,9 +4518,9 @@
     {
       "time": 24600,
       "values": {
-        "t_tank_top": 24.7821,
-        "t_tank_bottom": 23.8097,
-        "t_collector": 26.5921,
+        "t_tank_top": 24.7259,
+        "t_tank_bottom": 23.7526,
+        "t_collector": 26.537,
         "t_greenhouse": 17.6642,
         "t_outdoor": 14.9952
       },
@@ -4529,9 +4529,9 @@
     {
       "time": 24660,
       "values": {
-        "t_tank_top": 24.8137,
-        "t_tank_bottom": 23.8434,
-        "t_collector": 26.6196,
+        "t_tank_top": 24.7575,
+        "t_tank_bottom": 23.7863,
+        "t_collector": 26.5645,
         "t_greenhouse": 17.6661,
         "t_outdoor": 14.9961
       },
@@ -4540,9 +4540,9 @@
     {
       "time": 24720,
       "values": {
-        "t_tank_top": 24.8451,
-        "t_tank_bottom": 23.877,
-        "t_collector": 26.647,
+        "t_tank_top": 24.789,
+        "t_tank_bottom": 23.8199,
+        "t_collector": 26.592,
         "t_greenhouse": 17.6678,
         "t_outdoor": 14.9969
       },
@@ -4551,9 +4551,9 @@
     {
       "time": 24780,
       "values": {
-        "t_tank_top": 24.8764,
-        "t_tank_bottom": 23.9105,
-        "t_collector": 26.6743,
+        "t_tank_top": 24.8204,
+        "t_tank_bottom": 23.8535,
+        "t_collector": 26.6193,
         "t_greenhouse": 17.6694,
         "t_outdoor": 14.9977
       },
@@ -4562,9 +4562,9 @@
     {
       "time": 24840,
       "values": {
-        "t_tank_top": 24.9077,
-        "t_tank_bottom": 23.9439,
-        "t_collector": 26.7015,
+        "t_tank_top": 24.8516,
+        "t_tank_bottom": 23.887,
+        "t_collector": 26.6465,
         "t_greenhouse": 17.6709,
         "t_outdoor": 14.9983
       },
@@ -4573,9 +4573,9 @@
     {
       "time": 24900,
       "values": {
-        "t_tank_top": 24.9388,
-        "t_tank_bottom": 23.9773,
-        "t_collector": 26.7285,
+        "t_tank_top": 24.8828,
+        "t_tank_bottom": 23.9203,
+        "t_collector": 26.6736,
         "t_greenhouse": 17.6723,
         "t_outdoor": 14.9988
       },
@@ -4584,9 +4584,9 @@
     {
       "time": 24960,
       "values": {
-        "t_tank_top": 24.9699,
-        "t_tank_bottom": 24.0105,
-        "t_collector": 26.7554,
+        "t_tank_top": 24.9139,
+        "t_tank_bottom": 23.9536,
+        "t_collector": 26.7005,
         "t_greenhouse": 17.6735,
         "t_outdoor": 14.9992
       },
@@ -4595,9 +4595,9 @@
     {
       "time": 25020,
       "values": {
-        "t_tank_top": 25.0008,
-        "t_tank_bottom": 24.0437,
-        "t_collector": 26.7822,
+        "t_tank_top": 24.9449,
+        "t_tank_bottom": 23.9869,
+        "t_collector": 26.7274,
         "t_greenhouse": 17.6746,
         "t_outdoor": 14.9996
       },
@@ -4606,9 +4606,9 @@
     {
       "time": 25080,
       "values": {
-        "t_tank_top": 25.0316,
-        "t_tank_bottom": 24.0768,
-        "t_collector": 26.8088,
+        "t_tank_top": 24.9758,
+        "t_tank_bottom": 24.02,
+        "t_collector": 26.7541,
         "t_greenhouse": 17.6755,
         "t_outdoor": 14.9998
       },
@@ -4617,9 +4617,9 @@
     {
       "time": 25140,
       "values": {
-        "t_tank_top": 25.0624,
-        "t_tank_bottom": 24.1098,
-        "t_collector": 26.8354,
+        "t_tank_top": 25.0065,
+        "t_tank_bottom": 24.053,
+        "t_collector": 26.7806,
         "t_greenhouse": 17.6763,
         "t_outdoor": 15
       },
@@ -4628,9 +4628,9 @@
     {
       "time": 25200,
       "values": {
-        "t_tank_top": 25.093,
-        "t_tank_bottom": 24.1427,
-        "t_collector": 26.8618,
+        "t_tank_top": 25.0372,
+        "t_tank_bottom": 24.086,
+        "t_collector": 26.8071,
         "t_greenhouse": 17.677,
         "t_outdoor": 15
       },
@@ -4639,9 +4639,9 @@
     {
       "time": 25260,
       "values": {
-        "t_tank_top": 25.1236,
-        "t_tank_bottom": 24.1755,
-        "t_collector": 26.888,
+        "t_tank_top": 25.0678,
+        "t_tank_bottom": 24.1189,
+        "t_collector": 26.8334,
         "t_greenhouse": 17.6776,
         "t_outdoor": 15
       },
@@ -4650,9 +4650,9 @@
     {
       "time": 25320,
       "values": {
-        "t_tank_top": 25.154,
-        "t_tank_bottom": 24.2083,
-        "t_collector": 26.9142,
+        "t_tank_top": 25.0983,
+        "t_tank_bottom": 24.1516,
+        "t_collector": 26.8595,
         "t_greenhouse": 17.678,
         "t_outdoor": 14.9998
       },
@@ -4661,9 +4661,9 @@
     {
       "time": 25380,
       "values": {
-        "t_tank_top": 25.1843,
-        "t_tank_bottom": 24.2409,
-        "t_collector": 26.9402,
+        "t_tank_top": 25.1286,
+        "t_tank_bottom": 24.1843,
+        "t_collector": 26.8856,
         "t_greenhouse": 17.6783,
         "t_outdoor": 14.9996
       },
@@ -4672,9 +4672,9 @@
     {
       "time": 25440,
       "values": {
-        "t_tank_top": 25.2145,
-        "t_tank_bottom": 24.2735,
-        "t_collector": 26.966,
+        "t_tank_top": 25.1589,
+        "t_tank_bottom": 24.2169,
+        "t_collector": 26.9115,
         "t_greenhouse": 17.6785,
         "t_outdoor": 14.9992
       },
@@ -4683,9 +4683,9 @@
     {
       "time": 25500,
       "values": {
-        "t_tank_top": 25.2447,
-        "t_tank_bottom": 24.306,
-        "t_collector": 26.9918,
+        "t_tank_top": 25.1891,
+        "t_tank_bottom": 24.2495,
+        "t_collector": 26.9373,
         "t_greenhouse": 17.6785,
         "t_outdoor": 14.9988
       },
@@ -4694,9 +4694,9 @@
     {
       "time": 25560,
       "values": {
-        "t_tank_top": 25.2747,
-        "t_tank_bottom": 24.3384,
-        "t_collector": 27.0174,
+        "t_tank_top": 25.2191,
+        "t_tank_bottom": 24.2819,
+        "t_collector": 26.9629,
         "t_greenhouse": 17.6784,
         "t_outdoor": 14.9983
       },
@@ -4705,9 +4705,9 @@
     {
       "time": 25620,
       "values": {
-        "t_tank_top": 25.3046,
-        "t_tank_bottom": 24.3707,
-        "t_collector": 27.0428,
+        "t_tank_top": 25.2491,
+        "t_tank_bottom": 24.3142,
+        "t_collector": 26.9884,
         "t_greenhouse": 17.6781,
         "t_outdoor": 14.9977
       },
@@ -4716,9 +4716,9 @@
     {
       "time": 25680,
       "values": {
-        "t_tank_top": 25.3344,
-        "t_tank_bottom": 24.4029,
-        "t_collector": 27.0682,
+        "t_tank_top": 25.2789,
+        "t_tank_bottom": 24.3465,
+        "t_collector": 27.0138,
         "t_greenhouse": 17.6778,
         "t_outdoor": 14.997
       },
@@ -4727,9 +4727,9 @@
     {
       "time": 25740,
       "values": {
-        "t_tank_top": 25.3641,
-        "t_tank_bottom": 24.435,
-        "t_collector": 27.0934,
+        "t_tank_top": 25.3086,
+        "t_tank_bottom": 24.3786,
+        "t_collector": 27.039,
         "t_greenhouse": 17.6773,
         "t_outdoor": 14.9962
       },
@@ -4738,9 +4738,9 @@
     {
       "time": 25800,
       "values": {
-        "t_tank_top": 25.3937,
-        "t_tank_bottom": 24.467,
-        "t_collector": 27.1185,
+        "t_tank_top": 25.3383,
+        "t_tank_bottom": 24.4107,
+        "t_collector": 27.0642,
         "t_greenhouse": 17.6766,
         "t_outdoor": 14.9953
       },
@@ -4749,9 +4749,9 @@
     {
       "time": 25860,
       "values": {
-        "t_tank_top": 25.4232,
-        "t_tank_bottom": 24.4989,
-        "t_collector": 27.1434,
+        "t_tank_top": 25.3678,
+        "t_tank_bottom": 24.4427,
+        "t_collector": 27.0891,
         "t_greenhouse": 17.6759,
         "t_outdoor": 14.9943
       },
@@ -4760,9 +4760,9 @@
     {
       "time": 25920,
       "values": {
-        "t_tank_top": 25.4525,
-        "t_tank_bottom": 24.5308,
-        "t_collector": 27.1682,
+        "t_tank_top": 25.3972,
+        "t_tank_bottom": 24.4745,
+        "t_collector": 27.114,
         "t_greenhouse": 17.675,
         "t_outdoor": 14.9932
       },
@@ -4771,9 +4771,9 @@
     {
       "time": 25980,
       "values": {
-        "t_tank_top": 25.4818,
-        "t_tank_bottom": 24.5625,
-        "t_collector": 27.1929,
+        "t_tank_top": 25.4265,
+        "t_tank_bottom": 24.5063,
+        "t_collector": 27.1387,
         "t_greenhouse": 17.674,
         "t_outdoor": 14.992
       },
@@ -4782,9 +4782,9 @@
     {
       "time": 26040,
       "values": {
-        "t_tank_top": 25.511,
-        "t_tank_bottom": 24.5942,
-        "t_collector": 27.2174,
+        "t_tank_top": 25.4557,
+        "t_tank_bottom": 24.538,
+        "t_collector": 27.1633,
         "t_greenhouse": 17.6728,
         "t_outdoor": 14.9907
       },
@@ -4793,9 +4793,9 @@
     {
       "time": 26100,
       "values": {
-        "t_tank_top": 25.54,
-        "t_tank_bottom": 24.6257,
-        "t_collector": 27.2418,
+        "t_tank_top": 25.4848,
+        "t_tank_bottom": 24.5696,
+        "t_collector": 27.1877,
         "t_greenhouse": 17.6715,
         "t_outdoor": 14.9893
       },
@@ -4804,9 +4804,9 @@
     {
       "time": 26160,
       "values": {
-        "t_tank_top": 25.5689,
-        "t_tank_bottom": 24.6572,
-        "t_collector": 27.2661,
+        "t_tank_top": 25.5138,
+        "t_tank_bottom": 24.6011,
+        "t_collector": 27.212,
         "t_greenhouse": 17.6701,
         "t_outdoor": 14.9878
       },
@@ -4815,9 +4815,9 @@
     {
       "time": 26220,
       "values": {
-        "t_tank_top": 25.5978,
-        "t_tank_bottom": 24.6885,
-        "t_collector": 27.2902,
+        "t_tank_top": 25.5426,
+        "t_tank_bottom": 24.6325,
+        "t_collector": 27.2362,
         "t_greenhouse": 17.6685,
         "t_outdoor": 14.9863
       },
@@ -4826,9 +4826,9 @@
     {
       "time": 26280,
       "values": {
-        "t_tank_top": 25.6265,
-        "t_tank_bottom": 24.7198,
-        "t_collector": 27.3142,
+        "t_tank_top": 25.5714,
+        "t_tank_bottom": 24.6638,
+        "t_collector": 27.2602,
         "t_greenhouse": 17.6669,
         "t_outdoor": 14.9846
       },
@@ -4837,9 +4837,9 @@
     {
       "time": 26340,
       "values": {
-        "t_tank_top": 25.6551,
-        "t_tank_bottom": 24.751,
-        "t_collector": 27.338,
+        "t_tank_top": 25.6,
+        "t_tank_bottom": 24.695,
+        "t_collector": 27.2841,
         "t_greenhouse": 17.665,
         "t_outdoor": 14.9829
       },
@@ -4848,9 +4848,9 @@
     {
       "time": 26400,
       "values": {
-        "t_tank_top": 25.6836,
-        "t_tank_bottom": 24.782,
-        "t_collector": 27.3618,
+        "t_tank_top": 25.6286,
+        "t_tank_bottom": 24.7261,
+        "t_collector": 27.3078,
         "t_greenhouse": 17.6631,
         "t_outdoor": 14.981
       },
@@ -4859,9 +4859,9 @@
     {
       "time": 26460,
       "values": {
-        "t_tank_top": 25.7119,
-        "t_tank_bottom": 24.813,
-        "t_collector": 27.3853,
+        "t_tank_top": 25.657,
+        "t_tank_bottom": 24.7572,
+        "t_collector": 27.3314,
         "t_greenhouse": 17.661,
         "t_outdoor": 14.9791
       },
@@ -4870,9 +4870,9 @@
     {
       "time": 26520,
       "values": {
-        "t_tank_top": 25.7402,
-        "t_tank_bottom": 24.8439,
-        "t_collector": 27.4088,
+        "t_tank_top": 25.6853,
+        "t_tank_bottom": 24.7881,
+        "t_collector": 27.3549,
         "t_greenhouse": 17.6588,
         "t_outdoor": 14.977
       },
@@ -4881,9 +4881,9 @@
     {
       "time": 26580,
       "values": {
-        "t_tank_top": 25.7684,
-        "t_tank_bottom": 24.8747,
-        "t_collector": 27.4321,
+        "t_tank_top": 25.7135,
+        "t_tank_bottom": 24.8189,
+        "t_collector": 27.3783,
         "t_greenhouse": 17.6564,
         "t_outdoor": 14.9749
       },
@@ -4892,9 +4892,9 @@
     {
       "time": 26640,
       "values": {
-        "t_tank_top": 25.7964,
-        "t_tank_bottom": 24.9053,
-        "t_collector": 27.4552,
+        "t_tank_top": 25.7416,
+        "t_tank_bottom": 24.8496,
+        "t_collector": 27.4014,
         "t_greenhouse": 17.654,
         "t_outdoor": 14.9726
       },
@@ -4903,9 +4903,9 @@
     {
       "time": 26700,
       "values": {
-        "t_tank_top": 25.8243,
-        "t_tank_bottom": 24.9359,
-        "t_collector": 27.4782,
+        "t_tank_top": 25.7695,
+        "t_tank_bottom": 24.8802,
+        "t_collector": 27.4245,
         "t_greenhouse": 17.6514,
         "t_outdoor": 14.9703
       },
@@ -4914,9 +4914,9 @@
     {
       "time": 26760,
       "values": {
-        "t_tank_top": 25.8521,
-        "t_tank_bottom": 24.9664,
-        "t_collector": 27.5011,
+        "t_tank_top": 25.7974,
+        "t_tank_bottom": 24.9107,
+        "t_collector": 27.4474,
         "t_greenhouse": 17.6486,
         "t_outdoor": 14.9679
       },
@@ -4925,9 +4925,9 @@
     {
       "time": 26820,
       "values": {
-        "t_tank_top": 25.8798,
-        "t_tank_bottom": 24.9968,
-        "t_collector": 27.5238,
+        "t_tank_top": 25.8251,
+        "t_tank_bottom": 24.9412,
+        "t_collector": 27.4702,
         "t_greenhouse": 17.6457,
         "t_outdoor": 14.9654
       },
@@ -4936,9 +4936,9 @@
     {
       "time": 26880,
       "values": {
-        "t_tank_top": 25.9074,
-        "t_tank_bottom": 25.0271,
-        "t_collector": 27.5464,
+        "t_tank_top": 25.8527,
+        "t_tank_bottom": 24.9715,
+        "t_collector": 27.4928,
         "t_greenhouse": 17.6427,
         "t_outdoor": 14.9628
       },
@@ -4947,9 +4947,9 @@
     {
       "time": 26940,
       "values": {
-        "t_tank_top": 25.9349,
-        "t_tank_bottom": 25.0572,
-        "t_collector": 27.5689,
+        "t_tank_top": 25.8802,
+        "t_tank_bottom": 25.0017,
+        "t_collector": 27.5153,
         "t_greenhouse": 17.6396,
         "t_outdoor": 14.9601
       },
@@ -4958,9 +4958,9 @@
     {
       "time": 27000,
       "values": {
-        "t_tank_top": 25.9622,
-        "t_tank_bottom": 25.0873,
-        "t_collector": 27.5912,
+        "t_tank_top": 25.9076,
+        "t_tank_bottom": 25.0318,
+        "t_collector": 27.5376,
         "t_greenhouse": 17.6363,
         "t_outdoor": 14.9573
       },
@@ -4969,9 +4969,9 @@
     {
       "time": 27060,
       "values": {
-        "t_tank_top": 25.9894,
-        "t_tank_bottom": 25.1173,
-        "t_collector": 27.6133,
+        "t_tank_top": 25.9348,
+        "t_tank_bottom": 25.0618,
+        "t_collector": 27.5598,
         "t_greenhouse": 17.6329,
         "t_outdoor": 14.9544
       },
@@ -4980,9 +4980,9 @@
     {
       "time": 27120,
       "values": {
-        "t_tank_top": 26.0165,
-        "t_tank_bottom": 25.1471,
-        "t_collector": 27.6354,
+        "t_tank_top": 25.962,
+        "t_tank_bottom": 25.0917,
+        "t_collector": 27.5819,
         "t_greenhouse": 17.6294,
         "t_outdoor": 14.9514
       },
@@ -4991,9 +4991,9 @@
     {
       "time": 27180,
       "values": {
-        "t_tank_top": 26.0435,
-        "t_tank_bottom": 25.1769,
-        "t_collector": 27.6572,
+        "t_tank_top": 25.989,
+        "t_tank_bottom": 25.1215,
+        "t_collector": 27.6038,
         "t_greenhouse": 17.6257,
         "t_outdoor": 14.9483
       },
@@ -5002,9 +5002,9 @@
     {
       "time": 27240,
       "values": {
-        "t_tank_top": 26.0704,
-        "t_tank_bottom": 25.2065,
-        "t_collector": 27.679,
+        "t_tank_top": 26.0159,
+        "t_tank_bottom": 25.1512,
+        "t_collector": 27.6256,
         "t_greenhouse": 17.622,
         "t_outdoor": 14.9451
       },
@@ -5013,9 +5013,9 @@
     {
       "time": 27300,
       "values": {
-        "t_tank_top": 26.0971,
-        "t_tank_bottom": 25.2361,
-        "t_collector": 27.7005,
+        "t_tank_top": 26.0427,
+        "t_tank_bottom": 25.1808,
+        "t_collector": 27.6472,
         "t_greenhouse": 17.618,
         "t_outdoor": 14.9419
       },
@@ -5024,9 +5024,9 @@
     {
       "time": 27360,
       "values": {
-        "t_tank_top": 26.1238,
-        "t_tank_bottom": 25.2655,
-        "t_collector": 27.722,
+        "t_tank_top": 26.0694,
+        "t_tank_bottom": 25.2103,
+        "t_collector": 27.6687,
         "t_greenhouse": 17.614,
         "t_outdoor": 14.9385
       },
@@ -5035,9 +5035,9 @@
     {
       "time": 27420,
       "values": {
-        "t_tank_top": 26.1503,
-        "t_tank_bottom": 25.2949,
-        "t_collector": 27.7433,
+        "t_tank_top": 26.0959,
+        "t_tank_bottom": 25.2396,
+        "t_collector": 27.69,
         "t_greenhouse": 17.6098,
         "t_outdoor": 14.935
       },
@@ -5046,9 +5046,9 @@
     {
       "time": 27480,
       "values": {
-        "t_tank_top": 26.1767,
-        "t_tank_bottom": 25.3241,
-        "t_collector": 27.7644,
+        "t_tank_top": 26.1224,
+        "t_tank_bottom": 25.2689,
+        "t_collector": 27.7112,
         "t_greenhouse": 17.6055,
         "t_outdoor": 14.9315
       },
@@ -5057,9 +5057,9 @@
     {
       "time": 27540,
       "values": {
-        "t_tank_top": 26.2029,
-        "t_tank_bottom": 25.3532,
-        "t_collector": 27.7854,
+        "t_tank_top": 26.1487,
+        "t_tank_bottom": 25.2981,
+        "t_collector": 27.7323,
         "t_greenhouse": 17.601,
         "t_outdoor": 14.9278
       },
@@ -5068,9 +5068,9 @@
     {
       "time": 27600,
       "values": {
-        "t_tank_top": 26.2291,
-        "t_tank_bottom": 25.3822,
-        "t_collector": 27.8063,
+        "t_tank_top": 26.1749,
+        "t_tank_bottom": 25.3271,
+        "t_collector": 27.7532,
         "t_greenhouse": 17.5964,
         "t_outdoor": 14.9241
       },
@@ -5079,9 +5079,9 @@
     {
       "time": 27660,
       "values": {
-        "t_tank_top": 26.2551,
-        "t_tank_bottom": 25.4111,
-        "t_collector": 27.827,
+        "t_tank_top": 26.2009,
+        "t_tank_bottom": 25.3561,
+        "t_collector": 27.7739,
         "t_greenhouse": 17.5917,
         "t_outdoor": 14.9203
       },
@@ -5090,9 +5090,9 @@
     {
       "time": 27720,
       "values": {
-        "t_tank_top": 26.281,
-        "t_tank_bottom": 25.4399,
-        "t_collector": 27.8476,
+        "t_tank_top": 26.2269,
+        "t_tank_bottom": 25.3849,
+        "t_collector": 27.7945,
         "t_greenhouse": 17.5869,
         "t_outdoor": 14.9163
       },
@@ -5101,9 +5101,9 @@
     {
       "time": 27780,
       "values": {
-        "t_tank_top": 26.3068,
-        "t_tank_bottom": 25.4686,
-        "t_collector": 27.868,
+        "t_tank_top": 26.2527,
+        "t_tank_bottom": 25.4137,
+        "t_collector": 27.815,
         "t_greenhouse": 17.5819,
         "t_outdoor": 14.9123
       },
@@ -5112,9 +5112,9 @@
     {
       "time": 27840,
       "values": {
-        "t_tank_top": 26.3324,
-        "t_tank_bottom": 25.4972,
-        "t_collector": 27.8883,
+        "t_tank_top": 26.2784,
+        "t_tank_bottom": 25.4423,
+        "t_collector": 27.8353,
         "t_greenhouse": 17.5768,
         "t_outdoor": 14.9082
       },
@@ -5123,9 +5123,9 @@
     {
       "time": 27900,
       "values": {
-        "t_tank_top": 26.358,
-        "t_tank_bottom": 25.5257,
-        "t_collector": 27.9084,
+        "t_tank_top": 26.3039,
+        "t_tank_bottom": 25.4708,
+        "t_collector": 27.8554,
         "t_greenhouse": 17.5716,
         "t_outdoor": 14.904
       },
@@ -5134,9 +5134,9 @@
     {
       "time": 27960,
       "values": {
-        "t_tank_top": 26.3834,
-        "t_tank_bottom": 25.554,
-        "t_collector": 27.9284,
+        "t_tank_top": 26.3294,
+        "t_tank_bottom": 25.4992,
+        "t_collector": 27.8754,
         "t_greenhouse": 17.5662,
         "t_outdoor": 14.8997
       },
@@ -5145,9 +5145,9 @@
     {
       "time": 28020,
       "values": {
-        "t_tank_top": 26.4087,
-        "t_tank_bottom": 25.5823,
-        "t_collector": 27.9482,
+        "t_tank_top": 26.3547,
+        "t_tank_bottom": 25.5275,
+        "t_collector": 27.8953,
         "t_greenhouse": 17.5607,
         "t_outdoor": 14.8953
       },
@@ -5156,9 +5156,9 @@
     {
       "time": 28080,
       "values": {
-        "t_tank_top": 26.4338,
-        "t_tank_bottom": 25.6104,
-        "t_collector": 27.9679,
+        "t_tank_top": 26.3799,
+        "t_tank_bottom": 25.5556,
+        "t_collector": 27.915,
         "t_greenhouse": 17.5551,
         "t_outdoor": 14.8908
       },
@@ -5167,9 +5167,9 @@
     {
       "time": 28140,
       "values": {
-        "t_tank_top": 26.4588,
-        "t_tank_bottom": 25.6385,
-        "t_collector": 27.9874,
+        "t_tank_top": 26.405,
+        "t_tank_bottom": 25.5837,
+        "t_collector": 27.9346,
         "t_greenhouse": 17.5493,
         "t_outdoor": 14.8862
       },
@@ -5178,9 +5178,9 @@
     {
       "time": 28200,
       "values": {
-        "t_tank_top": 26.4837,
-        "t_tank_bottom": 25.6664,
-        "t_collector": 28.0068,
+        "t_tank_top": 26.4299,
+        "t_tank_bottom": 25.6117,
+        "t_collector": 27.954,
         "t_greenhouse": 17.5434,
         "t_outdoor": 14.8816
       },
@@ -5189,9 +5189,9 @@
     {
       "time": 28260,
       "values": {
-        "t_tank_top": 26.5085,
-        "t_tank_bottom": 25.6942,
-        "t_collector": 28.026,
+        "t_tank_top": 26.4547,
+        "t_tank_bottom": 25.6395,
+        "t_collector": 27.9733,
         "t_greenhouse": 17.5374,
         "t_outdoor": 14.8768
       },
@@ -5200,9 +5200,9 @@
     {
       "time": 28320,
       "values": {
-        "t_tank_top": 26.5332,
-        "t_tank_bottom": 25.7219,
-        "t_collector": 28.0451,
+        "t_tank_top": 26.4794,
+        "t_tank_bottom": 25.6672,
+        "t_collector": 27.9924,
         "t_greenhouse": 17.5312,
         "t_outdoor": 14.8719
       },
@@ -5211,9 +5211,9 @@
     {
       "time": 28380,
       "values": {
-        "t_tank_top": 26.5577,
-        "t_tank_bottom": 25.7494,
-        "t_collector": 28.064,
+        "t_tank_top": 26.504,
+        "t_tank_bottom": 25.6948,
+        "t_collector": 28.0113,
         "t_greenhouse": 17.525,
         "t_outdoor": 14.867
       },
@@ -5222,9 +5222,9 @@
     {
       "time": 28440,
       "values": {
-        "t_tank_top": 26.5821,
-        "t_tank_bottom": 25.7769,
-        "t_collector": 28.0828,
+        "t_tank_top": 26.5284,
+        "t_tank_bottom": 25.7223,
+        "t_collector": 28.0301,
         "t_greenhouse": 17.5186,
         "t_outdoor": 14.8619
       },
@@ -5233,9 +5233,9 @@
     {
       "time": 28500,
       "values": {
-        "t_tank_top": 26.6064,
-        "t_tank_bottom": 25.8042,
-        "t_collector": 28.1014,
+        "t_tank_top": 26.5527,
+        "t_tank_bottom": 25.7497,
+        "t_collector": 28.0488,
         "t_greenhouse": 17.512,
         "t_outdoor": 14.8568
       },
@@ -5244,9 +5244,9 @@
     {
       "time": 28560,
       "values": {
-        "t_tank_top": 26.6305,
-        "t_tank_bottom": 25.8314,
-        "t_collector": 28.1198,
+        "t_tank_top": 26.5769,
+        "t_tank_bottom": 25.777,
+        "t_collector": 28.0673,
         "t_greenhouse": 17.5053,
         "t_outdoor": 14.8516
       },
@@ -5255,9 +5255,9 @@
     {
       "time": 28620,
       "values": {
-        "t_tank_top": 26.6545,
-        "t_tank_bottom": 25.8586,
-        "t_collector": 28.1382,
+        "t_tank_top": 26.6009,
+        "t_tank_bottom": 25.8041,
+        "t_collector": 28.0856,
         "t_greenhouse": 17.4985,
         "t_outdoor": 14.8462
       },
@@ -5266,9 +5266,9 @@
     {
       "time": 28680,
       "values": {
-        "t_tank_top": 26.6784,
-        "t_tank_bottom": 25.8856,
-        "t_collector": 28.1563,
+        "t_tank_top": 26.6249,
+        "t_tank_bottom": 25.8312,
+        "t_collector": 28.1038,
         "t_greenhouse": 17.4916,
         "t_outdoor": 14.8408
       },
@@ -5277,9 +5277,9 @@
     {
       "time": 28740,
       "values": {
-        "t_tank_top": 26.7021,
-        "t_tank_bottom": 25.9124,
-        "t_collector": 28.1743,
+        "t_tank_top": 26.6487,
+        "t_tank_bottom": 25.8581,
+        "t_collector": 28.1219,
         "t_greenhouse": 17.4846,
         "t_outdoor": 14.8353
       },
@@ -5288,9 +5288,9 @@
     {
       "time": 28800,
       "values": {
-        "t_tank_top": 26.7258,
-        "t_tank_bottom": 25.9392,
-        "t_collector": 28.1922,
+        "t_tank_top": 26.6723,
+        "t_tank_bottom": 25.8849,
+        "t_collector": 28.1398,
         "t_greenhouse": 17.4774,
         "t_outdoor": 14.8297
       },
@@ -5299,9 +5299,9 @@
     {
       "time": 28860,
       "values": {
-        "t_tank_top": 26.7492,
-        "t_tank_bottom": 25.9658,
-        "t_collector": 28.2099,
+        "t_tank_top": 26.6958,
+        "t_tank_bottom": 25.9116,
+        "t_collector": 28.1575,
         "t_greenhouse": 17.4701,
         "t_outdoor": 14.824
       },
@@ -5310,9 +5310,9 @@
     {
       "time": 28920,
       "values": {
-        "t_tank_top": 26.7726,
-        "t_tank_bottom": 25.9924,
-        "t_collector": 28.2274,
+        "t_tank_top": 26.7192,
+        "t_tank_bottom": 25.9381,
+        "t_collector": 28.1751,
         "t_greenhouse": 17.4626,
         "t_outdoor": 14.8182
       },
@@ -5321,9 +5321,9 @@
     {
       "time": 28980,
       "values": {
-        "t_tank_top": 26.7958,
-        "t_tank_bottom": 26.0188,
-        "t_collector": 28.2448,
+        "t_tank_top": 26.7425,
+        "t_tank_bottom": 25.9646,
+        "t_collector": 28.1925,
         "t_greenhouse": 17.455,
         "t_outdoor": 14.8124
       },
@@ -5332,9 +5332,9 @@
     {
       "time": 29040,
       "values": {
-        "t_tank_top": 26.8189,
-        "t_tank_bottom": 26.045,
-        "t_collector": 28.262,
+        "t_tank_top": 26.7656,
+        "t_tank_bottom": 25.9909,
+        "t_collector": 28.2098,
         "t_greenhouse": 17.4473,
         "t_outdoor": 14.8064
       },
@@ -5343,9 +5343,9 @@
     {
       "time": 29100,
       "values": {
-        "t_tank_top": 26.8419,
-        "t_tank_bottom": 26.0712,
-        "t_collector": 28.2791,
+        "t_tank_top": 26.7886,
+        "t_tank_bottom": 26.0171,
+        "t_collector": 28.2269,
         "t_greenhouse": 17.4395,
         "t_outdoor": 14.8004
       },
@@ -5354,9 +5354,9 @@
     {
       "time": 29160,
       "values": {
-        "t_tank_top": 26.8647,
-        "t_tank_bottom": 26.0973,
-        "t_collector": 28.2961,
+        "t_tank_top": 26.8115,
+        "t_tank_bottom": 26.0432,
+        "t_collector": 28.2439,
         "t_greenhouse": 17.4315,
         "t_outdoor": 14.7942
       },
@@ -5365,9 +5365,9 @@
     {
       "time": 29220,
       "values": {
-        "t_tank_top": 26.8874,
-        "t_tank_bottom": 26.1232,
-        "t_collector": 28.3128,
+        "t_tank_top": 26.8342,
+        "t_tank_bottom": 26.0691,
+        "t_collector": 28.2607,
         "t_greenhouse": 17.4234,
         "t_outdoor": 14.788
       },
@@ -5376,9 +5376,9 @@
     {
       "time": 29280,
       "values": {
-        "t_tank_top": 26.91,
-        "t_tank_bottom": 26.149,
-        "t_collector": 28.3294,
+        "t_tank_top": 26.8568,
+        "t_tank_bottom": 26.095,
+        "t_collector": 28.2773,
         "t_greenhouse": 17.4152,
         "t_outdoor": 14.7816
       },
@@ -5387,9 +5387,9 @@
     {
       "time": 29340,
       "values": {
-        "t_tank_top": 26.9324,
-        "t_tank_bottom": 26.1747,
-        "t_collector": 28.3459,
+        "t_tank_top": 26.8793,
+        "t_tank_bottom": 26.1207,
+        "t_collector": 28.2938,
         "t_greenhouse": 17.4069,
         "t_outdoor": 14.7752
       },
@@ -5398,9 +5398,9 @@
     {
       "time": 29400,
       "values": {
-        "t_tank_top": 26.9547,
-        "t_tank_bottom": 26.2002,
-        "t_collector": 28.3622,
+        "t_tank_top": 26.9016,
+        "t_tank_bottom": 26.1463,
+        "t_collector": 28.3102,
         "t_greenhouse": 17.3984,
         "t_outdoor": 14.7687
       },
@@ -5409,9 +5409,9 @@
     {
       "time": 29460,
       "values": {
-        "t_tank_top": 26.9768,
-        "t_tank_bottom": 26.2257,
-        "t_collector": 28.3783,
+        "t_tank_top": 26.9238,
+        "t_tank_bottom": 26.1718,
+        "t_collector": 28.3264,
         "t_greenhouse": 17.3898,
         "t_outdoor": 14.7621
       },
@@ -5420,9 +5420,9 @@
     {
       "time": 29520,
       "values": {
-        "t_tank_top": 26.9988,
-        "t_tank_bottom": 26.251,
-        "t_collector": 28.3943,
+        "t_tank_top": 26.9459,
+        "t_tank_bottom": 26.1971,
+        "t_collector": 28.3424,
         "t_greenhouse": 17.3811,
         "t_outdoor": 14.7554
       },
@@ -5431,9 +5431,9 @@
     {
       "time": 29580,
       "values": {
-        "t_tank_top": 27.0207,
-        "t_tank_bottom": 26.2762,
-        "t_collector": 28.4101,
+        "t_tank_top": 26.9678,
+        "t_tank_bottom": 26.2224,
+        "t_collector": 28.3582,
         "t_greenhouse": 17.3722,
         "t_outdoor": 14.7486
       },
@@ -5442,9 +5442,9 @@
     {
       "time": 29640,
       "values": {
-        "t_tank_top": 27.0425,
-        "t_tank_bottom": 26.3012,
-        "t_collector": 28.4258,
+        "t_tank_top": 26.9896,
+        "t_tank_bottom": 26.2475,
+        "t_collector": 28.374,
         "t_greenhouse": 17.3632,
         "t_outdoor": 14.7417
       },
@@ -5453,9 +5453,9 @@
     {
       "time": 29700,
       "values": {
-        "t_tank_top": 27.0641,
-        "t_tank_bottom": 26.3262,
-        "t_collector": 28.4413,
+        "t_tank_top": 27.0112,
+        "t_tank_bottom": 26.2725,
+        "t_collector": 28.3895,
         "t_greenhouse": 17.3541,
         "t_outdoor": 14.7348
       },
@@ -5464,9 +5464,9 @@
     {
       "time": 29760,
       "values": {
-        "t_tank_top": 27.0856,
-        "t_tank_bottom": 26.351,
-        "t_collector": 28.4567,
+        "t_tank_top": 27.0327,
+        "t_tank_bottom": 26.2973,
+        "t_collector": 28.4049,
         "t_greenhouse": 17.3449,
         "t_outdoor": 14.7277
       },
@@ -5475,9 +5475,9 @@
     {
       "time": 29820,
       "values": {
-        "t_tank_top": 27.1069,
-        "t_tank_bottom": 26.3757,
-        "t_collector": 28.4719,
+        "t_tank_top": 27.0541,
+        "t_tank_bottom": 26.322,
+        "t_collector": 28.4201,
         "t_greenhouse": 17.3355,
         "t_outdoor": 14.7206
       },
@@ -5486,9 +5486,9 @@
     {
       "time": 29880,
       "values": {
-        "t_tank_top": 27.1281,
-        "t_tank_bottom": 26.4003,
-        "t_collector": 28.4869,
+        "t_tank_top": 27.0753,
+        "t_tank_bottom": 26.3466,
+        "t_collector": 28.4352,
         "t_greenhouse": 17.326,
         "t_outdoor": 14.7133
       },
@@ -5497,9 +5497,9 @@
     {
       "time": 29940,
       "values": {
-        "t_tank_top": 27.1492,
-        "t_tank_bottom": 26.4247,
-        "t_collector": 28.5018,
+        "t_tank_top": 27.0964,
+        "t_tank_bottom": 26.3711,
+        "t_collector": 28.4501,
         "t_greenhouse": 17.3164,
         "t_outdoor": 14.706
       },
@@ -5508,9 +5508,9 @@
     {
       "time": 30000,
       "values": {
-        "t_tank_top": 27.1701,
-        "t_tank_bottom": 26.449,
-        "t_collector": 28.5165,
+        "t_tank_top": 27.1174,
+        "t_tank_bottom": 26.3955,
+        "t_collector": 28.4649,
         "t_greenhouse": 17.3066,
         "t_outdoor": 14.6986
       },
@@ -5519,9 +5519,9 @@
     {
       "time": 30060,
       "values": {
-        "t_tank_top": 27.1909,
-        "t_tank_bottom": 26.4732,
-        "t_collector": 28.531,
+        "t_tank_top": 27.1382,
+        "t_tank_bottom": 26.4197,
+        "t_collector": 28.4794,
         "t_greenhouse": 17.2967,
         "t_outdoor": 14.6911
       },
@@ -5530,9 +5530,9 @@
     {
       "time": 30120,
       "values": {
-        "t_tank_top": 27.2115,
-        "t_tank_bottom": 26.4973,
-        "t_collector": 28.5454,
+        "t_tank_top": 27.1589,
+        "t_tank_bottom": 26.4438,
+        "t_collector": 28.4939,
         "t_greenhouse": 17.2867,
         "t_outdoor": 14.6835
       },
@@ -5541,9 +5541,9 @@
     {
       "time": 30180,
       "values": {
-        "t_tank_top": 27.232,
-        "t_tank_bottom": 26.5212,
-        "t_collector": 28.5597,
+        "t_tank_top": 27.1794,
+        "t_tank_bottom": 26.4678,
+        "t_collector": 28.5081,
         "t_greenhouse": 17.2766,
         "t_outdoor": 14.6758
       },
@@ -5552,9 +5552,9 @@
     {
       "time": 30240,
       "values": {
-        "t_tank_top": 27.2524,
-        "t_tank_bottom": 26.545,
-        "t_collector": 28.5737,
+        "t_tank_top": 27.1998,
+        "t_tank_bottom": 26.4916,
+        "t_collector": 28.5222,
         "t_greenhouse": 17.2663,
         "t_outdoor": 14.668
       },
@@ -5563,9 +5563,9 @@
     {
       "time": 30300,
       "values": {
-        "t_tank_top": 27.2726,
-        "t_tank_bottom": 26.5687,
-        "t_collector": 28.5877,
+        "t_tank_top": 27.2201,
+        "t_tank_bottom": 26.5153,
+        "t_collector": 28.5362,
         "t_greenhouse": 17.256,
         "t_outdoor": 14.6602
       },
@@ -5574,9 +5574,9 @@
     {
       "time": 30360,
       "values": {
-        "t_tank_top": 27.2927,
-        "t_tank_bottom": 26.5922,
-        "t_collector": 28.6014,
+        "t_tank_top": 27.2402,
+        "t_tank_bottom": 26.5389,
+        "t_collector": 28.55,
         "t_greenhouse": 17.2454,
         "t_outdoor": 14.6522
       },
@@ -5585,119 +5585,119 @@
     {
       "time": 30420,
       "values": {
-        "t_tank_top": 27.3095,
-        "t_tank_bottom": 26.6156,
-        "t_collector": 28.6776,
+        "t_tank_top": 27.2602,
+        "t_tank_bottom": 26.5624,
+        "t_collector": 28.5636,
         "t_greenhouse": 17.2348,
         "t_outdoor": 14.6442
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 30480,
       "values": {
-        "t_tank_top": 27.2836,
-        "t_tank_bottom": 26.638,
-        "t_collector": 29.6182,
+        "t_tank_top": 27.28,
+        "t_tank_bottom": 26.5857,
+        "t_collector": 28.5771,
         "t_greenhouse": 17.2241,
         "t_outdoor": 14.6361
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 30540,
       "values": {
-        "t_tank_top": 27.2594,
-        "t_tank_bottom": 26.6587,
-        "t_collector": 30.5375,
+        "t_tank_top": 27.2997,
+        "t_tank_bottom": 26.6089,
+        "t_collector": 28.5904,
         "t_greenhouse": 17.2132,
         "t_outdoor": 14.6278
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 30600,
       "values": {
-        "t_tank_top": 27.2368,
-        "t_tank_bottom": 26.6778,
-        "t_collector": 31.436,
+        "t_tank_top": 27.3193,
+        "t_tank_bottom": 26.632,
+        "t_collector": 28.6035,
         "t_greenhouse": 17.2022,
         "t_outdoor": 14.6195
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 30660,
       "values": {
-        "t_tank_top": 27.2156,
-        "t_tank_bottom": 26.6954,
-        "t_collector": 32.3139,
+        "t_tank_top": 27.3387,
+        "t_tank_bottom": 26.6549,
+        "t_collector": 28.6165,
         "t_greenhouse": 17.191,
         "t_outdoor": 14.6111
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 30720,
       "values": {
-        "t_tank_top": 27.1957,
-        "t_tank_bottom": 26.7117,
-        "t_collector": 33.1717,
+        "t_tank_top": 27.358,
+        "t_tank_bottom": 26.6777,
+        "t_collector": 28.6293,
         "t_greenhouse": 17.1798,
         "t_outdoor": 14.6027
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 30780,
       "values": {
-        "t_tank_top": 27.1771,
-        "t_tank_bottom": 26.7268,
-        "t_collector": 34.0096,
+        "t_tank_top": 27.3771,
+        "t_tank_bottom": 26.7004,
+        "t_collector": 28.6419,
         "t_greenhouse": 17.1684,
         "t_outdoor": 14.5941
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 30840,
       "values": {
-        "t_tank_top": 27.1597,
-        "t_tank_bottom": 26.7407,
-        "t_collector": 34.8279,
+        "t_tank_top": 27.3961,
+        "t_tank_bottom": 26.7229,
+        "t_collector": 28.6544,
         "t_greenhouse": 17.1569,
         "t_outdoor": 14.5854
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 30900,
       "values": {
-        "t_tank_top": 27.1434,
-        "t_tank_bottom": 26.7535,
-        "t_collector": 35.6271,
+        "t_tank_top": 27.4149,
+        "t_tank_bottom": 26.7453,
+        "t_collector": 28.6667,
         "t_greenhouse": 17.1452,
         "t_outdoor": 14.5767
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 30960,
       "values": {
-        "t_tank_top": 27.1281,
-        "t_tank_bottom": 26.7652,
-        "t_collector": 36.4074,
+        "t_tank_top": 27.4336,
+        "t_tank_bottom": 26.7676,
+        "t_collector": 28.6789,
         "t_greenhouse": 17.1335,
         "t_outdoor": 14.5679
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 31020,
       "values": {
-        "t_tank_top": 27.2868,
-        "t_tank_bottom": 26.7778,
-        "t_collector": 34.9733,
+        "t_tank_top": 27.4522,
+        "t_tank_bottom": 26.7897,
+        "t_collector": 28.6909,
         "t_greenhouse": 17.1216,
         "t_outdoor": 14.559
       },
@@ -5706,9 +5706,9 @@
     {
       "time": 31080,
       "values": {
-        "t_tank_top": 27.5064,
-        "t_tank_bottom": 26.7983,
-        "t_collector": 32.5484,
+        "t_tank_top": 27.4706,
+        "t_tank_bottom": 26.8118,
+        "t_collector": 28.7027,
         "t_greenhouse": 17.1096,
         "t_outdoor": 14.55
       },
@@ -5717,9 +5717,9 @@
     {
       "time": 31140,
       "values": {
-        "t_tank_top": 27.6377,
-        "t_tank_bottom": 26.8242,
-        "t_collector": 31.0672,
+        "t_tank_top": 27.4888,
+        "t_tank_bottom": 26.8336,
+        "t_collector": 28.7143,
         "t_greenhouse": 17.0975,
         "t_outdoor": 14.5409
       },
@@ -5728,9 +5728,9 @@
     {
       "time": 31200,
       "values": {
-        "t_tank_top": 27.7157,
-        "t_tank_bottom": 26.8527,
-        "t_collector": 30.1658,
+        "t_tank_top": 27.5069,
+        "t_tank_bottom": 26.8554,
+        "t_collector": 28.7258,
         "t_greenhouse": 17.0852,
         "t_outdoor": 14.5317
       },
@@ -5739,9 +5739,9 @@
     {
       "time": 31260,
       "values": {
-        "t_tank_top": 27.7619,
-        "t_tank_bottom": 26.8824,
-        "t_collector": 29.6203,
+        "t_tank_top": 27.5249,
+        "t_tank_bottom": 26.877,
+        "t_collector": 28.7372,
         "t_greenhouse": 17.0728,
         "t_outdoor": 14.5224
       },
@@ -5750,9 +5750,9 @@
     {
       "time": 31320,
       "values": {
-        "t_tank_top": 27.7894,
-        "t_tank_bottom": 26.9122,
-        "t_collector": 29.2933,
+        "t_tank_top": 27.5427,
+        "t_tank_bottom": 26.8984,
+        "t_collector": 28.7483,
         "t_greenhouse": 17.0603,
         "t_outdoor": 14.5131
       },
@@ -5761,9 +5761,9 @@
     {
       "time": 31380,
       "values": {
-        "t_tank_top": 27.8062,
-        "t_tank_bottom": 26.9418,
-        "t_collector": 29.1002,
+        "t_tank_top": 27.5604,
+        "t_tank_bottom": 26.9198,
+        "t_collector": 28.7593,
         "t_greenhouse": 17.0477,
         "t_outdoor": 14.5036
       },
@@ -5772,9 +5772,9 @@
     {
       "time": 31440,
       "values": {
-        "t_tank_top": 27.8171,
-        "t_tank_bottom": 26.9708,
-        "t_collector": 28.9888,
+        "t_tank_top": 27.5779,
+        "t_tank_bottom": 26.941,
+        "t_collector": 28.7701,
         "t_greenhouse": 17.035,
         "t_outdoor": 14.4941
       },
@@ -5783,119 +5783,119 @@
     {
       "time": 31500,
       "values": {
-        "t_tank_top": 27.7931,
-        "t_tank_bottom": 26.9986,
-        "t_collector": 29.6744,
+        "t_tank_top": 27.5953,
+        "t_tank_bottom": 26.962,
+        "t_collector": 28.7808,
         "t_greenhouse": 17.0221,
         "t_outdoor": 14.4845
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 31560,
       "values": {
-        "t_tank_top": 27.7636,
-        "t_tank_bottom": 27.0244,
-        "t_collector": 30.5132,
+        "t_tank_top": 27.6125,
+        "t_tank_bottom": 26.9829,
+        "t_collector": 28.7913,
         "t_greenhouse": 17.0091,
         "t_outdoor": 14.4748
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 31620,
       "values": {
-        "t_tank_top": 27.7361,
-        "t_tank_bottom": 27.0482,
-        "t_collector": 31.3322,
+        "t_tank_top": 27.6296,
+        "t_tank_bottom": 27.0037,
+        "t_collector": 28.8016,
         "t_greenhouse": 16.996,
         "t_outdoor": 14.4651
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 31680,
       "values": {
-        "t_tank_top": 27.7103,
-        "t_tank_bottom": 27.0703,
-        "t_collector": 32.1317,
+        "t_tank_top": 27.6465,
+        "t_tank_bottom": 27.0244,
+        "t_collector": 28.8118,
         "t_greenhouse": 16.9828,
         "t_outdoor": 14.4552
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 31740,
       "values": {
-        "t_tank_top": 27.6862,
-        "t_tank_bottom": 27.0906,
-        "t_collector": 32.9122,
+        "t_tank_top": 27.6633,
+        "t_tank_bottom": 27.0449,
+        "t_collector": 28.8218,
         "t_greenhouse": 16.9694,
         "t_outdoor": 14.4453
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 31800,
       "values": {
-        "t_tank_top": 27.6637,
-        "t_tank_bottom": 27.1095,
-        "t_collector": 33.6739,
+        "t_tank_top": 27.6799,
+        "t_tank_bottom": 27.0652,
+        "t_collector": 28.8316,
         "t_greenhouse": 16.9559,
         "t_outdoor": 14.4352
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 31860,
       "values": {
-        "t_tank_top": 27.6426,
-        "t_tank_bottom": 27.1269,
-        "t_collector": 34.4171,
+        "t_tank_top": 27.6964,
+        "t_tank_bottom": 27.0855,
+        "t_collector": 28.8413,
         "t_greenhouse": 16.9423,
         "t_outdoor": 14.4251
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 31920,
       "values": {
-        "t_tank_top": 27.6228,
-        "t_tank_bottom": 27.143,
-        "t_collector": 35.1422,
+        "t_tank_top": 27.7127,
+        "t_tank_bottom": 27.1056,
+        "t_collector": 28.8508,
         "t_greenhouse": 16.9286,
         "t_outdoor": 14.4149
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 31980,
       "values": {
-        "t_tank_top": 27.6042,
-        "t_tank_bottom": 27.1578,
-        "t_collector": 35.8495,
+        "t_tank_top": 27.7289,
+        "t_tank_bottom": 27.1255,
+        "t_collector": 28.8601,
         "t_greenhouse": 16.9148,
         "t_outdoor": 14.4046
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 32040,
       "values": {
-        "t_tank_top": 27.5869,
-        "t_tank_bottom": 27.1714,
-        "t_collector": 36.5392,
+        "t_tank_top": 27.745,
+        "t_tank_bottom": 27.1453,
+        "t_collector": 28.8692,
         "t_greenhouse": 16.9008,
         "t_outdoor": 14.3943
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 32100,
       "values": {
-        "t_tank_top": 27.583,
-        "t_tank_bottom": 27.184,
-        "t_collector": 37.0556,
+        "t_tank_top": 27.7608,
+        "t_tank_bottom": 27.165,
+        "t_collector": 28.8782,
         "t_greenhouse": 16.8867,
         "t_outdoor": 14.3838
       },
@@ -5904,9 +5904,9 @@
     {
       "time": 32160,
       "values": {
-        "t_tank_top": 27.8595,
-        "t_tank_bottom": 27.2017,
-        "t_collector": 33.9056,
+        "t_tank_top": 27.7766,
+        "t_tank_bottom": 27.1845,
+        "t_collector": 28.887,
         "t_greenhouse": 16.8725,
         "t_outdoor": 14.3733
       },
@@ -5915,9 +5915,9 @@
     {
       "time": 32220,
       "values": {
-        "t_tank_top": 28.0214,
-        "t_tank_bottom": 27.2263,
-        "t_collector": 31.979,
+        "t_tank_top": 27.7922,
+        "t_tank_bottom": 27.2039,
+        "t_collector": 28.8957,
         "t_greenhouse": 16.8582,
         "t_outdoor": 14.3627
       },
@@ -5926,9 +5926,9 @@
     {
       "time": 32280,
       "values": {
-        "t_tank_top": 28.1142,
-        "t_tank_bottom": 27.2544,
-        "t_collector": 30.8041,
+        "t_tank_top": 27.8076,
+        "t_tank_bottom": 27.2232,
+        "t_collector": 28.9042,
         "t_greenhouse": 16.8438,
         "t_outdoor": 14.352
       },
@@ -5937,9 +5937,9 @@
     {
       "time": 32340,
       "values": {
-        "t_tank_top": 28.1659,
-        "t_tank_bottom": 27.284,
-        "t_collector": 30.0907,
+        "t_tank_top": 27.8229,
+        "t_tank_bottom": 27.2423,
+        "t_collector": 28.9125,
         "t_greenhouse": 16.8292,
         "t_outdoor": 14.3412
       },
@@ -5948,9 +5948,9 @@
     {
       "time": 32400,
       "values": {
-        "t_tank_top": 28.1935,
-        "t_tank_bottom": 27.3139,
-        "t_collector": 29.6605,
+        "t_tank_top": 27.838,
+        "t_tank_bottom": 27.2612,
+        "t_collector": 28.9206,
         "t_greenhouse": 16.8146,
         "t_outdoor": 14.3303
       },
@@ -5959,9 +5959,9 @@
     {
       "time": 32460,
       "values": {
-        "t_tank_top": 28.2072,
-        "t_tank_bottom": 27.3434,
-        "t_collector": 29.4038,
+        "t_tank_top": 27.853,
+        "t_tank_bottom": 27.2801,
+        "t_collector": 28.9286,
         "t_greenhouse": 16.7998,
         "t_outdoor": 14.3194
       },
@@ -5970,141 +5970,141 @@
     {
       "time": 32520,
       "values": {
-        "t_tank_top": 28.1872,
-        "t_tank_bottom": 27.3719,
-        "t_collector": 29.8863,
+        "t_tank_top": 27.8678,
+        "t_tank_bottom": 27.2987,
+        "t_collector": 28.9364,
         "t_greenhouse": 16.7849,
         "t_outdoor": 14.3083
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 32580,
       "values": {
-        "t_tank_top": 28.1569,
-        "t_tank_bottom": 27.3983,
-        "t_collector": 30.6367,
+        "t_tank_top": 27.8824,
+        "t_tank_bottom": 27.3173,
+        "t_collector": 28.944,
         "t_greenhouse": 16.7698,
         "t_outdoor": 14.2972
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 32640,
       "values": {
-        "t_tank_top": 28.1286,
-        "t_tank_bottom": 27.4227,
-        "t_collector": 31.3687,
+        "t_tank_top": 27.897,
+        "t_tank_bottom": 27.3357,
+        "t_collector": 28.9514,
         "t_greenhouse": 16.7547,
         "t_outdoor": 14.286
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 32700,
       "values": {
-        "t_tank_top": 28.1021,
-        "t_tank_bottom": 27.4453,
-        "t_collector": 32.0825,
+        "t_tank_top": 27.9113,
+        "t_tank_bottom": 27.3539,
+        "t_collector": 28.9587,
         "t_greenhouse": 16.7394,
         "t_outdoor": 14.2747
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 32760,
       "values": {
-        "t_tank_top": 28.0774,
-        "t_tank_bottom": 27.4662,
-        "t_collector": 32.7785,
+        "t_tank_top": 27.9255,
+        "t_tank_bottom": 27.372,
+        "t_collector": 28.9658,
         "t_greenhouse": 16.724,
         "t_outdoor": 14.2634
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 32820,
       "values": {
-        "t_tank_top": 28.0542,
-        "t_tank_bottom": 27.4855,
-        "t_collector": 33.4569,
+        "t_tank_top": 27.9396,
+        "t_tank_bottom": 27.39,
+        "t_collector": 28.9728,
         "t_greenhouse": 16.7085,
         "t_outdoor": 14.252
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 32880,
       "values": {
-        "t_tank_top": 28.0325,
-        "t_tank_bottom": 27.5033,
-        "t_collector": 34.1181,
+        "t_tank_top": 27.9535,
+        "t_tank_bottom": 27.4078,
+        "t_collector": 28.9796,
         "t_greenhouse": 16.6929,
         "t_outdoor": 14.2404
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 32940,
       "values": {
-        "t_tank_top": 28.0122,
-        "t_tank_bottom": 27.5198,
-        "t_collector": 34.7623,
+        "t_tank_top": 27.9672,
+        "t_tank_bottom": 27.4254,
+        "t_collector": 28.9862,
         "t_greenhouse": 16.6772,
         "t_outdoor": 14.2288
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 33000,
       "values": {
-        "t_tank_top": 27.9931,
-        "t_tank_bottom": 27.5349,
-        "t_collector": 35.3899,
+        "t_tank_top": 27.9808,
+        "t_tank_bottom": 27.443,
+        "t_collector": 28.9926,
         "t_greenhouse": 16.6613,
         "t_outdoor": 14.2172
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 33060,
       "values": {
-        "t_tank_top": 27.9752,
-        "t_tank_bottom": 27.5489,
-        "t_collector": 36.001,
+        "t_tank_top": 27.9942,
+        "t_tank_bottom": 27.4603,
+        "t_collector": 28.9988,
         "t_greenhouse": 16.6454,
         "t_outdoor": 14.2054
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 33120,
       "values": {
-        "t_tank_top": 27.9585,
-        "t_tank_bottom": 27.5618,
-        "t_collector": 36.5961,
+        "t_tank_top": 28.0075,
+        "t_tank_bottom": 27.4776,
+        "t_collector": 29.0049,
         "t_greenhouse": 16.6293,
         "t_outdoor": 14.1936
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 33180,
       "values": {
-        "t_tank_top": 27.9427,
-        "t_tank_bottom": 27.5736,
-        "t_collector": 37.1752,
+        "t_tank_top": 28.0206,
+        "t_tank_bottom": 27.4947,
+        "t_collector": 29.0108,
         "t_greenhouse": 16.6131,
         "t_outdoor": 14.1816
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 33240,
       "values": {
-        "t_tank_top": 28.0224,
-        "t_tank_bottom": 27.585,
-        "t_collector": 36.551,
+        "t_tank_top": 28.0336,
+        "t_tank_bottom": 27.5116,
+        "t_collector": 29.0166,
         "t_greenhouse": 16.5968,
         "t_outdoor": 14.1696
       },
@@ -6113,9 +6113,9 @@
     {
       "time": 33300,
       "values": {
-        "t_tank_top": 28.2666,
-        "t_tank_bottom": 27.6034,
-        "t_collector": 33.6676,
+        "t_tank_top": 28.0464,
+        "t_tank_bottom": 27.5284,
+        "t_collector": 29.0221,
         "t_greenhouse": 16.5803,
         "t_outdoor": 14.1576
       },
@@ -6124,9 +6124,9 @@
     {
       "time": 33360,
       "values": {
-        "t_tank_top": 28.4067,
-        "t_tank_bottom": 27.6277,
-        "t_collector": 31.9042,
+        "t_tank_top": 28.059,
+        "t_tank_bottom": 27.545,
+        "t_collector": 29.0275,
         "t_greenhouse": 16.5638,
         "t_outdoor": 14.1454
       },
@@ -6135,9 +6135,9 @@
     {
       "time": 33420,
       "values": {
-        "t_tank_top": 28.4843,
-        "t_tank_bottom": 27.6548,
-        "t_collector": 30.8288,
+        "t_tank_top": 28.0715,
+        "t_tank_bottom": 27.5615,
+        "t_collector": 29.0328,
         "t_greenhouse": 16.5471,
         "t_outdoor": 14.1332
       },
@@ -6146,9 +6146,9 @@
     {
       "time": 33480,
       "values": {
-        "t_tank_top": 28.5248,
-        "t_tank_bottom": 27.683,
-        "t_collector": 30.1758,
+        "t_tank_top": 28.0839,
+        "t_tank_bottom": 27.5779,
+        "t_collector": 29.0378,
         "t_greenhouse": 16.5304,
         "t_outdoor": 14.1208
       },
@@ -6157,9 +6157,9 @@
     {
       "time": 33540,
       "values": {
-        "t_tank_top": 28.5438,
-        "t_tank_bottom": 27.7112,
-        "t_collector": 29.7818,
+        "t_tank_top": 28.096,
+        "t_tank_bottom": 27.5941,
+        "t_collector": 29.0427,
         "t_greenhouse": 16.5135,
         "t_outdoor": 14.1084
       },
@@ -6168,174 +6168,174 @@
     {
       "time": 33600,
       "values": {
-        "t_tank_top": 28.5224,
-        "t_tank_bottom": 27.7385,
-        "t_collector": 30.2254,
+        "t_tank_top": 28.1081,
+        "t_tank_bottom": 27.6101,
+        "t_collector": 29.0474,
         "t_greenhouse": 16.4965,
         "t_outdoor": 14.096
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 33660,
       "values": {
-        "t_tank_top": 28.4931,
-        "t_tank_bottom": 27.7637,
-        "t_collector": 30.8753,
+        "t_tank_top": 28.1199,
+        "t_tank_bottom": 27.626,
+        "t_collector": 29.0519,
         "t_greenhouse": 16.4794,
         "t_outdoor": 14.0834
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 33720,
       "values": {
-        "t_tank_top": 28.4657,
-        "t_tank_bottom": 27.787,
-        "t_collector": 31.5083,
+        "t_tank_top": 28.1316,
+        "t_tank_bottom": 27.6418,
+        "t_collector": 29.0563,
         "t_greenhouse": 16.4621,
         "t_outdoor": 14.0708
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 33780,
       "values": {
-        "t_tank_top": 28.4401,
-        "t_tank_bottom": 27.8086,
-        "t_collector": 32.1246,
+        "t_tank_top": 28.1432,
+        "t_tank_bottom": 27.6574,
+        "t_collector": 29.0604,
         "t_greenhouse": 16.4448,
         "t_outdoor": 14.0581
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 33840,
       "values": {
-        "t_tank_top": 28.4162,
-        "t_tank_bottom": 27.8285,
-        "t_collector": 32.7245,
+        "t_tank_top": 28.1546,
+        "t_tank_bottom": 27.6728,
+        "t_collector": 29.0645,
         "t_greenhouse": 16.4273,
         "t_outdoor": 14.0453
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 33900,
       "values": {
-        "t_tank_top": 28.3937,
-        "t_tank_bottom": 27.8469,
-        "t_collector": 33.3084,
+        "t_tank_top": 28.1658,
+        "t_tank_bottom": 27.6881,
+        "t_collector": 29.0683,
         "t_greenhouse": 16.4098,
         "t_outdoor": 14.0324
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 33960,
       "values": {
-        "t_tank_top": 28.3727,
-        "t_tank_bottom": 27.8639,
-        "t_collector": 33.8763,
+        "t_tank_top": 28.1769,
+        "t_tank_bottom": 27.7033,
+        "t_collector": 29.0719,
         "t_greenhouse": 16.3921,
         "t_outdoor": 14.0195
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 34020,
       "values": {
-        "t_tank_top": 28.353,
-        "t_tank_bottom": 27.8796,
-        "t_collector": 34.4288,
+        "t_tank_top": 28.1878,
+        "t_tank_bottom": 27.7183,
+        "t_collector": 29.0754,
         "t_greenhouse": 16.3743,
         "t_outdoor": 14.0065
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 34080,
       "values": {
-        "t_tank_top": 28.3345,
-        "t_tank_bottom": 27.894,
-        "t_collector": 34.9659,
+        "t_tank_top": 28.1985,
+        "t_tank_bottom": 27.7331,
+        "t_collector": 29.0787,
         "t_greenhouse": 16.3564,
         "t_outdoor": 13.9934
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 34140,
       "values": {
-        "t_tank_top": 28.3172,
-        "t_tank_bottom": 27.9073,
-        "t_collector": 35.4879,
+        "t_tank_top": 28.2091,
+        "t_tank_bottom": 27.7478,
+        "t_collector": 29.0819,
         "t_greenhouse": 16.3384,
         "t_outdoor": 13.9802
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 34200,
       "values": {
-        "t_tank_top": 28.3009,
-        "t_tank_bottom": 27.9195,
-        "t_collector": 35.9952,
+        "t_tank_top": 28.2195,
+        "t_tank_bottom": 27.7623,
+        "t_collector": 29.0848,
         "t_greenhouse": 16.3203,
         "t_outdoor": 13.967
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 34260,
       "values": {
-        "t_tank_top": 28.2856,
-        "t_tank_bottom": 27.9308,
-        "t_collector": 36.4879,
+        "t_tank_top": 28.2298,
+        "t_tank_bottom": 27.7767,
+        "t_collector": 29.0876,
         "t_greenhouse": 16.302,
         "t_outdoor": 13.9537
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 34320,
       "values": {
-        "t_tank_top": 28.2713,
-        "t_tank_bottom": 27.9411,
-        "t_collector": 36.9664,
+        "t_tank_top": 28.2399,
+        "t_tank_bottom": 27.791,
+        "t_collector": 29.0902,
         "t_greenhouse": 16.2837,
         "t_outdoor": 13.9403
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 34380,
       "values": {
-        "t_tank_top": 28.2578,
-        "t_tank_bottom": 27.9505,
-        "t_collector": 37.4308,
+        "t_tank_top": 28.2499,
+        "t_tank_bottom": 27.8051,
+        "t_collector": 29.0927,
         "t_greenhouse": 16.2653,
         "t_outdoor": 13.9268
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 34440,
       "values": {
-        "t_tank_top": 28.245,
-        "t_tank_bottom": 27.9591,
-        "t_collector": 37.8813,
+        "t_tank_top": 28.2596,
+        "t_tank_bottom": 27.819,
+        "t_collector": 29.0949,
         "t_greenhouse": 16.2467,
         "t_outdoor": 13.9133
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 34500,
       "values": {
-        "t_tank_top": 28.4862,
-        "t_tank_bottom": 27.9711,
-        "t_collector": 35.0861,
+        "t_tank_top": 28.2693,
+        "t_tank_bottom": 27.8328,
+        "t_collector": 29.097,
         "t_greenhouse": 16.228,
         "t_outdoor": 13.8996
       },
@@ -6344,9 +6344,9 @@
     {
       "time": 34560,
       "values": {
-        "t_tank_top": 28.6666,
-        "t_tank_bottom": 27.9908,
-        "t_collector": 32.8224,
+        "t_tank_top": 28.2787,
+        "t_tank_bottom": 27.8464,
+        "t_collector": 29.0989,
         "t_greenhouse": 16.2092,
         "t_outdoor": 13.886
       },
@@ -6355,9 +6355,9 @@
     {
       "time": 34620,
       "values": {
-        "t_tank_top": 28.7662,
-        "t_tank_bottom": 28.0147,
-        "t_collector": 31.4387,
+        "t_tank_top": 28.288,
+        "t_tank_bottom": 27.8599,
+        "t_collector": 29.1007,
         "t_greenhouse": 16.1904,
         "t_outdoor": 13.8722
       },
@@ -6366,9 +6366,9 @@
     {
       "time": 34680,
       "values": {
-        "t_tank_top": 28.8177,
-        "t_tank_bottom": 28.0403,
-        "t_collector": 30.5954,
+        "t_tank_top": 28.2972,
+        "t_tank_bottom": 27.8732,
+        "t_collector": 29.1022,
         "t_greenhouse": 16.1714,
         "t_outdoor": 13.8584
       },
@@ -6377,9 +6377,9 @@
     {
       "time": 34740,
       "values": {
-        "t_tank_top": 28.8409,
-        "t_tank_bottom": 28.0662,
-        "t_collector": 30.0837,
+        "t_tank_top": 28.3061,
+        "t_tank_bottom": 27.8864,
+        "t_collector": 29.1036,
         "t_greenhouse": 16.1522,
         "t_outdoor": 13.8444
       },
@@ -6388,229 +6388,229 @@
     {
       "time": 34800,
       "values": {
-        "t_tank_top": 28.8194,
-        "t_tank_bottom": 28.0913,
-        "t_collector": 30.4633,
+        "t_tank_top": 28.315,
+        "t_tank_bottom": 27.8994,
+        "t_collector": 29.1048,
         "t_greenhouse": 16.133,
         "t_outdoor": 13.8305
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 34860,
       "values": {
-        "t_tank_top": 28.792,
-        "t_tank_bottom": 28.1145,
-        "t_collector": 30.9985,
+        "t_tank_top": 28.3236,
+        "t_tank_bottom": 27.9122,
+        "t_collector": 29.1059,
         "t_greenhouse": 16.1137,
         "t_outdoor": 13.8164
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 34920,
       "values": {
-        "t_tank_top": 28.7664,
-        "t_tank_bottom": 28.136,
-        "t_collector": 31.5186,
+        "t_tank_top": 28.3321,
+        "t_tank_bottom": 27.9249,
+        "t_collector": 29.1067,
         "t_greenhouse": 16.0943,
         "t_outdoor": 13.8023
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 34980,
       "values": {
-        "t_tank_top": 28.7424,
-        "t_tank_bottom": 28.1558,
-        "t_collector": 32.0237,
+        "t_tank_top": 28.3404,
+        "t_tank_bottom": 27.9375,
+        "t_collector": 29.1074,
         "t_greenhouse": 16.0748,
         "t_outdoor": 13.7881
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 35040,
       "values": {
-        "t_tank_top": 28.7199,
-        "t_tank_bottom": 28.1741,
-        "t_collector": 32.5141,
+        "t_tank_top": 28.3486,
+        "t_tank_bottom": 27.9498,
+        "t_collector": 29.1079,
         "t_greenhouse": 16.0551,
         "t_outdoor": 13.7738
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 35100,
       "values": {
-        "t_tank_top": 28.6988,
-        "t_tank_bottom": 28.1909,
-        "t_collector": 32.9901,
+        "t_tank_top": 28.3566,
+        "t_tank_bottom": 27.9621,
+        "t_collector": 29.1082,
         "t_greenhouse": 16.0354,
         "t_outdoor": 13.7594
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 35160,
       "values": {
-        "t_tank_top": 28.679,
-        "t_tank_bottom": 28.2065,
-        "t_collector": 33.452,
+        "t_tank_top": 28.3644,
+        "t_tank_bottom": 27.9742,
+        "t_collector": 29.1084,
         "t_greenhouse": 16.0155,
         "t_outdoor": 13.745
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 35220,
       "values": {
-        "t_tank_top": 28.6605,
-        "t_tank_bottom": 28.2208,
-        "t_collector": 33.8998,
+        "t_tank_top": 28.3721,
+        "t_tank_bottom": 27.9861,
+        "t_collector": 29.1084,
         "t_greenhouse": 15.9956,
         "t_outdoor": 13.7305
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 35280,
       "values": {
-        "t_tank_top": 28.6431,
-        "t_tank_bottom": 28.234,
-        "t_collector": 34.334,
+        "t_tank_top": 28.3796,
+        "t_tank_bottom": 27.9978,
+        "t_collector": 29.1082,
         "t_greenhouse": 15.9755,
         "t_outdoor": 13.716
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 35340,
       "values": {
-        "t_tank_top": 28.6268,
-        "t_tank_bottom": 28.2461,
-        "t_collector": 34.7547,
+        "t_tank_top": 28.387,
+        "t_tank_bottom": 28.0094,
+        "t_collector": 29.1078,
         "t_greenhouse": 15.9553,
         "t_outdoor": 13.7013
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 35400,
       "values": {
-        "t_tank_top": 28.6114,
-        "t_tank_bottom": 28.2572,
-        "t_collector": 35.1622,
+        "t_tank_top": 28.3941,
+        "t_tank_bottom": 28.0209,
+        "t_collector": 29.1072,
         "t_greenhouse": 15.9351,
         "t_outdoor": 13.6866
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 35460,
       "values": {
-        "t_tank_top": 28.597,
-        "t_tank_bottom": 28.2674,
-        "t_collector": 35.5566,
+        "t_tank_top": 28.4012,
+        "t_tank_bottom": 28.0322,
+        "t_collector": 29.1065,
         "t_greenhouse": 15.9147,
         "t_outdoor": 13.6719
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 35520,
       "values": {
-        "t_tank_top": 28.5834,
-        "t_tank_bottom": 28.2767,
-        "t_collector": 35.9382,
+        "t_tank_top": 28.408,
+        "t_tank_bottom": 28.0433,
+        "t_collector": 29.1056,
         "t_greenhouse": 15.8942,
         "t_outdoor": 13.657
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 35580,
       "values": {
-        "t_tank_top": 28.5707,
-        "t_tank_bottom": 28.2853,
-        "t_collector": 36.3072,
+        "t_tank_top": 28.4147,
+        "t_tank_bottom": 28.0543,
+        "t_collector": 29.1045,
         "t_greenhouse": 15.8736,
         "t_outdoor": 13.6421
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 35640,
       "values": {
-        "t_tank_top": 28.5586,
-        "t_tank_bottom": 28.2931,
-        "t_collector": 36.6639,
+        "t_tank_top": 28.4212,
+        "t_tank_bottom": 28.0651,
+        "t_collector": 29.1033,
         "t_greenhouse": 15.8529,
         "t_outdoor": 13.6271
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 35700,
       "values": {
-        "t_tank_top": 28.5473,
-        "t_tank_bottom": 28.3002,
-        "t_collector": 37.0084,
+        "t_tank_top": 28.4276,
+        "t_tank_bottom": 28.0758,
+        "t_collector": 29.1018,
         "t_greenhouse": 15.8321,
         "t_outdoor": 13.6121
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 35760,
       "values": {
-        "t_tank_top": 28.5366,
-        "t_tank_bottom": 28.3066,
-        "t_collector": 37.3409,
+        "t_tank_top": 28.4338,
+        "t_tank_bottom": 28.0863,
+        "t_collector": 29.1002,
         "t_greenhouse": 15.8113,
         "t_outdoor": 13.597
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 35820,
       "values": {
-        "t_tank_top": 28.5264,
-        "t_tank_bottom": 28.3125,
-        "t_collector": 37.6616,
+        "t_tank_top": 28.4398,
+        "t_tank_bottom": 28.0966,
+        "t_collector": 29.0984,
         "t_greenhouse": 15.7903,
         "t_outdoor": 13.5818
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 35880,
       "values": {
-        "t_tank_top": 28.5169,
-        "t_tank_bottom": 28.3178,
-        "t_collector": 37.9708,
+        "t_tank_top": 28.4457,
+        "t_tank_bottom": 28.1068,
+        "t_collector": 29.0964,
         "t_greenhouse": 15.7692,
         "t_outdoor": 13.5665
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 35940,
       "values": {
-        "t_tank_top": 28.5078,
-        "t_tank_bottom": 28.3226,
-        "t_collector": 38.2686,
+        "t_tank_top": 28.4514,
+        "t_tank_bottom": 28.1168,
+        "t_collector": 29.0943,
         "t_greenhouse": 15.748,
         "t_outdoor": 13.5512
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 36000,
       "values": {
-        "t_tank_top": 28.7495,
-        "t_tank_bottom": 28.3308,
-        "t_collector": 35.3968,
+        "t_tank_top": 28.4569,
+        "t_tank_bottom": 28.1267,
+        "t_collector": 29.092,
         "t_greenhouse": 15.7267,
         "t_outdoor": 13.5358
       },
@@ -6619,9 +6619,9 @@
     {
       "time": 36060,
       "values": {
-        "t_tank_top": 28.9325,
-        "t_tank_bottom": 28.3471,
-        "t_collector": 33.0311,
+        "t_tank_top": 28.4622,
+        "t_tank_bottom": 28.1364,
+        "t_collector": 29.0895,
         "t_greenhouse": 15.7053,
         "t_outdoor": 13.5203
       },
@@ -6630,9 +6630,9 @@
     {
       "time": 36120,
       "values": {
-        "t_tank_top": 29.0314,
-        "t_tank_bottom": 28.3677,
-        "t_collector": 31.5834,
+        "t_tank_top": 28.4674,
+        "t_tank_bottom": 28.1459,
+        "t_collector": 29.0868,
         "t_greenhouse": 15.6838,
         "t_outdoor": 13.5048
       },
@@ -6641,9 +6641,9 @@
     {
       "time": 36180,
       "values": {
-        "t_tank_top": 29.0801,
-        "t_tank_bottom": 28.39,
-        "t_collector": 30.6994,
+        "t_tank_top": 28.4725,
+        "t_tank_bottom": 28.1553,
+        "t_collector": 29.084,
         "t_greenhouse": 15.6622,
         "t_outdoor": 13.4892
       },
@@ -6652,9 +6652,9 @@
     {
       "time": 36240,
       "values": {
-        "t_tank_top": 29.0994,
-        "t_tank_bottom": 28.4127,
-        "t_collector": 30.1613,
+        "t_tank_top": 28.4773,
+        "t_tank_bottom": 28.1645,
+        "t_collector": 29.0809,
         "t_greenhouse": 15.6405,
         "t_outdoor": 13.4736
       },
@@ -6663,372 +6663,372 @@
     {
       "time": 36300,
       "values": {
-        "t_tank_top": 29.0801,
-        "t_tank_bottom": 28.4346,
-        "t_collector": 30.4045,
+        "t_tank_top": 28.482,
+        "t_tank_bottom": 28.1736,
+        "t_collector": 29.0777,
         "t_greenhouse": 15.6187,
         "t_outdoor": 13.4578
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 36360,
       "values": {
-        "t_tank_top": 29.0555,
-        "t_tank_bottom": 28.4548,
-        "t_collector": 30.7955,
+        "t_tank_top": 28.4866,
+        "t_tank_bottom": 28.1825,
+        "t_collector": 29.0743,
         "t_greenhouse": 15.5968,
         "t_outdoor": 13.442
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 36420,
       "values": {
-        "t_tank_top": 29.0324,
-        "t_tank_bottom": 28.4735,
-        "t_collector": 31.1736,
+        "t_tank_top": 28.4909,
+        "t_tank_bottom": 28.1913,
+        "t_collector": 29.0708,
         "t_greenhouse": 15.5748,
         "t_outdoor": 13.4262
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 36480,
       "values": {
-        "t_tank_top": 29.0108,
-        "t_tank_bottom": 28.4907,
-        "t_collector": 31.539,
+        "t_tank_top": 28.4951,
+        "t_tank_bottom": 28.1998,
+        "t_collector": 29.067,
         "t_greenhouse": 15.5527,
         "t_outdoor": 13.4103
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 36540,
       "values": {
-        "t_tank_top": 28.9905,
-        "t_tank_bottom": 28.5066,
-        "t_collector": 31.8919,
+        "t_tank_top": 28.4991,
+        "t_tank_bottom": 28.2083,
+        "t_collector": 29.0631,
         "t_greenhouse": 15.5305,
         "t_outdoor": 13.3943
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 36600,
       "values": {
-        "t_tank_top": 28.9715,
-        "t_tank_bottom": 28.5212,
-        "t_collector": 32.2325,
+        "t_tank_top": 28.503,
+        "t_tank_bottom": 28.2165,
+        "t_collector": 29.059,
         "t_greenhouse": 15.5082,
         "t_outdoor": 13.3782
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 36660,
       "values": {
-        "t_tank_top": 28.9536,
-        "t_tank_bottom": 28.5347,
-        "t_collector": 32.5611,
+        "t_tank_top": 28.5067,
+        "t_tank_bottom": 28.2246,
+        "t_collector": 29.0547,
         "t_greenhouse": 15.4859,
         "t_outdoor": 13.3621
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 36720,
       "values": {
-        "t_tank_top": 28.9369,
-        "t_tank_bottom": 28.547,
-        "t_collector": 32.8778,
+        "t_tank_top": 28.5102,
+        "t_tank_bottom": 28.2325,
+        "t_collector": 29.0503,
         "t_greenhouse": 15.4634,
         "t_outdoor": 13.3459
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 36780,
       "values": {
-        "t_tank_top": 28.9211,
-        "t_tank_bottom": 28.5584,
-        "t_collector": 33.1829,
+        "t_tank_top": 28.5136,
+        "t_tank_bottom": 28.2403,
+        "t_collector": 29.0457,
         "t_greenhouse": 15.4408,
         "t_outdoor": 13.3297
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 36840,
       "values": {
-        "t_tank_top": 28.9063,
-        "t_tank_bottom": 28.5688,
-        "t_collector": 33.4765,
+        "t_tank_top": 28.5168,
+        "t_tank_bottom": 28.2479,
+        "t_collector": 29.0409,
         "t_greenhouse": 15.4181,
         "t_outdoor": 13.3134
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 36900,
       "values": {
-        "t_tank_top": 28.8923,
-        "t_tank_bottom": 28.5783,
-        "t_collector": 33.7588,
+        "t_tank_top": 28.5198,
+        "t_tank_bottom": 28.2554,
+        "t_collector": 29.0359,
         "t_greenhouse": 15.3954,
         "t_outdoor": 13.297
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 36960,
       "values": {
-        "t_tank_top": 28.8792,
-        "t_tank_bottom": 28.587,
-        "t_collector": 34.03,
+        "t_tank_top": 28.5227,
+        "t_tank_bottom": 28.2627,
+        "t_collector": 29.0307,
         "t_greenhouse": 15.3725,
         "t_outdoor": 13.2806
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 37020,
       "values": {
-        "t_tank_top": 28.8668,
-        "t_tank_bottom": 28.5949,
-        "t_collector": 34.2904,
+        "t_tank_top": 28.5253,
+        "t_tank_bottom": 28.2698,
+        "t_collector": 29.0254,
         "t_greenhouse": 15.3496,
         "t_outdoor": 13.2641
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 37080,
       "values": {
-        "t_tank_top": 28.8552,
-        "t_tank_bottom": 28.6022,
-        "t_collector": 34.54,
+        "t_tank_top": 28.5279,
+        "t_tank_bottom": 28.2767,
+        "t_collector": 29.0199,
         "t_greenhouse": 15.3265,
         "t_outdoor": 13.2475
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 37140,
       "values": {
-        "t_tank_top": 28.8442,
-        "t_tank_bottom": 28.6087,
-        "t_collector": 34.7791,
+        "t_tank_top": 28.5302,
+        "t_tank_bottom": 28.2835,
+        "t_collector": 29.0142,
         "t_greenhouse": 15.3034,
         "t_outdoor": 13.2309
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 37200,
       "values": {
-        "t_tank_top": 28.8338,
-        "t_tank_bottom": 28.6147,
-        "t_collector": 35.0079,
+        "t_tank_top": 28.5324,
+        "t_tank_bottom": 28.2902,
+        "t_collector": 29.0083,
         "t_greenhouse": 15.2801,
         "t_outdoor": 13.2142
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 37260,
       "values": {
-        "t_tank_top": 28.8239,
-        "t_tank_bottom": 28.6201,
-        "t_collector": 35.2265,
+        "t_tank_top": 28.5344,
+        "t_tank_bottom": 28.2966,
+        "t_collector": 29.0023,
         "t_greenhouse": 15.2568,
         "t_outdoor": 13.1975
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 37320,
       "values": {
-        "t_tank_top": 28.8146,
-        "t_tank_bottom": 28.6249,
-        "t_collector": 35.4351,
+        "t_tank_top": 28.5362,
+        "t_tank_bottom": 28.3029,
+        "t_collector": 28.996,
         "t_greenhouse": 15.2334,
         "t_outdoor": 13.1807
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 37380,
       "values": {
-        "t_tank_top": 28.8058,
-        "t_tank_bottom": 28.6293,
-        "t_collector": 35.6339,
+        "t_tank_top": 28.5379,
+        "t_tank_bottom": 28.3091,
+        "t_collector": 28.9896,
         "t_greenhouse": 15.2099,
         "t_outdoor": 13.1638
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 37440,
       "values": {
-        "t_tank_top": 28.7974,
-        "t_tank_bottom": 28.6332,
-        "t_collector": 35.823,
+        "t_tank_top": 28.5394,
+        "t_tank_bottom": 28.3151,
+        "t_collector": 28.9831,
         "t_greenhouse": 15.1862,
         "t_outdoor": 13.1469
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 37500,
       "values": {
-        "t_tank_top": 28.7895,
-        "t_tank_bottom": 28.6367,
-        "t_collector": 36.0026,
+        "t_tank_top": 28.5408,
+        "t_tank_bottom": 28.3209,
+        "t_collector": 28.9763,
         "t_greenhouse": 15.1626,
         "t_outdoor": 13.1299
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 37560,
       "values": {
-        "t_tank_top": 28.7819,
-        "t_tank_bottom": 28.6398,
-        "t_collector": 36.1728,
+        "t_tank_top": 28.5419,
+        "t_tank_bottom": 28.3265,
+        "t_collector": 28.9694,
         "t_greenhouse": 15.1388,
         "t_outdoor": 13.1129
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 37620,
       "values": {
-        "t_tank_top": 28.7748,
-        "t_tank_bottom": 28.6425,
-        "t_collector": 36.3339,
+        "t_tank_top": 28.5429,
+        "t_tank_bottom": 28.332,
+        "t_collector": 28.9623,
         "t_greenhouse": 15.1149,
         "t_outdoor": 13.0958
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 37680,
       "values": {
-        "t_tank_top": 28.7679,
-        "t_tank_bottom": 28.6448,
-        "t_collector": 36.4859,
+        "t_tank_top": 28.5437,
+        "t_tank_bottom": 28.3373,
+        "t_collector": 28.955,
         "t_greenhouse": 15.0909,
         "t_outdoor": 13.0786
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 37740,
       "values": {
-        "t_tank_top": 28.7614,
-        "t_tank_bottom": 28.6469,
-        "t_collector": 36.629,
+        "t_tank_top": 28.5444,
+        "t_tank_bottom": 28.3425,
+        "t_collector": 28.9475,
         "t_greenhouse": 15.0669,
         "t_outdoor": 13.0614
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 37800,
       "values": {
-        "t_tank_top": 28.7552,
-        "t_tank_bottom": 28.6486,
-        "t_collector": 36.7634,
+        "t_tank_top": 28.5449,
+        "t_tank_bottom": 28.3475,
+        "t_collector": 28.9399,
         "t_greenhouse": 15.0427,
         "t_outdoor": 13.0441
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 37860,
       "values": {
-        "t_tank_top": 28.7492,
-        "t_tank_bottom": 28.6501,
-        "t_collector": 36.8892,
+        "t_tank_top": 28.5452,
+        "t_tank_bottom": 28.3523,
+        "t_collector": 28.932,
         "t_greenhouse": 15.0185,
         "t_outdoor": 13.0268
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 37920,
       "values": {
-        "t_tank_top": 28.7435,
-        "t_tank_bottom": 28.6513,
-        "t_collector": 37.0066,
+        "t_tank_top": 28.5454,
+        "t_tank_bottom": 28.357,
+        "t_collector": 28.924,
         "t_greenhouse": 14.9941,
         "t_outdoor": 13.0094
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 37980,
       "values": {
-        "t_tank_top": 28.7381,
-        "t_tank_bottom": 28.6522,
-        "t_collector": 37.1157,
+        "t_tank_top": 28.5453,
+        "t_tank_bottom": 28.3614,
+        "t_collector": 28.9159,
         "t_greenhouse": 14.9697,
         "t_outdoor": 12.9919
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 38040,
       "values": {
-        "t_tank_top": 28.7328,
-        "t_tank_bottom": 28.6529,
-        "t_collector": 37.2166,
+        "t_tank_top": 28.5451,
+        "t_tank_bottom": 28.3658,
+        "t_collector": 28.9075,
         "t_greenhouse": 14.9452,
         "t_outdoor": 12.9744
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 38100,
       "values": {
-        "t_tank_top": 28.7278,
-        "t_tank_bottom": 28.6535,
-        "t_collector": 37.3095,
+        "t_tank_top": 28.5448,
+        "t_tank_bottom": 28.3699,
+        "t_collector": 28.899,
         "t_greenhouse": 14.9206,
         "t_outdoor": 12.9568
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 38160,
       "values": {
-        "t_tank_top": 28.723,
-        "t_tank_bottom": 28.6538,
-        "t_collector": 37.3945,
+        "t_tank_top": 28.5443,
+        "t_tank_bottom": 28.3739,
+        "t_collector": 28.8903,
         "t_greenhouse": 14.896,
         "t_outdoor": 12.9392
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 38220,
       "values": {
-        "t_tank_top": 28.7183,
-        "t_tank_bottom": 28.6539,
-        "t_collector": 37.4717,
+        "t_tank_top": 28.5436,
+        "t_tank_bottom": 28.3778,
+        "t_collector": 28.8814,
         "t_greenhouse": 14.8712,
         "t_outdoor": 12.9215
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 38280,
       "values": {
-        "t_tank_top": 28.7138,
-        "t_tank_bottom": 28.6539,
-        "t_collector": 37.5413,
+        "t_tank_top": 28.5383,
+        "t_tank_bottom": 28.3814,
+        "t_collector": 29.0149,
         "t_greenhouse": 14.8464,
         "t_outdoor": 12.9038
       },
@@ -7037,9 +7037,9 @@
     {
       "time": 38340,
       "values": {
-        "t_tank_top": 28.7095,
-        "t_tank_bottom": 28.6537,
-        "t_collector": 37.6034,
+        "t_tank_top": 28.5306,
+        "t_tank_bottom": 28.3846,
+        "t_collector": 29.2287,
         "t_greenhouse": 14.8214,
         "t_outdoor": 12.886
       },
@@ -7048,9 +7048,9 @@
     {
       "time": 38400,
       "values": {
-        "t_tank_top": 28.7053,
-        "t_tank_bottom": 28.6534,
-        "t_collector": 37.6582,
+        "t_tank_top": 28.5233,
+        "t_tank_bottom": 28.3874,
+        "t_collector": 29.4324,
         "t_greenhouse": 14.7964,
         "t_outdoor": 12.8682
       },
@@ -7059,9 +7059,9 @@
     {
       "time": 38460,
       "values": {
-        "t_tank_top": 28.7012,
-        "t_tank_bottom": 28.6529,
-        "t_collector": 37.7057,
+        "t_tank_top": 28.5164,
+        "t_tank_bottom": 28.3899,
+        "t_collector": 29.6262,
         "t_greenhouse": 14.7713,
         "t_outdoor": 12.8503
       },
@@ -7070,9 +7070,9 @@
     {
       "time": 38520,
       "values": {
-        "t_tank_top": 28.6973,
-        "t_tank_bottom": 28.6524,
-        "t_collector": 37.746,
+        "t_tank_top": 28.5097,
+        "t_tank_bottom": 28.3921,
+        "t_collector": 29.8103,
         "t_greenhouse": 14.7461,
         "t_outdoor": 12.8323
       },
@@ -7081,9 +7081,9 @@
     {
       "time": 38580,
       "values": {
-        "t_tank_top": 28.6934,
-        "t_tank_bottom": 28.6516,
-        "t_collector": 37.7793,
+        "t_tank_top": 28.5034,
+        "t_tank_bottom": 28.3939,
+        "t_collector": 29.9848,
         "t_greenhouse": 14.7208,
         "t_outdoor": 12.8143
       },
@@ -7092,9 +7092,9 @@
     {
       "time": 38640,
       "values": {
-        "t_tank_top": 28.6897,
-        "t_tank_bottom": 28.6508,
-        "t_collector": 37.8058,
+        "t_tank_top": 28.4973,
+        "t_tank_bottom": 28.3955,
+        "t_collector": 30.1499,
         "t_greenhouse": 14.6955,
         "t_outdoor": 12.7963
       },
@@ -7103,9 +7103,9 @@
     {
       "time": 38700,
       "values": {
-        "t_tank_top": 28.6861,
-        "t_tank_bottom": 28.6499,
-        "t_collector": 37.8255,
+        "t_tank_top": 28.4916,
+        "t_tank_bottom": 28.3968,
+        "t_collector": 30.3058,
         "t_greenhouse": 14.67,
         "t_outdoor": 12.7782
       },
@@ -7114,9 +7114,9 @@
     {
       "time": 38760,
       "values": {
-        "t_tank_top": 28.6825,
-        "t_tank_bottom": 28.6489,
-        "t_collector": 37.8385,
+        "t_tank_top": 28.486,
+        "t_tank_bottom": 28.3978,
+        "t_collector": 30.4526,
         "t_greenhouse": 14.6445,
         "t_outdoor": 12.76
       },
@@ -7125,9 +7125,9 @@
     {
       "time": 38820,
       "values": {
-        "t_tank_top": 28.6791,
-        "t_tank_bottom": 28.6478,
-        "t_collector": 37.8449,
+        "t_tank_top": 28.4807,
+        "t_tank_bottom": 28.3987,
+        "t_collector": 30.5904,
         "t_greenhouse": 14.6189,
         "t_outdoor": 12.7418
       },
@@ -7136,9 +7136,9 @@
     {
       "time": 38880,
       "values": {
-        "t_tank_top": 28.6757,
-        "t_tank_bottom": 28.6466,
-        "t_collector": 37.8449,
+        "t_tank_top": 28.4756,
+        "t_tank_bottom": 28.3993,
+        "t_collector": 30.7195,
         "t_greenhouse": 14.5932,
         "t_outdoor": 12.7235
       },
@@ -7147,9 +7147,9 @@
     {
       "time": 38940,
       "values": {
-        "t_tank_top": 28.6724,
-        "t_tank_bottom": 28.6453,
-        "t_collector": 37.8385,
+        "t_tank_top": 28.4707,
+        "t_tank_bottom": 28.3997,
+        "t_collector": 30.8399,
         "t_greenhouse": 14.5675,
         "t_outdoor": 12.7052
       },
@@ -7158,9 +7158,9 @@
     {
       "time": 39000,
       "values": {
-        "t_tank_top": 28.6692,
-        "t_tank_bottom": 28.6439,
-        "t_collector": 37.826,
+        "t_tank_top": 28.466,
+        "t_tank_bottom": 28.3999,
+        "t_collector": 30.9518,
         "t_greenhouse": 14.5416,
         "t_outdoor": 12.6868
       },
@@ -7169,9 +7169,9 @@
     {
       "time": 39060,
       "values": {
-        "t_tank_top": 28.666,
-        "t_tank_bottom": 28.6425,
-        "t_collector": 37.8073,
+        "t_tank_top": 28.4614,
+        "t_tank_bottom": 28.3999,
+        "t_collector": 31.0554,
         "t_greenhouse": 14.5157,
         "t_outdoor": 12.6684
       },
@@ -7180,9 +7180,9 @@
     {
       "time": 39120,
       "values": {
-        "t_tank_top": 28.6629,
-        "t_tank_bottom": 28.6411,
-        "t_collector": 37.7825,
+        "t_tank_top": 28.457,
+        "t_tank_bottom": 28.3998,
+        "t_collector": 31.1508,
         "t_greenhouse": 14.4897,
         "t_outdoor": 12.6499
       },
@@ -7191,9 +7191,9 @@
     {
       "time": 39180,
       "values": {
-        "t_tank_top": 28.6598,
-        "t_tank_bottom": 28.6395,
-        "t_collector": 37.7519,
+        "t_tank_top": 28.4528,
+        "t_tank_bottom": 28.3995,
+        "t_collector": 31.2381,
         "t_greenhouse": 14.4636,
         "t_outdoor": 12.6314
       },
@@ -7202,9 +7202,9 @@
     {
       "time": 39240,
       "values": {
-        "t_tank_top": 28.6568,
-        "t_tank_bottom": 28.6379,
-        "t_collector": 37.7154,
+        "t_tank_top": 28.4487,
+        "t_tank_bottom": 28.3991,
+        "t_collector": 31.3175,
         "t_greenhouse": 14.4374,
         "t_outdoor": 12.6128
       },
@@ -7213,9 +7213,9 @@
     {
       "time": 39300,
       "values": {
-        "t_tank_top": 28.6539,
-        "t_tank_bottom": 28.6363,
-        "t_collector": 37.6732,
+        "t_tank_top": 28.4447,
+        "t_tank_bottom": 28.3985,
+        "t_collector": 31.3891,
         "t_greenhouse": 14.4112,
         "t_outdoor": 12.5942
       },
@@ -7224,9 +7224,9 @@
     {
       "time": 39360,
       "values": {
-        "t_tank_top": 28.651,
-        "t_tank_bottom": 28.6346,
-        "t_collector": 37.6253,
+        "t_tank_top": 28.4408,
+        "t_tank_bottom": 28.3979,
+        "t_collector": 31.4531,
         "t_greenhouse": 14.3849,
         "t_outdoor": 12.5755
       },
@@ -7235,9 +7235,9 @@
     {
       "time": 39420,
       "values": {
-        "t_tank_top": 28.6481,
-        "t_tank_bottom": 28.6329,
-        "t_collector": 37.5719,
+        "t_tank_top": 28.437,
+        "t_tank_bottom": 28.3971,
+        "t_collector": 31.5095,
         "t_greenhouse": 14.3585,
         "t_outdoor": 12.5568
       },
@@ -7246,9 +7246,9 @@
     {
       "time": 39480,
       "values": {
-        "t_tank_top": 28.6453,
-        "t_tank_bottom": 28.6311,
-        "t_collector": 37.5131,
+        "t_tank_top": 28.4334,
+        "t_tank_bottom": 28.3962,
+        "t_collector": 31.5585,
         "t_greenhouse": 14.332,
         "t_outdoor": 12.538
       },
@@ -7257,9 +7257,9 @@
     {
       "time": 39540,
       "values": {
-        "t_tank_top": 28.6425,
-        "t_tank_bottom": 28.6293,
-        "t_collector": 37.4489,
+        "t_tank_top": 28.4298,
+        "t_tank_bottom": 28.3952,
+        "t_collector": 31.6003,
         "t_greenhouse": 14.3054,
         "t_outdoor": 12.5192
       },
@@ -7268,9 +7268,9 @@
     {
       "time": 39600,
       "values": {
-        "t_tank_top": 28.6397,
-        "t_tank_bottom": 28.6274,
-        "t_collector": 37.3794,
+        "t_tank_top": 28.4263,
+        "t_tank_bottom": 28.3942,
+        "t_collector": 31.6348,
         "t_greenhouse": 14.2788,
         "t_outdoor": 12.5003
       },
@@ -7279,9 +7279,9 @@
     {
       "time": 39660,
       "values": {
-        "t_tank_top": 28.637,
-        "t_tank_bottom": 28.6255,
-        "t_collector": 37.3048,
+        "t_tank_top": 28.4229,
+        "t_tank_bottom": 28.393,
+        "t_collector": 31.6624,
         "t_greenhouse": 14.2521,
         "t_outdoor": 12.4814
       },
@@ -7290,9 +7290,9 @@
     {
       "time": 39720,
       "values": {
-        "t_tank_top": 28.6342,
-        "t_tank_bottom": 28.6236,
-        "t_collector": 37.225,
+        "t_tank_top": 28.4196,
+        "t_tank_bottom": 28.3917,
+        "t_collector": 31.683,
         "t_greenhouse": 14.2253,
         "t_outdoor": 12.4624
       },
@@ -7301,9 +7301,9 @@
     {
       "time": 39780,
       "values": {
-        "t_tank_top": 28.6316,
-        "t_tank_bottom": 28.6217,
-        "t_collector": 37.1403,
+        "t_tank_top": 28.4163,
+        "t_tank_bottom": 28.3904,
+        "t_collector": 31.6969,
         "t_greenhouse": 14.1985,
         "t_outdoor": 12.4434
       },
@@ -7312,9 +7312,9 @@
     {
       "time": 39840,
       "values": {
-        "t_tank_top": 28.6289,
-        "t_tank_bottom": 28.6197,
-        "t_collector": 37.0506,
+        "t_tank_top": 28.4131,
+        "t_tank_bottom": 28.389,
+        "t_collector": 31.704,
         "t_greenhouse": 14.1715,
         "t_outdoor": 12.4244
       },
@@ -7323,9 +7323,9 @@
     {
       "time": 39900,
       "values": {
-        "t_tank_top": 28.6262,
-        "t_tank_bottom": 28.6177,
-        "t_collector": 36.9561,
+        "t_tank_top": 28.41,
+        "t_tank_bottom": 28.3876,
+        "t_collector": 31.7046,
         "t_greenhouse": 14.1445,
         "t_outdoor": 12.4053
       },
@@ -7334,9 +7334,9 @@
     {
       "time": 39960,
       "values": {
-        "t_tank_top": 28.6236,
-        "t_tank_bottom": 28.6157,
-        "t_collector": 36.8568,
+        "t_tank_top": 28.4069,
+        "t_tank_bottom": 28.3861,
+        "t_collector": 31.6987,
         "t_greenhouse": 14.1174,
         "t_outdoor": 12.3861
       },
@@ -7345,9 +7345,9 @@
     {
       "time": 40020,
       "values": {
-        "t_tank_top": 28.621,
-        "t_tank_bottom": 28.6136,
-        "t_collector": 36.7528,
+        "t_tank_top": 28.4039,
+        "t_tank_bottom": 28.3845,
+        "t_collector": 31.6865,
         "t_greenhouse": 14.0903,
         "t_outdoor": 12.3669
       },
@@ -7356,9 +7356,9 @@
     {
       "time": 40080,
       "values": {
-        "t_tank_top": 28.6184,
-        "t_tank_bottom": 28.6115,
-        "t_collector": 36.6442,
+        "t_tank_top": 28.4009,
+        "t_tank_bottom": 28.3829,
+        "t_collector": 31.6681,
         "t_greenhouse": 14.0631,
         "t_outdoor": 12.3477
       },
@@ -7367,9 +7367,9 @@
     {
       "time": 40140,
       "values": {
-        "t_tank_top": 28.6159,
-        "t_tank_bottom": 28.6094,
-        "t_collector": 36.5311,
+        "t_tank_top": 28.398,
+        "t_tank_bottom": 28.3812,
+        "t_collector": 31.6435,
         "t_greenhouse": 14.0358,
         "t_outdoor": 12.3284
       },
@@ -7378,9 +7378,9 @@
     {
       "time": 40200,
       "values": {
-        "t_tank_top": 28.6133,
-        "t_tank_bottom": 28.6073,
-        "t_collector": 36.4135,
+        "t_tank_top": 28.3951,
+        "t_tank_bottom": 28.3795,
+        "t_collector": 31.6129,
         "t_greenhouse": 14.0084,
         "t_outdoor": 12.3091
       },
@@ -7389,9 +7389,9 @@
     {
       "time": 40260,
       "values": {
-        "t_tank_top": 28.6108,
-        "t_tank_bottom": 28.6052,
-        "t_collector": 36.2916,
+        "t_tank_top": 28.3923,
+        "t_tank_bottom": 28.3777,
+        "t_collector": 31.5763,
         "t_greenhouse": 13.981,
         "t_outdoor": 12.2897
       },
@@ -7400,9 +7400,9 @@
     {
       "time": 40320,
       "values": {
-        "t_tank_top": 28.6082,
-        "t_tank_bottom": 28.603,
-        "t_collector": 36.1653,
+        "t_tank_top": 28.3895,
+        "t_tank_bottom": 28.3759,
+        "t_collector": 31.5339,
         "t_greenhouse": 13.9534,
         "t_outdoor": 12.2703
       },
@@ -7411,9 +7411,9 @@
     {
       "time": 40380,
       "values": {
-        "t_tank_top": 28.6057,
-        "t_tank_bottom": 28.6009,
-        "t_collector": 36.0348,
+        "t_tank_top": 28.3867,
+        "t_tank_bottom": 28.3741,
+        "t_collector": 31.4858,
         "t_greenhouse": 13.9259,
         "t_outdoor": 12.2508
       },
@@ -7422,9 +7422,9 @@
     {
       "time": 40440,
       "values": {
-        "t_tank_top": 28.6032,
-        "t_tank_bottom": 28.5987,
-        "t_collector": 35.9001,
+        "t_tank_top": 28.3839,
+        "t_tank_bottom": 28.3722,
+        "t_collector": 31.4321,
         "t_greenhouse": 13.8982,
         "t_outdoor": 12.2313
       },
@@ -7433,9 +7433,9 @@
     {
       "time": 40500,
       "values": {
-        "t_tank_top": 28.6007,
-        "t_tank_bottom": 28.5965,
-        "t_collector": 35.7614,
+        "t_tank_top": 28.3812,
+        "t_tank_bottom": 28.3703,
+        "t_collector": 31.3728,
         "t_greenhouse": 13.8705,
         "t_outdoor": 12.2118
       },
@@ -7444,9 +7444,9 @@
     {
       "time": 40560,
       "values": {
-        "t_tank_top": 28.5982,
-        "t_tank_bottom": 28.5943,
-        "t_collector": 35.6186,
+        "t_tank_top": 28.3785,
+        "t_tank_bottom": 28.3684,
+        "t_collector": 31.3081,
         "t_greenhouse": 13.8427,
         "t_outdoor": 12.1922
       },
@@ -7455,9 +7455,9 @@
     {
       "time": 40620,
       "values": {
-        "t_tank_top": 28.5957,
-        "t_tank_bottom": 28.5921,
-        "t_collector": 35.4718,
+        "t_tank_top": 28.3758,
+        "t_tank_bottom": 28.3664,
+        "t_collector": 31.238,
         "t_greenhouse": 13.8148,
         "t_outdoor": 12.1726
       },
@@ -7466,9 +7466,9 @@
     {
       "time": 40680,
       "values": {
-        "t_tank_top": 28.5932,
-        "t_tank_bottom": 28.5899,
-        "t_collector": 35.3212,
+        "t_tank_top": 28.3732,
+        "t_tank_bottom": 28.3644,
+        "t_collector": 31.1627,
         "t_greenhouse": 13.7869,
         "t_outdoor": 12.1529
       },
@@ -7477,9 +7477,9 @@
     {
       "time": 40740,
       "values": {
-        "t_tank_top": 28.5907,
-        "t_tank_bottom": 28.5876,
-        "t_collector": 35.1667,
+        "t_tank_top": 28.3706,
+        "t_tank_bottom": 28.3624,
+        "t_collector": 31.0822,
         "t_greenhouse": 13.7589,
         "t_outdoor": 12.1332
       },
@@ -7488,9 +7488,9 @@
     {
       "time": 40800,
       "values": {
-        "t_tank_top": 28.5883,
-        "t_tank_bottom": 28.5854,
-        "t_collector": 35.0084,
+        "t_tank_top": 28.3679,
+        "t_tank_bottom": 28.3603,
+        "t_collector": 30.9966,
         "t_greenhouse": 13.7309,
         "t_outdoor": 12.1134
       },
@@ -7499,9 +7499,9 @@
     {
       "time": 40860,
       "values": {
-        "t_tank_top": 28.5858,
-        "t_tank_bottom": 28.5831,
-        "t_collector": 34.8465,
+        "t_tank_top": 28.3654,
+        "t_tank_bottom": 28.3583,
+        "t_collector": 30.906,
         "t_greenhouse": 13.7027,
         "t_outdoor": 12.0936
       },
@@ -7510,9 +7510,9 @@
     {
       "time": 40920,
       "values": {
-        "t_tank_top": 28.5834,
-        "t_tank_bottom": 28.5808,
-        "t_collector": 34.6809,
+        "t_tank_top": 28.3628,
+        "t_tank_bottom": 28.3562,
+        "t_collector": 30.8105,
         "t_greenhouse": 13.6745,
         "t_outdoor": 12.0738
       },
@@ -7521,9 +7521,9 @@
     {
       "time": 40980,
       "values": {
-        "t_tank_top": 28.5809,
-        "t_tank_bottom": 28.5786,
-        "t_collector": 34.5117,
+        "t_tank_top": 28.3602,
+        "t_tank_bottom": 28.3541,
+        "t_collector": 30.7102,
         "t_greenhouse": 13.6463,
         "t_outdoor": 12.0539
       },
@@ -7532,9 +7532,9 @@
     {
       "time": 41040,
       "values": {
-        "t_tank_top": 28.5784,
-        "t_tank_bottom": 28.5763,
-        "t_collector": 34.339,
+        "t_tank_top": 28.3577,
+        "t_tank_bottom": 28.3519,
+        "t_collector": 30.6051,
         "t_greenhouse": 13.6179,
         "t_outdoor": 12.034
       },
@@ -7543,9 +7543,9 @@
     {
       "time": 41100,
       "values": {
-        "t_tank_top": 28.576,
-        "t_tank_bottom": 28.574,
-        "t_collector": 34.1628,
+        "t_tank_top": 28.3551,
+        "t_tank_bottom": 28.3498,
+        "t_collector": 30.4954,
         "t_greenhouse": 13.5896,
         "t_outdoor": 12.0141
       },
@@ -7554,9 +7554,9 @@
     {
       "time": 41160,
       "values": {
-        "t_tank_top": 28.5736,
-        "t_tank_bottom": 28.5717,
-        "t_collector": 33.9833,
+        "t_tank_top": 28.3526,
+        "t_tank_bottom": 28.3476,
+        "t_collector": 30.3811,
         "t_greenhouse": 13.5611,
         "t_outdoor": 11.9941
       },
@@ -7565,9 +7565,9 @@
     {
       "time": 41220,
       "values": {
-        "t_tank_top": 28.5711,
-        "t_tank_bottom": 28.5694,
-        "t_collector": 33.8004,
+        "t_tank_top": 28.3501,
+        "t_tank_bottom": 28.3455,
+        "t_collector": 30.2622,
         "t_greenhouse": 13.5326,
         "t_outdoor": 11.9741
       },
@@ -7576,9 +7576,9 @@
     {
       "time": 41280,
       "values": {
-        "t_tank_top": 28.5687,
-        "t_tank_bottom": 28.567,
-        "t_collector": 33.6141,
+        "t_tank_top": 28.3476,
+        "t_tank_bottom": 28.3433,
+        "t_collector": 30.139,
         "t_greenhouse": 13.504,
         "t_outdoor": 11.954
       },
@@ -7587,9 +7587,9 @@
     {
       "time": 41340,
       "values": {
-        "t_tank_top": 28.5662,
-        "t_tank_bottom": 28.5647,
-        "t_collector": 33.4247,
+        "t_tank_top": 28.3451,
+        "t_tank_bottom": 28.3411,
+        "t_collector": 30.0114,
         "t_greenhouse": 13.4754,
         "t_outdoor": 11.9339
       },
@@ -7598,9 +7598,9 @@
     {
       "time": 41400,
       "values": {
-        "t_tank_top": 28.5638,
-        "t_tank_bottom": 28.5624,
-        "t_collector": 33.2321,
+        "t_tank_top": 28.3426,
+        "t_tank_bottom": 28.3389,
+        "t_collector": 29.8794,
         "t_greenhouse": 13.4467,
         "t_outdoor": 11.9138
       },
@@ -7609,9 +7609,9 @@
     {
       "time": 41460,
       "values": {
-        "t_tank_top": 28.5614,
-        "t_tank_bottom": 28.56,
-        "t_collector": 33.0363,
+        "t_tank_top": 28.3401,
+        "t_tank_bottom": 28.3366,
+        "t_collector": 29.7433,
         "t_greenhouse": 13.4179,
         "t_outdoor": 11.8936
       },
@@ -7620,9 +7620,9 @@
     {
       "time": 41520,
       "values": {
-        "t_tank_top": 28.5589,
-        "t_tank_bottom": 28.5577,
-        "t_collector": 32.8375,
+        "t_tank_top": 28.3376,
+        "t_tank_bottom": 28.3344,
+        "t_collector": 29.6031,
         "t_greenhouse": 13.3891,
         "t_outdoor": 11.8734
       },
@@ -7631,9 +7631,9 @@
     {
       "time": 41580,
       "values": {
-        "t_tank_top": 28.5565,
-        "t_tank_bottom": 28.5553,
-        "t_collector": 32.6356,
+        "t_tank_top": 28.3351,
+        "t_tank_bottom": 28.3322,
+        "t_collector": 29.4588,
         "t_greenhouse": 13.3602,
         "t_outdoor": 11.8531
       },
@@ -7642,9 +7642,9 @@
     {
       "time": 41640,
       "values": {
-        "t_tank_top": 28.554,
-        "t_tank_bottom": 28.553,
-        "t_collector": 32.4308,
+        "t_tank_top": 28.3327,
+        "t_tank_bottom": 28.3299,
+        "t_collector": 29.3104,
         "t_greenhouse": 13.3312,
         "t_outdoor": 11.8328
       },
@@ -7653,9 +7653,9 @@
     {
       "time": 41700,
       "values": {
-        "t_tank_top": 28.5516,
-        "t_tank_bottom": 28.5506,
-        "t_collector": 32.223,
+        "t_tank_top": 28.3302,
+        "t_tank_bottom": 28.3276,
+        "t_collector": 29.1582,
         "t_greenhouse": 13.3022,
         "t_outdoor": 11.8125
       },
@@ -7664,9 +7664,9 @@
     {
       "time": 41760,
       "values": {
-        "t_tank_top": 28.5492,
-        "t_tank_bottom": 28.5483,
-        "t_collector": 32.0123,
+        "t_tank_top": 28.3277,
+        "t_tank_bottom": 28.3253,
+        "t_collector": 29.0021,
         "t_greenhouse": 13.2732,
         "t_outdoor": 11.7922
       },
@@ -7675,9 +7675,9 @@
     {
       "time": 41820,
       "values": {
-        "t_tank_top": 28.5467,
-        "t_tank_bottom": 28.5459,
-        "t_collector": 31.7989,
+        "t_tank_top": 28.3253,
+        "t_tank_bottom": 28.3231,
+        "t_collector": 28.8421,
         "t_greenhouse": 13.244,
         "t_outdoor": 11.7718
       },
@@ -7686,9 +7686,9 @@
     {
       "time": 41880,
       "values": {
-        "t_tank_top": 28.5443,
-        "t_tank_bottom": 28.5435,
-        "t_collector": 31.5826,
+        "t_tank_top": 28.3228,
+        "t_tank_bottom": 28.3208,
+        "t_collector": 28.6785,
         "t_greenhouse": 13.2148,
         "t_outdoor": 11.7514
       },
@@ -7697,9 +7697,9 @@
     {
       "time": 41940,
       "values": {
-        "t_tank_top": 28.5419,
-        "t_tank_bottom": 28.5411,
-        "t_collector": 31.3636,
+        "t_tank_top": 28.3204,
+        "t_tank_bottom": 28.3185,
+        "t_collector": 28.5112,
         "t_greenhouse": 13.1856,
         "t_outdoor": 11.7309
       },
@@ -7708,9 +7708,9 @@
     {
       "time": 42000,
       "values": {
-        "t_tank_top": 28.5394,
-        "t_tank_bottom": 28.5387,
-        "t_collector": 31.142,
+        "t_tank_top": 28.3179,
+        "t_tank_bottom": 28.3161,
+        "t_collector": 28.3403,
         "t_greenhouse": 13.1563,
         "t_outdoor": 11.7104
       },
@@ -7719,9 +7719,9 @@
     {
       "time": 42060,
       "values": {
-        "t_tank_top": 28.537,
-        "t_tank_bottom": 28.5364,
-        "t_collector": 30.9177,
+        "t_tank_top": 28.3155,
+        "t_tank_bottom": 28.3138,
+        "t_collector": 28.1658,
         "t_greenhouse": 13.1269,
         "t_outdoor": 11.6899
       },
@@ -7730,9 +7730,9 @@
     {
       "time": 42120,
       "values": {
-        "t_tank_top": 28.5346,
-        "t_tank_bottom": 28.534,
-        "t_collector": 30.6908,
+        "t_tank_top": 28.3131,
+        "t_tank_bottom": 28.3115,
+        "t_collector": 27.9878,
         "t_greenhouse": 13.0975,
         "t_outdoor": 11.6694
       },
@@ -7741,9 +7741,9 @@
     {
       "time": 42180,
       "values": {
-        "t_tank_top": 28.5321,
-        "t_tank_bottom": 28.5316,
-        "t_collector": 30.4613,
+        "t_tank_top": 28.3106,
+        "t_tank_bottom": 28.3092,
+        "t_collector": 27.8065,
         "t_greenhouse": 13.0681,
         "t_outdoor": 11.6488
       },
@@ -7752,9 +7752,9 @@
     {
       "time": 42240,
       "values": {
-        "t_tank_top": 28.5297,
-        "t_tank_bottom": 28.5292,
-        "t_collector": 30.2293,
+        "t_tank_top": 28.3082,
+        "t_tank_bottom": 28.3068,
+        "t_collector": 27.6217,
         "t_greenhouse": 13.0385,
         "t_outdoor": 11.6282
       },
@@ -7763,9 +7763,9 @@
     {
       "time": 42300,
       "values": {
-        "t_tank_top": 28.5272,
-        "t_tank_bottom": 28.5268,
-        "t_collector": 29.9949,
+        "t_tank_top": 28.3057,
+        "t_tank_bottom": 28.3045,
+        "t_collector": 27.4337,
         "t_greenhouse": 13.009,
         "t_outdoor": 11.6075
       },
@@ -7774,9 +7774,9 @@
     {
       "time": 42360,
       "values": {
-        "t_tank_top": 28.5248,
-        "t_tank_bottom": 28.5243,
-        "t_collector": 29.758,
+        "t_tank_top": 28.3033,
+        "t_tank_bottom": 28.3021,
+        "t_collector": 27.2424,
         "t_greenhouse": 12.9793,
         "t_outdoor": 11.5869
       },
@@ -7785,9 +7785,9 @@
     {
       "time": 42420,
       "values": {
-        "t_tank_top": 28.5224,
-        "t_tank_bottom": 28.5219,
-        "t_collector": 29.5188,
+        "t_tank_top": 28.3009,
+        "t_tank_bottom": 28.2998,
+        "t_collector": 27.0479,
         "t_greenhouse": 12.9496,
         "t_outdoor": 11.5662
       },
@@ -7796,9 +7796,9 @@
     {
       "time": 42480,
       "values": {
-        "t_tank_top": 28.5199,
-        "t_tank_bottom": 28.5195,
-        "t_collector": 29.2772,
+        "t_tank_top": 28.2984,
+        "t_tank_bottom": 28.2974,
+        "t_collector": 26.8503,
         "t_greenhouse": 12.9199,
         "t_outdoor": 11.5454
       },
@@ -7807,9 +7807,9 @@
     {
       "time": 42540,
       "values": {
-        "t_tank_top": 28.5175,
-        "t_tank_bottom": 28.5171,
-        "t_collector": 29.0333,
+        "t_tank_top": 28.296,
+        "t_tank_bottom": 28.295,
+        "t_collector": 26.6495,
         "t_greenhouse": 12.8901,
         "t_outdoor": 11.5247
       },
@@ -7818,9 +7818,9 @@
     {
       "time": 42600,
       "values": {
-        "t_tank_top": 28.515,
-        "t_tank_bottom": 28.5147,
-        "t_collector": 28.7872,
+        "t_tank_top": 28.2935,
+        "t_tank_bottom": 28.2927,
+        "t_collector": 26.4458,
         "t_greenhouse": 12.8603,
         "t_outdoor": 11.5039
       },
@@ -7829,9 +7829,9 @@
     {
       "time": 42660,
       "values": {
-        "t_tank_top": 28.5126,
-        "t_tank_bottom": 28.5122,
-        "t_collector": 28.5388,
+        "t_tank_top": 28.2911,
+        "t_tank_bottom": 28.2903,
+        "t_collector": 26.2391,
         "t_greenhouse": 12.8304,
         "t_outdoor": 11.4831
       },
@@ -7840,9 +7840,9 @@
     {
       "time": 42720,
       "values": {
-        "t_tank_top": 28.5101,
-        "t_tank_bottom": 28.5098,
-        "t_collector": 28.2882,
+        "t_tank_top": 28.2887,
+        "t_tank_bottom": 28.2879,
+        "t_collector": 26.0294,
         "t_greenhouse": 12.8004,
         "t_outdoor": 11.4622
       },
@@ -7851,9 +7851,9 @@
     {
       "time": 42780,
       "values": {
-        "t_tank_top": 28.5076,
-        "t_tank_bottom": 28.5074,
-        "t_collector": 28.0355,
+        "t_tank_top": 28.2862,
+        "t_tank_bottom": 28.2855,
+        "t_collector": 25.8169,
         "t_greenhouse": 12.7704,
         "t_outdoor": 11.4413
       },
@@ -7862,9 +7862,9 @@
     {
       "time": 42840,
       "values": {
-        "t_tank_top": 28.5052,
-        "t_tank_bottom": 28.5049,
-        "t_collector": 27.7807,
+        "t_tank_top": 28.2838,
+        "t_tank_bottom": 28.2831,
+        "t_collector": 25.6015,
         "t_greenhouse": 12.7404,
         "t_outdoor": 11.4204
       },
@@ -7873,9 +7873,9 @@
     {
       "time": 42900,
       "values": {
-        "t_tank_top": 28.5027,
-        "t_tank_bottom": 28.5025,
-        "t_collector": 27.5238,
+        "t_tank_top": 28.2814,
+        "t_tank_bottom": 28.2807,
+        "t_collector": 25.3834,
         "t_greenhouse": 12.7103,
         "t_outdoor": 11.3995
       },
@@ -7884,9 +7884,9 @@
     {
       "time": 42960,
       "values": {
-        "t_tank_top": 28.5003,
-        "t_tank_bottom": 28.5001,
-        "t_collector": 27.2648,
+        "t_tank_top": 28.2789,
+        "t_tank_bottom": 28.2783,
+        "t_collector": 25.1626,
         "t_greenhouse": 12.6801,
         "t_outdoor": 11.3785
       },
@@ -7895,9 +7895,9 @@
     {
       "time": 43020,
       "values": {
-        "t_tank_top": 28.4978,
-        "t_tank_bottom": 28.4976,
-        "t_collector": 27.0039,
+        "t_tank_top": 28.2765,
+        "t_tank_bottom": 28.2759,
+        "t_collector": 24.939,
         "t_greenhouse": 12.65,
         "t_outdoor": 11.3576
       },
@@ -7906,9 +7906,9 @@
     {
       "time": 43080,
       "values": {
-        "t_tank_top": 28.4953,
-        "t_tank_bottom": 28.4952,
-        "t_collector": 26.741,
+        "t_tank_top": 28.274,
+        "t_tank_bottom": 28.2735,
+        "t_collector": 24.7128,
         "t_greenhouse": 12.6197,
         "t_outdoor": 11.3365
       },
@@ -7917,9 +7917,9 @@
     {
       "time": 43140,
       "values": {
-        "t_tank_top": 28.4929,
-        "t_tank_bottom": 28.4927,
-        "t_collector": 26.4761,
+        "t_tank_top": 28.2716,
+        "t_tank_bottom": 28.2711,
+        "t_collector": 24.4841,
         "t_greenhouse": 12.5894,
         "t_outdoor": 11.3155
       },
@@ -7928,9 +7928,9 @@
     {
       "time": 43200,
       "values": {
-        "t_tank_top": 28.4904,
-        "t_tank_bottom": 28.4902,
-        "t_collector": 26.2094,
+        "t_tank_top": 28.2691,
+        "t_tank_bottom": 28.2687,
+        "t_collector": 24.2528,
         "t_greenhouse": 12.5591,
         "t_outdoor": 11.2944
       },
@@ -7946,99 +7946,27 @@
     },
     {
       "kind": "sim",
-      "time": 1279,
-      "text": "solar_charging → idle | delta=2.0°C < 2°C threshold | T_coll=12.3 T_top=11.4 T_bot=10.3 T_gh=10.7 T_out=9.2",
+      "time": 1489,
+      "text": "solar_charging → idle | tank stopped rising (peak T_top=11.5°C, now 11.4°C, drop 0.1°C) | T_coll=12.1 T_top=11.4 T_bot=10.4 T_gh=10.7 T_out=9.2",
       "mode": "idle"
     },
     {
       "kind": "sim",
-      "time": 1947,
-      "text": "idle → solar_charging | delta=10.0°C > 10°C threshold | T_coll=20.6 T_top=11.1 T_bot=10.6 T_gh=10.8 T_out=9.4",
+      "time": 2157,
+      "text": "idle → solar_charging | delta=10.0°C > 10°C threshold | T_coll=20.7 T_top=11.1 T_bot=10.7 T_gh=10.8 T_out=9.5",
       "mode": "solar_charging"
     },
     {
       "kind": "sim",
-      "time": 2409,
-      "text": "solar_charging → idle | delta=2.0°C < 2°C threshold | T_coll=12.8 T_top=11.8 T_bot=10.8 T_gh=10.8 T_out=9.6",
-      "mode": "idle"
-    },
-    {
-      "kind": "sim",
-      "time": 2996,
-      "text": "idle → solar_charging | delta=10.0°C > 10°C threshold | T_coll=21.1 T_top=11.5 T_bot=11.1 T_gh=11.0 T_out=9.8",
-      "mode": "solar_charging"
-    },
-    {
-      "kind": "sim",
-      "time": 30416,
-      "text": "solar_charging → idle | delta=2.0°C < 2°C threshold | T_coll=28.6 T_top=27.3 T_bot=26.6 T_gh=17.2 T_out=14.6",
-      "mode": "idle"
-    },
-    {
-      "kind": "sim",
-      "time": 30989,
-      "text": "idle → solar_charging | delta=10.0°C > 10°C threshold | T_coll=36.8 T_top=27.1 T_bot=26.8 T_gh=17.1 T_out=14.6",
-      "mode": "solar_charging"
-    },
-    {
-      "kind": "sim",
-      "time": 31451,
-      "text": "solar_charging → idle | delta=2.0°C < 2°C threshold | T_coll=29.0 T_top=27.8 T_bot=27.0 T_gh=17.0 T_out=14.5",
-      "mode": "idle"
-    },
-    {
-      "kind": "sim",
-      "time": 32098,
-      "text": "idle → solar_charging | delta=10.0°C > 10°C threshold | T_coll=37.2 T_top=27.6 T_bot=27.2 T_gh=16.9 T_out=14.4",
-      "mode": "solar_charging"
-    },
-    {
-      "kind": "sim",
-      "time": 32478,
-      "text": "solar_charging → idle | delta=2.0°C < 2°C threshold | T_coll=29.3 T_top=28.2 T_bot=27.4 T_gh=16.8 T_out=14.3",
-      "mode": "idle"
-    },
-    {
-      "kind": "sim",
-      "time": 33224,
-      "text": "idle → solar_charging | delta=10.0°C > 10°C threshold | T_coll=37.6 T_top=27.9 T_bot=27.6 T_gh=16.6 T_out=14.2",
-      "mode": "solar_charging"
-    },
-    {
-      "kind": "sim",
-      "time": 33554,
-      "text": "solar_charging → idle | delta=2.0°C < 2°C threshold | T_coll=29.7 T_top=28.5 T_bot=27.7 T_gh=16.5 T_out=14.1",
-      "mode": "idle"
-    },
-    {
-      "kind": "sim",
-      "time": 34451,
-      "text": "idle → solar_charging | delta=10.0°C > 10°C threshold | T_coll=38.0 T_top=28.2 T_bot=28.0 T_gh=16.2 T_out=13.9",
-      "mode": "solar_charging"
-    },
-    {
-      "kind": "sim",
-      "time": 34751,
-      "text": "solar_charging → idle | delta=1.9°C < 2°C threshold | T_coll=30.0 T_top=28.8 T_bot=28.1 T_gh=16.1 T_out=13.8",
-      "mode": "idle"
-    },
-    {
-      "kind": "sim",
-      "time": 35952,
-      "text": "idle → solar_charging | delta=10.0°C > 10°C threshold | T_coll=38.3 T_top=28.5 T_bot=28.3 T_gh=15.7 T_out=13.5",
-      "mode": "solar_charging"
-    },
-    {
-      "kind": "sim",
-      "time": 36252,
-      "text": "solar_charging → idle | delta=1.7°C < 2°C threshold | T_coll=30.1 T_top=29.1 T_bot=28.4 T_gh=15.6 T_out=13.5",
+      "time": 38243,
+      "text": "solar_charging → idle | tank stopped rising (peak T_top=28.5°C, now 28.5°C, drop 0.0°C) | T_coll=28.9 T_top=28.5 T_bot=28.4 T_gh=14.9 T_out=12.9",
       "mode": "idle"
     }
   ],
   "final_model_state": {
-    "t_tank_top": 28.4904,
-    "t_tank_bottom": 28.4902,
-    "t_collector": 26.2094,
+    "t_tank_top": 28.2691,
+    "t_tank_bottom": 28.2687,
+    "t_collector": 24.2528,
     "t_greenhouse": 12.5591,
     "t_outdoor": 11.2944,
     "irradiance": 0.0312,
@@ -8046,9 +7974,11 @@
   },
   "final_controller_state": {
     "currentMode": "idle",
-    "modeStartTime": 36252,
+    "modeStartTime": 38243,
     "collectorsDrained": false,
     "lastRefillAttempt": 0,
-    "emergencyHeatingActive": false
+    "emergencyHeatingActive": false,
+    "solarChargePeakTankTop": null,
+    "solarChargePeakTankTopAt": 0
   }
 }

--- a/playground/js/control.js
+++ b/playground/js/control.js
@@ -34,6 +34,12 @@ export class ControlStateMachine {
     this.collectorsDrained = false;
     this.lastRefillAttempt = 0;
     this.emergencyHeatingActive = false;
+    // Solar-charging tank-rise tracking (mirrors evaluate() flags).
+    // Reset each time we leave SOLAR_CHARGING; carried across ticks
+    // while we are in solar charging so the no-rise-for-5-min and
+    // tank-dropped-2°C exit conditions can fire.
+    this.solarChargePeakTankTop = null;
+    this.solarChargePeakTankTopAt = 0;
     this.transitionLog = [];
   }
 
@@ -58,6 +64,8 @@ export class ControlStateMachine {
       collectorsDrained: this.collectorsDrained,
       lastRefillAttempt: this.lastRefillAttempt,
       emergencyHeatingActive: this.emergencyHeatingActive,
+      solarChargePeakTankTop: this.solarChargePeakTankTop,
+      solarChargePeakTankTopAt: this.solarChargePeakTankTopAt,
       sensorAge: { collector: 0, tank_top: 0, tank_bottom: 0, greenhouse: 0, outdoor: 0 },
     };
   }
@@ -72,6 +80,9 @@ export class ControlStateMachine {
     const prevMode = this.currentMode;
     const sensorStr = this._sensorSummary(sensors);
     const shellyState = this._buildShellyState(sensors, simTime);
+    // Snapshot peak before evaluate() resets it so the transition log
+    // can describe the session that just ended.
+    const prevPeak = this.solarChargePeakTankTop;
 
     // Delegate decision to the real Shelly control logic
     const result = _evaluate(shellyState, null);
@@ -81,11 +92,13 @@ export class ControlStateMachine {
     this.collectorsDrained = result.flags.collectorsDrained;
     this.lastRefillAttempt = result.flags.lastRefillAttempt;
     this.emergencyHeatingActive = result.flags.emergencyHeatingActive;
+    this.solarChargePeakTankTop = result.flags.solarChargePeakTankTop;
+    this.solarChargePeakTankTopAt = result.flags.solarChargePeakTankTopAt;
 
     // Build transition log entry
     let transition = null;
     if (nextMode !== prevMode) {
-      transition = this._describeTransition(prevMode, nextMode, sensors, sensorStr);
+      transition = this._describeTransition(prevMode, nextMode, sensors, sensorStr, prevPeak);
       this.currentMode = nextMode;
       this.modeStartTime = simTime;
       this.transitionLog.push({ time: simTime, transition });
@@ -105,7 +118,7 @@ export class ControlStateMachine {
   }
 
   /** Human-readable transition description for the log panel */
-  _describeTransition(from, to, sensors, sensorStr) {
+  _describeTransition(from, to, sensors, sensorStr, prevSolarPeak) {
     const s = sensors;
     const delta = (s.t_collector - s.t_tank_bottom).toFixed(1);
 
@@ -134,7 +147,12 @@ export class ControlStateMachine {
       return `greenhouse_heating → idle | T_gh=${s.t_greenhouse.toFixed(1)}°C > 12°C | ${sensorStr}`;
     }
     if (from === 'solar_charging' && to === 'idle') {
-      return `solar_charging → idle | delta=${delta}°C < 2°C threshold | ${sensorStr}`;
+      const peak = (typeof prevSolarPeak === 'number') ? prevSolarPeak : null;
+      if (peak !== null) {
+        const drop = (peak - s.t_tank_top).toFixed(1);
+        return `solar_charging → idle | tank stopped rising (peak T_top=${peak.toFixed(1)}°C, now ${s.t_tank_top.toFixed(1)}°C, drop ${drop}°C) | ${sensorStr}`;
+      }
+      return `solar_charging → idle | tank stopped rising | ${sensorStr}`;
     }
     if (from === 'emergency_heating' && to === 'idle') {
       return `emergency_heating → idle | T_gh=${s.t_greenhouse.toFixed(1)}°C > 12°C | ${sensorStr}`;
@@ -148,6 +166,8 @@ export class ControlStateMachine {
     this.collectorsDrained = false;
     this.lastRefillAttempt = 0;
     this.emergencyHeatingActive = false;
+    this.solarChargePeakTankTop = null;
+    this.solarChargePeakTankTopAt = 0;
     this.transitionLog = [];
   }
 }

--- a/playground/js/main.js
+++ b/playground/js/main.js
@@ -1369,6 +1369,10 @@ function restoreBootstrapSnapshot(snapshot) {
   controller.collectorsDrained = fcs.collectorsDrained;
   controller.lastRefillAttempt = fcs.lastRefillAttempt;
   controller.emergencyHeatingActive = fcs.emergencyHeatingActive;
+  controller.solarChargePeakTankTop = (fcs.solarChargePeakTankTop !== undefined)
+    ? fcs.solarChargePeakTankTop
+    : null;
+  controller.solarChargePeakTankTopAt = fcs.solarChargePeakTankTopAt || 0;
 
   // Push the historical points + log entries into the UI stores.
   // resetSim() already cleared both, so we can just append.

--- a/scripts/generate-bootstrap-history.mjs
+++ b/scripts/generate-bootstrap-history.mjs
@@ -178,6 +178,8 @@ export function generate() {
     collectorsDrained: !!controller.collectorsDrained,
     lastRefillAttempt: controller.lastRefillAttempt,
     emergencyHeatingActive: !!controller.emergencyHeatingActive,
+    solarChargePeakTankTop: controller.solarChargePeakTankTop,
+    solarChargePeakTankTopAt: controller.solarChargePeakTankTopAt,
   };
 
   return {

--- a/shelly/control-logic.js
+++ b/shelly/control-logic.js
@@ -84,7 +84,13 @@ var VALVE_TIMING = {
 
 var DEFAULT_CONFIG = {
   solarEnterDelta: 10,
-  solarExitDelta: 2,
+  // Solar charging exits when the tank has stopped accepting heat:
+  //   - tank_top has not risen for solarExitStallSeconds, OR
+  //   - tank_top has dropped solarExitTankDrop °C from the session peak
+  // This replaces the old collector/tank_bottom delta exit so we keep
+  // pumping until the tank itself signals diminishing returns.
+  solarExitTankDrop: 2,
+  solarExitStallSeconds: 300,
   greenhouseEnterTemp: 10,
   greenhouseExitTemp: 12,
   greenhouseMinTankDelta: 5,
@@ -205,12 +211,42 @@ function evaluate(state, config, deviceConfig) {
   var flags = {
     collectorsDrained: state.collectorsDrained,
     lastRefillAttempt: state.lastRefillAttempt,
-    emergencyHeatingActive: state.emergencyHeatingActive || false
+    emergencyHeatingActive: state.emergencyHeatingActive || false,
+    // Solar-charging tank-rise tracking. Carried forward only while we
+    // remain in SOLAR_CHARGING — cleared whenever pumpMode ends up
+    // anything else (see end of function).
+    solarChargePeakTankTop: null,
+    solarChargePeakTankTopAt: 0
   };
+
+  // Carry forward and update peak tank_top while in SOLAR_CHARGING. We
+  // do this before the min-duration hold so peakAt advances during the
+  // hold — otherwise the stall counter would fire the instant the hold
+  // expires.
+  if (state.currentMode === MODES.SOLAR_CHARGING) {
+    var carriedPeak = (state.solarChargePeakTankTop !== undefined &&
+                       state.solarChargePeakTankTop !== null)
+      ? state.solarChargePeakTankTop
+      : null;
+    var carriedPeakAt = state.solarChargePeakTankTopAt || 0;
+    if (t.tank_top !== null) {
+      if (carriedPeak === null || t.tank_top > carriedPeak) {
+        carriedPeak = t.tank_top;
+        carriedPeakAt = state.now;
+      } else if (carriedPeakAt === 0) {
+        // First eval after entry where peak wasn't seeded — anchor now
+        carriedPeakAt = state.now;
+      }
+    }
+    flags.solarChargePeakTankTop = carriedPeak;
+    flags.solarChargePeakTankTopAt = carriedPeakAt;
+  }
 
   // Sensor staleness — any sensor stale triggers IDLE, emergency off
   if (anySensorStale(state.sensorAge, cfg.sensorStaleThreshold)) {
     flags.emergencyHeatingActive = false;
+    flags.solarChargePeakTankTop = null;
+    flags.solarChargePeakTankTopAt = 0;
     return makeResult(MODES.IDLE, flags, dc);
   }
 
@@ -227,6 +263,8 @@ function evaluate(state, config, deviceConfig) {
   // safetyOverride=true: MUST NOT be suppressed by device config
   if (t.outdoor !== null && t.outdoor < cfg.freezeDrainTemp &&
       !state.collectorsDrained) {
+    flags.solarChargePeakTankTop = null;
+    flags.solarChargePeakTankTopAt = 0;
     return makeResult(MODES.ACTIVE_DRAIN, flags, dc, true);
   }
 
@@ -236,6 +274,8 @@ function evaluate(state, config, deviceConfig) {
   // safetyOverride=true: MUST NOT be suppressed by device config
   if (t.collector !== null && t.collector > cfg.overheatDrainTemp &&
       state.currentMode === MODES.SOLAR_CHARGING && !state.collectorsDrained) {
+    flags.solarChargePeakTankTop = null;
+    flags.solarChargePeakTankTopAt = 0;
     return makeResult(MODES.ACTIVE_DRAIN, flags, dc, true);
   }
 
@@ -272,14 +312,35 @@ function evaluate(state, config, deviceConfig) {
   // Solar charging — capture free energy first
   if (t.collector !== null && t.tank_bottom !== null) {
     if (state.currentMode === MODES.SOLAR_CHARGING) {
-      if (t.collector >= t.tank_bottom + cfg.solarExitDelta) {
+      // Stay in solar charging until the tank stops accepting heat.
+      // We keep pumping even when collector ≈ tank_bottom because the
+      // collector continues absorbing irradiance while flow is on, and
+      // the tank itself is the most direct signal of whether we are
+      // still gaining energy. Two exit conditions:
+      //   1. tank_top has not exceeded the session peak for the past
+      //      cfg.solarExitStallSeconds seconds (stall), OR
+      //   2. tank_top has dropped >= cfg.solarExitTankDrop °C from the
+      //      session peak (we're actively cooling the tank).
+      var stalled = false;
+      var droppedFromPeak = false;
+      if (t.tank_top !== null && flags.solarChargePeakTankTop !== null) {
+        droppedFromPeak =
+          (flags.solarChargePeakTankTop - t.tank_top) >= cfg.solarExitTankDrop;
+        stalled =
+          (state.now - flags.solarChargePeakTankTopAt) >= cfg.solarExitStallSeconds;
+      }
+      if (!stalled && !droppedFromPeak) {
         pumpMode = MODES.SOLAR_CHARGING;
       }
-      // Below exit delta, fall through to IDLE
+      // Otherwise fall through to IDLE / other modes
     } else if (!state.collectorsDrained) {
-      // Normal solar entry
+      // Normal solar entry — collector clearly hotter than tank bottom
       if (t.collector > t.tank_bottom + cfg.solarEnterDelta) {
         pumpMode = MODES.SOLAR_CHARGING;
+        if (t.tank_top !== null) {
+          flags.solarChargePeakTankTop = t.tank_top;
+          flags.solarChargePeakTankTopAt = state.now;
+        }
       }
     } else {
       // Speculative refill — collectors drained, conditions suggest daylight
@@ -289,6 +350,10 @@ function evaluate(state, config, deviceConfig) {
           flags.collectorsDrained = false;
           flags.lastRefillAttempt = state.now;
           pumpMode = MODES.SOLAR_CHARGING;
+          if (t.tank_top !== null) {
+            flags.solarChargePeakTankTop = t.tank_top;
+            flags.solarChargePeakTankTopAt = state.now;
+          }
         }
       }
     }
@@ -315,6 +380,16 @@ function evaluate(state, config, deviceConfig) {
   if (t.collector !== null && t.collector > cfg.overheatDrainTemp &&
       !state.collectorsDrained && pumpMode !== MODES.SOLAR_CHARGING) {
     pumpMode = MODES.SOLAR_CHARGING;
+    if (t.tank_top !== null && flags.solarChargePeakTankTop === null) {
+      flags.solarChargePeakTankTop = t.tank_top;
+      flags.solarChargePeakTankTopAt = state.now;
+    }
+  }
+
+  // Clear peak tracking if we are not staying in / entering SOLAR_CHARGING
+  if (pumpMode !== MODES.SOLAR_CHARGING) {
+    flags.solarChargePeakTankTop = null;
+    flags.solarChargePeakTankTopAt = 0;
   }
 
   // ── Forced mode override (for staged deployment / manual testing) ──
@@ -323,6 +398,10 @@ function evaluate(state, config, deviceConfig) {
     if (MODES[forcedMode]) {
       pumpMode = MODES[forcedMode];
       flags.emergencyHeatingActive = false;
+      if (pumpMode !== MODES.SOLAR_CHARGING) {
+        flags.solarChargePeakTankTop = null;
+        flags.solarChargePeakTankTopAt = 0;
+      }
       return makeResult(pumpMode, flags, dc);
     }
   }
@@ -347,6 +426,8 @@ function evaluate(state, config, deviceConfig) {
       }
     }
     if (!allowed) {
+      flags.solarChargePeakTankTop = null;
+      flags.solarChargePeakTankTopAt = 0;
       return makeResult(MODES.IDLE, flags, dc);
     }
   }

--- a/shelly/control.js
+++ b/shelly/control.js
@@ -43,6 +43,11 @@ var state = {
   collectors_drained: false,
   last_refill_attempt: 0,
   emergency_heating_active: false,
+  // Solar-charging tank-rise tracking (mirrors evaluate() flags). Tank
+  // top temperature is tracked so we can keep pumping until the tank
+  // stops accepting heat (no rise for 5 min, or 2°C drop from peak).
+  solar_charge_peak_tank_top: null,
+  solar_charge_peak_tank_top_at: 0,
   last_error: null,
   valve_states: {},
   pump_on: false,
@@ -282,6 +287,8 @@ function buildEvalState() {
     collectorsDrained: state.collectors_drained,
     lastRefillAttempt: state.last_refill_attempt / 1000,
     emergencyHeatingActive: state.emergency_heating_active,
+    solarChargePeakTankTop: state.solar_charge_peak_tank_top,
+    solarChargePeakTankTopAt: state.solar_charge_peak_tank_top_at,
     sensorAge: sensorAge,
   };
 }
@@ -300,6 +307,9 @@ function applyFlags(flags) {
   state.collectors_drained = flags.collectorsDrained;
   state.last_refill_attempt = flags.lastRefillAttempt * 1000;
   state.emergency_heating_active = flags.emergencyHeatingActive;
+  state.solar_charge_peak_tank_top =
+    flags.solarChargePeakTankTop !== undefined ? flags.solarChargePeakTankTop : null;
+  state.solar_charge_peak_tank_top_at = flags.solarChargePeakTankTopAt || 0;
 }
 
 // ── Staged transitions (023-limit-valve-operations) ──
@@ -593,7 +603,9 @@ function stopDrain(reason) {
     flags: {
       collectorsDrained: true,
       lastRefillAttempt: state.last_refill_attempt / 1000,
-      emergencyHeatingActive: false
+      emergencyHeatingActive: false,
+      solarChargePeakTankTop: null,
+      solarChargePeakTankTopAt: 0
     },
     suppressed: false,
     safetyOverride: false

--- a/tests/control-logic.test.js
+++ b/tests/control-logic.test.js
@@ -81,22 +81,104 @@ describe('hysteresis', () => {
     assert.strictEqual(result.nextMode, MODES.IDLE);
   });
 
-  it('stays in solar at exact exit threshold (collector = tank_bottom + 2)', () => {
+  it('stays in solar even when collector falls below tank_bottom + 2 if tank still rising', () => {
+    // New exit criteria: stay in solar until tank_top stops rising for 5 min
+    // or drops 2°C from peak — NOT based on collector/tank_bottom delta.
+    // Here the collector is barely warmer than tank_bottom but tank_top just
+    // rose, so we keep harvesting.
     const result = evaluate(makeState({
-      temps: { collector: 32, tank_top: 40, tank_bottom: 30, greenhouse: 15, outdoor: 10 },
+      temps: { collector: 31, tank_top: 41, tank_bottom: 30, greenhouse: 15, outdoor: 10 },
       currentMode: MODES.SOLAR_CHARGING,
-      modeEnteredAt: 0, now: 2000
+      modeEnteredAt: 0, now: 2000,
+      solarChargePeakTankTop: 40,
+      solarChargePeakTankTopAt: 1500
     }), null);
     assert.strictEqual(result.nextMode, MODES.SOLAR_CHARGING);
   });
 
-  it('exits solar when collector < tank_bottom + 2', () => {
+  it('exits solar when tank_top has not risen for 5 minutes', () => {
+    // Peak was set 5 minutes ago and tank_top has not exceeded it since
     const result = evaluate(makeState({
-      temps: { collector: 31, tank_top: 40, tank_bottom: 30, greenhouse: 15, outdoor: 10 },
+      temps: { collector: 50, tank_top: 40, tank_bottom: 30, greenhouse: 15, outdoor: 10 },
       currentMode: MODES.SOLAR_CHARGING,
-      modeEnteredAt: 0, now: 2000
+      modeEnteredAt: 0, now: 2000,
+      solarChargePeakTankTop: 40,
+      solarChargePeakTankTopAt: 1700  // 300s ago
     }), null);
     assert.strictEqual(result.nextMode, MODES.IDLE);
+  });
+
+  it('exits solar when tank_top dropped 2°C from session peak', () => {
+    const result = evaluate(makeState({
+      temps: { collector: 50, tank_top: 38, tank_bottom: 30, greenhouse: 15, outdoor: 10 },
+      currentMode: MODES.SOLAR_CHARGING,
+      modeEnteredAt: 0, now: 2000,
+      solarChargePeakTankTop: 40,
+      solarChargePeakTankTopAt: 1900  // recent — stall not yet triggered
+    }), null);
+    assert.strictEqual(result.nextMode, MODES.IDLE);
+  });
+
+  it('stays in solar when tank_top has not stalled and has not dropped 2°C', () => {
+    // Tank dropped 1.5°C — under threshold; stall not yet 5 min
+    const result = evaluate(makeState({
+      temps: { collector: 18, tank_top: 38.5, tank_bottom: 30, greenhouse: 15, outdoor: 10 },
+      currentMode: MODES.SOLAR_CHARGING,
+      modeEnteredAt: 0, now: 2000,
+      solarChargePeakTankTop: 40,
+      solarChargePeakTankTopAt: 1850  // 150s ago
+    }), null);
+    assert.strictEqual(result.nextMode, MODES.SOLAR_CHARGING);
+  });
+
+  it('records peak tank_top on solar entry', () => {
+    const result = evaluate(makeState({
+      temps: { collector: 41, tank_top: 40, tank_bottom: 30, greenhouse: 15, outdoor: 10 },
+      currentMode: MODES.IDLE,
+      now: 2000
+    }), null);
+    assert.strictEqual(result.nextMode, MODES.SOLAR_CHARGING);
+    assert.strictEqual(result.flags.solarChargePeakTankTop, 40);
+    assert.strictEqual(result.flags.solarChargePeakTankTopAt, 2000);
+  });
+
+  it('updates peak tank_top during a session as tank rises', () => {
+    const result = evaluate(makeState({
+      temps: { collector: 50, tank_top: 42, tank_bottom: 30, greenhouse: 15, outdoor: 10 },
+      currentMode: MODES.SOLAR_CHARGING,
+      modeEnteredAt: 0, now: 2000,
+      solarChargePeakTankTop: 40,
+      solarChargePeakTankTopAt: 1500
+    }), null);
+    assert.strictEqual(result.nextMode, MODES.SOLAR_CHARGING);
+    assert.strictEqual(result.flags.solarChargePeakTankTop, 42);
+    assert.strictEqual(result.flags.solarChargePeakTankTopAt, 2000);
+  });
+
+  it('keeps peak unchanged if tank_top did not rise', () => {
+    const result = evaluate(makeState({
+      temps: { collector: 50, tank_top: 39.5, tank_bottom: 30, greenhouse: 15, outdoor: 10 },
+      currentMode: MODES.SOLAR_CHARGING,
+      modeEnteredAt: 0, now: 2000,
+      solarChargePeakTankTop: 40,
+      solarChargePeakTankTopAt: 1900
+    }), null);
+    assert.strictEqual(result.nextMode, MODES.SOLAR_CHARGING);
+    assert.strictEqual(result.flags.solarChargePeakTankTop, 40);
+    assert.strictEqual(result.flags.solarChargePeakTankTopAt, 1900);
+  });
+
+  it('clears peak tracking when leaving solar charging', () => {
+    const result = evaluate(makeState({
+      temps: { collector: 50, tank_top: 38, tank_bottom: 30, greenhouse: 15, outdoor: 10 },
+      currentMode: MODES.SOLAR_CHARGING,
+      modeEnteredAt: 0, now: 2000,
+      solarChargePeakTankTop: 40,
+      solarChargePeakTankTopAt: 1900
+    }), null);
+    assert.strictEqual(result.nextMode, MODES.IDLE);
+    assert.strictEqual(result.flags.solarChargePeakTankTop, null);
+    assert.strictEqual(result.flags.solarChargePeakTankTopAt, 0);
   });
 
   it('enters greenhouse heating at greenhouse < 10 with hot tank', () => {
@@ -199,19 +281,25 @@ describe('hysteresis', () => {
 
 describe('minimum duration', () => {
   it('holds mode for minimum time even if exit conditions met', () => {
+    // Tank dropped 2°C from peak — would normally trigger exit, but min hold blocks it
     const result = evaluate(makeState({
-      temps: { collector: 32, tank_top: 40, tank_bottom: 30, greenhouse: 15, outdoor: 10 },
+      temps: { collector: 18, tank_top: 38, tank_bottom: 30, greenhouse: 15, outdoor: 10 },
       currentMode: MODES.SOLAR_CHARGING,
-      modeEnteredAt: 900, now: 1000  // only 100s elapsed, min is 300
+      modeEnteredAt: 900, now: 1000,  // only 100s elapsed, min is 300
+      solarChargePeakTankTop: 40,
+      solarChargePeakTankTopAt: 950
     }), null);
     assert.strictEqual(result.nextMode, MODES.SOLAR_CHARGING);
   });
 
   it('allows exit after minimum duration', () => {
+    // Tank dropped 2°C from peak — exit allowed since min duration elapsed
     const result = evaluate(makeState({
-      temps: { collector: 31, tank_top: 40, tank_bottom: 30, greenhouse: 15, outdoor: 10 },
+      temps: { collector: 18, tank_top: 38, tank_bottom: 30, greenhouse: 15, outdoor: 10 },
       currentMode: MODES.SOLAR_CHARGING,
-      modeEnteredAt: 0, now: 1000  // 1000s elapsed > 300 min
+      modeEnteredAt: 0, now: 1000,  // 1000s elapsed > 300 min
+      solarChargePeakTankTop: 40,
+      solarChargePeakTankTopAt: 800
     }), null);
     assert.strictEqual(result.nextMode, MODES.IDLE);
   });

--- a/tests/notifications.test.js
+++ b/tests/notifications.test.js
@@ -8,6 +8,18 @@ describe('notifications', () => {
     delete require.cache[require.resolve('../server/lib/notifications.js')];
     notifications = require('../server/lib/notifications.js');
     notifications._reset();
+    // Suppress scheduled noon (12:00 EE[S]T) and evening (20:00 EE[S]T)
+    // reports for every subsuite. CI runs at the top of the noon hour
+    // every day, which would otherwise cause checkNoonReport() to fire
+    // a 'noon_report' inside any test that calls evaluate(). The
+    // overheat/freeze tests filter by notification type so the extra
+    // entry is harmless there, but it has been the source of repeated
+    // CI flakes (see commit 0478d16) and any future spurious-count
+    // assertion would be silently broken. Mark today as already-sent so
+    // the gate `day === lastNoonReport` returns early.
+    var today = Math.floor((Date.now() - new Date(new Date().getFullYear(), 0, 0)) / 86400000);
+    notifications._setLastEveningReport(today);
+    notifications._setLastNoonReport(today);
   });
 
   describe('predictValue (linear extrapolation)', () => {
@@ -212,10 +224,6 @@ describe('notifications', () => {
         },
       };
       notifications.init({ push: mockPush, deviceConfig: null });
-      // Suppress scheduled reports (which would fire if test runs at 12:00 or 20:00)
-      var today = Math.floor((Date.now() - new Date(new Date().getFullYear(), 0, 0)) / 86400000);
-      notifications._setLastEveningReport(today);
-      notifications._setLastNoonReport(today);
     });
 
     it('does not send any notification for normal temperatures', () => {
@@ -241,10 +249,6 @@ describe('notifications', () => {
         },
       };
       notifications.init({ push: mockPush, deviceConfig: null });
-      // Suppress scheduled reports (which would fire if test runs at 12:00 or 20:00)
-      var today = Math.floor((Date.now() - new Date(new Date().getFullYear(), 0, 0)) / 86400000);
-      notifications._setLastEveningReport(today);
-      notifications._setLastNoonReport(today);
     });
 
     it('does not send offline notification before 15 minutes', () => {

--- a/tests/simulation/simulator.js
+++ b/tests/simulation/simulator.js
@@ -21,6 +21,8 @@ function simulate(scenario, config) {
   let modeEnteredAt = 0;
   let collectorsDrained = initTemps.collectorsDrained || false;
   let lastRefillAttempt = initTemps.lastRefillAttempt || 0;
+  let solarChargePeakTankTop = null;
+  let solarChargePeakTankTopAt = 0;
   let drainDryTicks = 0;
 
   // Initial evaluate
@@ -109,6 +111,8 @@ function simulate(scenario, config) {
       now: t,
       collectorsDrained,
       lastRefillAttempt,
+      solarChargePeakTankTop,
+      solarChargePeakTankTopAt,
       sensorAge,
     };
 
@@ -121,6 +125,8 @@ function simulate(scenario, config) {
     }
     collectorsDrained = result.flags.collectorsDrained;
     lastRefillAttempt = result.flags.lastRefillAttempt;
+    solarChargePeakTankTop = result.flags.solarChargePeakTankTop;
+    solarChargePeakTankTopAt = result.flags.solarChargePeakTankTopAt;
 
     return result;
   }


### PR DESCRIPTION
## Summary
This PR replaces the solar charging exit criteria from a simple collector/tank_bottom temperature delta check with a more sophisticated tank-rise tracking mechanism. The system now exits solar charging when the tank stops accepting heat, rather than when the collector becomes insufficiently warm relative to the tank bottom.

## Key Changes

- **New exit criteria for solar charging mode**: Instead of exiting when `collector < tank_bottom + solarExitDelta`, the system now exits when:
  - Tank top has not risen for `solarExitStallSeconds` (default 300 seconds), OR
  - Tank top has dropped `solarExitTankDrop` °C (default 2°C) from the session peak
  
- **Configuration updates**: 
  - Replaced `solarExitDelta` with `solarExitTankDrop` and `solarExitStallSeconds` in `DEFAULT_CONFIG`
  - Updated documentation to clarify the new exit logic focuses on tank behavior rather than collector/tank_bottom delta

- **State tracking additions**:
  - Added `solarChargePeakTankTop` and `solarChargePeakTankTopAt` to track the peak tank temperature during a solar charging session
  - These flags are maintained across all state management layers (control-logic.js, control.js, playground/js/control.js, simulator.js)

- **Test updates**: Updated test cases to reflect the new exit criteria, including tests that verify the system stays in solar charging mode when the tank is still rising despite low collector temperatures

## Implementation Details

The new logic keeps the pump running longer during solar charging sessions by monitoring actual tank temperature rise rather than relying on a fixed collector/tank_bottom delta. This allows the system to continue harvesting heat as long as the tank is actively accepting it, improving overall system efficiency.

https://claude.ai/code/session_01VihqVwFgGMcJg69EXwo8aP