### PR TITLE
control-logic: transition reason codes + solar-entry delta 10 K → 5 K

### DIFF
--- a/playground/assets/bootstrap-history.json
+++ b/playground/assets/bootstrap-history.json
@@ -85,75 +85,75 @@
     {
       "time": 420,
       "values": {
-        "t_tank_top": 11.4042,
-        "t_tank_bottom": 9.5924,
-        "t_collector": 14.7916,
+        "t_tank_top": 11.4401,
+        "t_tank_bottom": 9.5926,
+        "t_collector": 14.086,
         "t_greenhouse": 10.8638,
         "t_outdoor": 8.8536
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 480,
       "values": {
-        "t_tank_top": 11.341,
-        "t_tank_bottom": 9.6551,
-        "t_collector": 15.4516,
+        "t_tank_top": 11.4537,
+        "t_tank_bottom": 9.6581,
+        "t_collector": 12.9628,
         "t_greenhouse": 10.8491,
         "t_outdoor": 8.8749
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 540,
       "values": {
-        "t_tank_top": 11.2821,
-        "t_tank_bottom": 9.7135,
-        "t_collector": 16.1058,
+        "t_tank_top": 11.4353,
+        "t_tank_bottom": 9.7212,
+        "t_collector": 12.303,
         "t_greenhouse": 10.8354,
         "t_outdoor": 8.8962
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 600,
       "values": {
-        "t_tank_top": 11.2274,
-        "t_tank_bottom": 9.7678,
-        "t_collector": 16.7543,
+        "t_tank_top": 11.4009,
+        "t_tank_bottom": 9.781,
+        "t_collector": 11.9262,
         "t_greenhouse": 10.8228,
         "t_outdoor": 8.9174
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 660,
       "values": {
-        "t_tank_top": 11.1764,
-        "t_tank_bottom": 9.8183,
-        "t_collector": 17.3971,
+        "t_tank_top": 11.3603,
+        "t_tank_bottom": 9.8374,
+        "t_collector": 11.7216,
         "t_greenhouse": 10.8112,
         "t_outdoor": 8.9388
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 720,
       "values": {
-        "t_tank_top": 11.129,
-        "t_tank_bottom": 9.8653,
-        "t_collector": 18.0344,
+        "t_tank_top": 11.3189,
+        "t_tank_bottom": 9.8903,
+        "t_collector": 11.6213,
         "t_greenhouse": 10.8006,
         "t_outdoor": 8.9601
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 780,
       "values": {
-        "t_tank_top": 11.0849,
-        "t_tank_bottom": 9.909,
-        "t_collector": 18.6662,
+        "t_tank_top": 11.2778,
+        "t_tank_bottom": 9.9399,
+        "t_collector": 11.7254,
         "t_greenhouse": 10.7911,
         "t_outdoor": 8.9814
       },
@@ -162,9 +162,9 @@
     {
       "time": 840,
       "values": {
-        "t_tank_top": 11.0438,
-        "t_tank_bottom": 9.9496,
-        "t_collector": 19.2927,
+        "t_tank_top": 11.2311,
+        "t_tank_bottom": 9.9862,
+        "t_collector": 12.4753,
         "t_greenhouse": 10.7825,
         "t_outdoor": 9.0028
       },
@@ -173,9 +173,9 @@
     {
       "time": 900,
       "values": {
-        "t_tank_top": 11.0056,
-        "t_tank_bottom": 9.9874,
-        "t_collector": 19.9138,
+        "t_tank_top": 11.1876,
+        "t_tank_bottom": 10.0292,
+        "t_collector": 13.2177,
         "t_greenhouse": 10.7748,
         "t_outdoor": 9.0242
       },
@@ -184,31 +184,31 @@
     {
       "time": 960,
       "values": {
-        "t_tank_top": 11.2178,
-        "t_tank_bottom": 10.0268,
-        "t_collector": 17.1108,
+        "t_tank_top": 11.1471,
+        "t_tank_bottom": 10.0692,
+        "t_collector": 13.9528,
         "t_greenhouse": 10.7681,
         "t_outdoor": 9.0456
       },
-      "mode": "solar_charging"
+      "mode": "idle"
     },
     {
       "time": 1020,
       "values": {
-        "t_tank_top": 11.358,
-        "t_tank_bottom": 10.0715,
-        "t_collector": 15.0167,
+        "t_tank_top": 11.1094,
+        "t_tank_bottom": 10.1065,
+        "t_collector": 14.6806,
         "t_greenhouse": 10.7623,
         "t_outdoor": 9.067
       },
-      "mode": "solar_charging"
+      "mode": "idle"
     },
     {
       "time": 1080,
       "values": {
-        "t_tank_top": 11.4267,
-        "t_tank_bottom": 10.1182,
-        "t_collector": 13.7549,
+        "t_tank_top": 11.1283,
+        "t_tank_bottom": 10.1415,
+        "t_collector": 14.589,
         "t_greenhouse": 10.7573,
         "t_outdoor": 9.0885
       },
@@ -217,9 +217,9 @@
     {
       "time": 1140,
       "values": {
-        "t_tank_top": 11.4543,
-        "t_tank_bottom": 10.1649,
-        "t_collector": 13.0037,
+        "t_tank_top": 11.2037,
+        "t_tank_bottom": 10.1777,
+        "t_collector": 13.5214,
         "t_greenhouse": 10.7532,
         "t_outdoor": 9.1099
       },
@@ -228,9 +228,9 @@
     {
       "time": 1200,
       "values": {
-        "t_tank_top": 11.4593,
-        "t_tank_bottom": 10.2104,
-        "t_collector": 12.565,
+        "t_tank_top": 11.2431,
+        "t_tank_bottom": 10.2146,
+        "t_collector": 12.8854,
         "t_greenhouse": 10.75,
         "t_outdoor": 9.1314
       },
@@ -239,9 +239,9 @@
     {
       "time": 1260,
       "values": {
-        "t_tank_top": 11.4527,
-        "t_tank_bottom": 10.2543,
-        "t_collector": 12.3174,
+        "t_tank_top": 11.262,
+        "t_tank_bottom": 10.2511,
+        "t_collector": 12.5139,
         "t_greenhouse": 10.7475,
         "t_outdoor": 9.1529
       },
@@ -250,9 +250,9 @@
     {
       "time": 1320,
       "values": {
-        "t_tank_top": 11.441,
-        "t_tank_bottom": 10.2962,
-        "t_collector": 12.1863,
+        "t_tank_top": 11.2699,
+        "t_tank_bottom": 10.2869,
+        "t_collector": 12.3043,
         "t_greenhouse": 10.7459,
         "t_outdoor": 9.1744
       },
@@ -261,9 +261,9 @@
     {
       "time": 1380,
       "values": {
-        "t_tank_top": 11.428,
-        "t_tank_bottom": 10.3363,
-        "t_collector": 12.1258,
+        "t_tank_top": 11.2726,
+        "t_tank_bottom": 10.3215,
+        "t_collector": 12.1935,
         "t_greenhouse": 10.745,
         "t_outdoor": 9.1959
       },
@@ -272,9 +272,9 @@
     {
       "time": 1440,
       "values": {
-        "t_tank_top": 11.4159,
-        "t_tank_bottom": 10.3745,
-        "t_collector": 12.1079,
+        "t_tank_top": 11.2732,
+        "t_tank_bottom": 10.3549,
+        "t_collector": 12.1429,
         "t_greenhouse": 10.7449,
         "t_outdoor": 9.2175
       },
@@ -283,130 +283,130 @@
     {
       "time": 1500,
       "values": {
-        "t_tank_top": 11.4009,
-        "t_tank_bottom": 10.4109,
-        "t_collector": 12.2621,
+        "t_tank_top": 11.2738,
+        "t_tank_bottom": 10.3872,
+        "t_collector": 12.1287,
         "t_greenhouse": 10.7456,
         "t_outdoor": 9.239
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 1560,
       "values": {
-        "t_tank_top": 11.3663,
-        "t_tank_bottom": 10.445,
-        "t_collector": 13.0719,
+        "t_tank_top": 11.2753,
+        "t_tank_bottom": 10.4184,
+        "t_collector": 12.1364,
         "t_greenhouse": 10.7469,
         "t_outdoor": 9.2606
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 1620,
       "values": {
-        "t_tank_top": 11.334,
-        "t_tank_bottom": 10.4768,
-        "t_collector": 13.8731,
+        "t_tank_top": 11.2784,
+        "t_tank_bottom": 10.4485,
+        "t_collector": 12.1572,
         "t_greenhouse": 10.749,
         "t_outdoor": 9.2822
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 1680,
       "values": {
-        "t_tank_top": 11.304,
-        "t_tank_bottom": 10.5064,
-        "t_collector": 14.6657,
+        "t_tank_top": 11.2832,
+        "t_tank_bottom": 10.4778,
+        "t_collector": 12.1855,
         "t_greenhouse": 10.7518,
         "t_outdoor": 9.3038
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 1740,
       "values": {
-        "t_tank_top": 11.276,
-        "t_tank_bottom": 10.5339,
-        "t_collector": 15.4498,
+        "t_tank_top": 11.2898,
+        "t_tank_bottom": 10.5062,
+        "t_collector": 12.2181,
         "t_greenhouse": 10.7552,
         "t_outdoor": 9.3254
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 1800,
       "values": {
-        "t_tank_top": 11.25,
-        "t_tank_bottom": 10.5594,
-        "t_collector": 16.2258,
+        "t_tank_top": 11.2983,
+        "t_tank_bottom": 10.5338,
+        "t_collector": 12.2531,
         "t_greenhouse": 10.7593,
         "t_outdoor": 9.347
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 1860,
       "values": {
-        "t_tank_top": 11.2258,
-        "t_tank_bottom": 10.5832,
-        "t_collector": 16.9935,
+        "t_tank_top": 11.3084,
+        "t_tank_bottom": 10.5608,
+        "t_collector": 12.2893,
         "t_greenhouse": 10.764,
         "t_outdoor": 9.3686
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 1920,
       "values": {
-        "t_tank_top": 11.2032,
-        "t_tank_bottom": 10.6053,
-        "t_collector": 17.7533,
+        "t_tank_top": 11.3201,
+        "t_tank_bottom": 10.5873,
+        "t_collector": 12.3259,
         "t_greenhouse": 10.7694,
         "t_outdoor": 9.3903
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 1980,
       "values": {
-        "t_tank_top": 11.1823,
-        "t_tank_bottom": 10.6259,
-        "t_collector": 18.5052,
+        "t_tank_top": 11.3333,
+        "t_tank_bottom": 10.6132,
+        "t_collector": 12.3627,
         "t_greenhouse": 10.7754,
         "t_outdoor": 9.412
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 2040,
       "values": {
-        "t_tank_top": 11.1627,
-        "t_tank_bottom": 10.645,
-        "t_collector": 19.2493,
+        "t_tank_top": 11.3478,
+        "t_tank_bottom": 10.6388,
+        "t_collector": 12.3993,
         "t_greenhouse": 10.7819,
         "t_outdoor": 9.4336
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 2100,
       "values": {
-        "t_tank_top": 11.1445,
-        "t_tank_bottom": 10.6628,
-        "t_collector": 19.9859,
+        "t_tank_top": 11.3635,
+        "t_tank_bottom": 10.6639,
+        "t_collector": 12.4357,
         "t_greenhouse": 10.7891,
         "t_outdoor": 9.4553
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 2160,
       "values": {
-        "t_tank_top": 11.1463,
-        "t_tank_bottom": 10.6794,
-        "t_collector": 20.4817,
+        "t_tank_top": 11.3804,
+        "t_tank_bottom": 10.6888,
+        "t_collector": 12.4718,
         "t_greenhouse": 10.7968,
         "t_outdoor": 9.477
       },
@@ -415,9 +415,9 @@
     {
       "time": 2220,
       "values": {
-        "t_tank_top": 11.4227,
-        "t_tank_bottom": 10.7011,
-        "t_collector": 17.4128,
+        "t_tank_top": 11.3982,
+        "t_tank_bottom": 10.7133,
+        "t_collector": 12.5076,
         "t_greenhouse": 10.8051,
         "t_outdoor": 9.4987
       },
@@ -426,9 +426,9 @@
     {
       "time": 2280,
       "values": {
-        "t_tank_top": 11.5873,
-        "t_tank_bottom": 10.7296,
-        "t_collector": 15.5458,
+        "t_tank_top": 11.417,
+        "t_tank_bottom": 10.7377,
+        "t_collector": 12.5431,
         "t_greenhouse": 10.8139,
         "t_outdoor": 9.5204
       },
@@ -437,9 +437,9 @@
     {
       "time": 2340,
       "values": {
-        "t_tank_top": 11.6849,
-        "t_tank_bottom": 10.7617,
-        "t_collector": 14.4173,
+        "t_tank_top": 11.4366,
+        "t_tank_bottom": 10.7619,
+        "t_collector": 12.5784,
         "t_greenhouse": 10.8232,
         "t_outdoor": 9.5421
       },
@@ -448,9 +448,9 @@
     {
       "time": 2400,
       "values": {
-        "t_tank_top": 11.7427,
-        "t_tank_bottom": 10.7952,
-        "t_collector": 13.7424,
+        "t_tank_top": 11.4569,
+        "t_tank_bottom": 10.7859,
+        "t_collector": 12.6135,
         "t_greenhouse": 10.833,
         "t_outdoor": 9.5639
       },
@@ -459,9 +459,9 @@
     {
       "time": 2460,
       "values": {
-        "t_tank_top": 11.7775,
-        "t_tank_bottom": 10.8292,
-        "t_collector": 13.3458,
+        "t_tank_top": 11.4779,
+        "t_tank_bottom": 10.8098,
+        "t_collector": 12.6483,
         "t_greenhouse": 10.8434,
         "t_outdoor": 9.5856
       },
@@ -470,9 +470,9 @@
     {
       "time": 2520,
       "values": {
-        "t_tank_top": 11.7993,
-        "t_tank_bottom": 10.863,
-        "t_collector": 13.1197,
+        "t_tank_top": 11.4995,
+        "t_tank_bottom": 10.8336,
+        "t_collector": 12.683,
         "t_greenhouse": 10.8542,
         "t_outdoor": 9.6073
       },
@@ -481,9 +481,9 @@
     {
       "time": 2580,
       "values": {
-        "t_tank_top": 11.8141,
-        "t_tank_bottom": 10.8961,
-        "t_collector": 12.9981,
+        "t_tank_top": 11.5218,
+        "t_tank_bottom": 10.8574,
+        "t_collector": 12.7176,
         "t_greenhouse": 10.8656,
         "t_outdoor": 9.6291
       },
@@ -492,9 +492,9 @@
     {
       "time": 2640,
       "values": {
-        "t_tank_top": 11.8257,
-        "t_tank_bottom": 10.9286,
-        "t_collector": 12.9401,
+        "t_tank_top": 11.5445,
+        "t_tank_bottom": 10.8811,
+        "t_collector": 12.752,
         "t_greenhouse": 10.8773,
         "t_outdoor": 9.6509
       },
@@ -503,9 +503,9 @@
     {
       "time": 2700,
       "values": {
-        "t_tank_top": 11.8362,
-        "t_tank_bottom": 10.9603,
-        "t_collector": 12.921,
+        "t_tank_top": 11.5677,
+        "t_tank_bottom": 10.9047,
+        "t_collector": 12.7863,
         "t_greenhouse": 10.8896,
         "t_outdoor": 9.6726
       },
@@ -514,9 +514,9 @@
     {
       "time": 2760,
       "values": {
-        "t_tank_top": 11.8467,
-        "t_tank_bottom": 10.9912,
-        "t_collector": 12.9253,
+        "t_tank_top": 11.5913,
+        "t_tank_bottom": 10.9284,
+        "t_collector": 12.8206,
         "t_greenhouse": 10.9023,
         "t_outdoor": 9.6944
       },
@@ -525,9 +525,9 @@
     {
       "time": 2820,
       "values": {
-        "t_tank_top": 11.858,
-        "t_tank_bottom": 11.0215,
-        "t_collector": 12.9437,
+        "t_tank_top": 11.6154,
+        "t_tank_bottom": 10.9521,
+        "t_collector": 12.8548,
         "t_greenhouse": 10.9154,
         "t_outdoor": 9.7162
       },
@@ -536,9 +536,9 @@
     {
       "time": 2880,
       "values": {
-        "t_tank_top": 11.8704,
-        "t_tank_bottom": 11.0511,
-        "t_collector": 12.9705,
+        "t_tank_top": 11.6398,
+        "t_tank_bottom": 10.9758,
+        "t_collector": 12.8889,
         "t_greenhouse": 10.9289,
         "t_outdoor": 9.738
       },
@@ -547,9 +547,9 @@
     {
       "time": 2940,
       "values": {
-        "t_tank_top": 11.884,
-        "t_tank_bottom": 11.0801,
-        "t_collector": 13.0022,
+        "t_tank_top": 11.6646,
+        "t_tank_bottom": 10.9995,
+        "t_collector": 12.923,
         "t_greenhouse": 10.9429,
         "t_outdoor": 9.7597
       },
@@ -558,9 +558,9 @@
     {
       "time": 3000,
       "values": {
-        "t_tank_top": 11.8989,
-        "t_tank_bottom": 11.1085,
-        "t_collector": 13.0366,
+        "t_tank_top": 11.6897,
+        "t_tank_bottom": 11.0233,
+        "t_collector": 12.9572,
         "t_greenhouse": 10.9572,
         "t_outdoor": 9.7815
       },
@@ -569,9 +569,9 @@
     {
       "time": 3060,
       "values": {
-        "t_tank_top": 11.915,
-        "t_tank_bottom": 11.1365,
-        "t_collector": 13.0726,
+        "t_tank_top": 11.715,
+        "t_tank_bottom": 11.0471,
+        "t_collector": 12.9913,
         "t_greenhouse": 10.9719,
         "t_outdoor": 9.8033
       },
@@ -580,9 +580,9 @@
     {
       "time": 3120,
       "values": {
-        "t_tank_top": 11.9324,
-        "t_tank_bottom": 11.1642,
-        "t_collector": 13.1093,
+        "t_tank_top": 11.7407,
+        "t_tank_bottom": 11.071,
+        "t_collector": 13.0254,
         "t_greenhouse": 10.9871,
         "t_outdoor": 9.8251
       },
@@ -591,9 +591,9 @@
     {
       "time": 3180,
       "values": {
-        "t_tank_top": 11.9508,
-        "t_tank_bottom": 11.1914,
-        "t_collector": 13.1464,
+        "t_tank_top": 11.7666,
+        "t_tank_bottom": 11.0949,
+        "t_collector": 13.0595,
         "t_greenhouse": 11.0026,
         "t_outdoor": 9.8469
       },
@@ -602,9 +602,9 @@
     {
       "time": 3240,
       "values": {
-        "t_tank_top": 11.9702,
-        "t_tank_bottom": 11.2184,
-        "t_collector": 13.1835,
+        "t_tank_top": 11.7928,
+        "t_tank_bottom": 11.1189,
+        "t_collector": 13.0937,
         "t_greenhouse": 11.0184,
         "t_outdoor": 9.8688
       },
@@ -613,9 +613,9 @@
     {
       "time": 3300,
       "values": {
-        "t_tank_top": 11.9906,
-        "t_tank_bottom": 11.2452,
-        "t_collector": 13.2206,
+        "t_tank_top": 11.8192,
+        "t_tank_bottom": 11.143,
+        "t_collector": 13.1279,
         "t_greenhouse": 11.0346,
         "t_outdoor": 9.8906
       },
@@ -624,9 +624,9 @@
     {
       "time": 3360,
       "values": {
-        "t_tank_top": 12.0118,
-        "t_tank_bottom": 11.2717,
-        "t_collector": 13.2575,
+        "t_tank_top": 11.8458,
+        "t_tank_bottom": 11.1672,
+        "t_collector": 13.1621,
         "t_greenhouse": 11.0512,
         "t_outdoor": 9.9124
       },
@@ -635,9 +635,9 @@
     {
       "time": 3420,
       "values": {
-        "t_tank_top": 12.0338,
-        "t_tank_bottom": 11.298,
-        "t_collector": 13.2942,
+        "t_tank_top": 11.8726,
+        "t_tank_bottom": 11.1915,
+        "t_collector": 13.1964,
         "t_greenhouse": 11.0681,
         "t_outdoor": 9.9342
       },
@@ -646,9 +646,9 @@
     {
       "time": 3480,
       "values": {
-        "t_tank_top": 12.0565,
-        "t_tank_bottom": 11.3242,
-        "t_collector": 13.3307,
+        "t_tank_top": 11.8996,
+        "t_tank_bottom": 11.2159,
+        "t_collector": 13.2307,
         "t_greenhouse": 11.0853,
         "t_outdoor": 9.956
       },
@@ -657,9 +657,9 @@
     {
       "time": 3540,
       "values": {
-        "t_tank_top": 12.0799,
-        "t_tank_bottom": 11.3503,
-        "t_collector": 13.3671,
+        "t_tank_top": 11.9269,
+        "t_tank_bottom": 11.2403,
+        "t_collector": 13.2651,
         "t_greenhouse": 11.1028,
         "t_outdoor": 9.9778
       },
@@ -668,9 +668,9 @@
     {
       "time": 3600,
       "values": {
-        "t_tank_top": 12.1038,
-        "t_tank_bottom": 11.3763,
-        "t_collector": 13.4034,
+        "t_tank_top": 11.9542,
+        "t_tank_bottom": 11.2649,
+        "t_collector": 13.2996,
         "t_greenhouse": 11.1206,
         "t_outdoor": 9.9996
       },
@@ -679,9 +679,9 @@
     {
       "time": 3660,
       "values": {
-        "t_tank_top": 12.1283,
-        "t_tank_bottom": 11.4023,
-        "t_collector": 13.4395,
+        "t_tank_top": 11.9818,
+        "t_tank_bottom": 11.2896,
+        "t_collector": 13.3341,
         "t_greenhouse": 11.1388,
         "t_outdoor": 10.0215
       },
@@ -690,9 +690,9 @@
     {
       "time": 3720,
       "values": {
-        "t_tank_top": 12.1532,
-        "t_tank_bottom": 11.4282,
-        "t_collector": 13.4755,
+        "t_tank_top": 12.0095,
+        "t_tank_bottom": 11.3143,
+        "t_collector": 13.3686,
         "t_greenhouse": 11.1572,
         "t_outdoor": 10.0433
       },
@@ -701,9 +701,9 @@
     {
       "time": 3780,
       "values": {
-        "t_tank_top": 12.1786,
-        "t_tank_bottom": 11.454,
-        "t_collector": 13.5114,
+        "t_tank_top": 12.0374,
+        "t_tank_bottom": 11.3392,
+        "t_collector": 13.4033,
         "t_greenhouse": 11.1759,
         "t_outdoor": 10.0651
       },
@@ -712,9 +712,9 @@
     {
       "time": 3840,
       "values": {
-        "t_tank_top": 12.2045,
-        "t_tank_bottom": 11.4799,
-        "t_collector": 13.5473,
+        "t_tank_top": 12.0654,
+        "t_tank_bottom": 11.3642,
+        "t_collector": 13.438,
         "t_greenhouse": 11.1949,
         "t_outdoor": 10.0869
       },
@@ -723,9 +723,9 @@
     {
       "time": 3900,
       "values": {
-        "t_tank_top": 12.2307,
-        "t_tank_bottom": 11.5058,
-        "t_collector": 13.583,
+        "t_tank_top": 12.0936,
+        "t_tank_bottom": 11.3893,
+        "t_collector": 13.4728,
         "t_greenhouse": 11.2142,
         "t_outdoor": 10.1087
       },
@@ -734,9 +734,9 @@
     {
       "time": 3960,
       "values": {
-        "t_tank_top": 12.2572,
-        "t_tank_bottom": 11.5317,
-        "t_collector": 13.6188,
+        "t_tank_top": 12.1219,
+        "t_tank_bottom": 11.4145,
+        "t_collector": 13.5076,
         "t_greenhouse": 11.2338,
         "t_outdoor": 10.1305
       },
@@ -745,9 +745,9 @@
     {
       "time": 4020,
       "values": {
-        "t_tank_top": 12.2841,
-        "t_tank_bottom": 11.5576,
-        "t_collector": 13.6545,
+        "t_tank_top": 12.1504,
+        "t_tank_bottom": 11.4398,
+        "t_collector": 13.5426,
         "t_greenhouse": 11.2536,
         "t_outdoor": 10.1523
       },
@@ -756,9 +756,9 @@
     {
       "time": 4080,
       "values": {
-        "t_tank_top": 12.3113,
-        "t_tank_bottom": 11.5835,
-        "t_collector": 13.6902,
+        "t_tank_top": 12.179,
+        "t_tank_bottom": 11.4653,
+        "t_collector": 13.5776,
         "t_greenhouse": 11.2736,
         "t_outdoor": 10.1741
       },
@@ -767,9 +767,9 @@
     {
       "time": 4140,
       "values": {
-        "t_tank_top": 12.3387,
-        "t_tank_bottom": 11.6095,
-        "t_collector": 13.7258,
+        "t_tank_top": 12.2078,
+        "t_tank_bottom": 11.4908,
+        "t_collector": 13.6127,
         "t_greenhouse": 11.2939,
         "t_outdoor": 10.1959
       },
@@ -778,9 +778,9 @@
     {
       "time": 4200,
       "values": {
-        "t_tank_top": 12.3665,
-        "t_tank_bottom": 11.6356,
-        "t_collector": 13.7615,
+        "t_tank_top": 12.2366,
+        "t_tank_bottom": 11.5165,
+        "t_collector": 13.6478,
         "t_greenhouse": 11.3144,
         "t_outdoor": 10.2177
       },
@@ -789,9 +789,9 @@
     {
       "time": 4260,
       "values": {
-        "t_tank_top": 12.3944,
-        "t_tank_bottom": 11.6617,
-        "t_collector": 13.7972,
+        "t_tank_top": 12.2656,
+        "t_tank_bottom": 11.5423,
+        "t_collector": 13.6831,
         "t_greenhouse": 11.3352,
         "t_outdoor": 10.2395
       },
@@ -800,9 +800,9 @@
     {
       "time": 4320,
       "values": {
-        "t_tank_top": 12.4226,
-        "t_tank_bottom": 11.6879,
-        "t_collector": 13.8329,
+        "t_tank_top": 12.2948,
+        "t_tank_bottom": 11.5682,
+        "t_collector": 13.7184,
         "t_greenhouse": 11.3562,
         "t_outdoor": 10.2613
       },
@@ -811,9 +811,9 @@
     {
       "time": 4380,
       "values": {
-        "t_tank_top": 12.451,
-        "t_tank_bottom": 11.7142,
-        "t_collector": 13.8687,
+        "t_tank_top": 12.324,
+        "t_tank_bottom": 11.5942,
+        "t_collector": 13.7538,
         "t_greenhouse": 11.3774,
         "t_outdoor": 10.2831
       },
@@ -822,9 +822,9 @@
     {
       "time": 4440,
       "values": {
-        "t_tank_top": 12.4796,
-        "t_tank_bottom": 11.7405,
-        "t_collector": 13.9045,
+        "t_tank_top": 12.3534,
+        "t_tank_bottom": 11.6203,
+        "t_collector": 13.7892,
         "t_greenhouse": 11.3988,
         "t_outdoor": 10.3049
       },
@@ -833,9 +833,9 @@
     {
       "time": 4500,
       "values": {
-        "t_tank_top": 12.5085,
-        "t_tank_bottom": 11.7669,
-        "t_collector": 13.9403,
+        "t_tank_top": 12.3829,
+        "t_tank_bottom": 11.6465,
+        "t_collector": 13.8248,
         "t_greenhouse": 11.4205,
         "t_outdoor": 10.3267
       },
@@ -844,9 +844,9 @@
     {
       "time": 4560,
       "values": {
-        "t_tank_top": 12.5374,
-        "t_tank_bottom": 11.7934,
-        "t_collector": 13.9761,
+        "t_tank_top": 12.4125,
+        "t_tank_bottom": 11.6729,
+        "t_collector": 13.8604,
         "t_greenhouse": 11.4423,
         "t_outdoor": 10.3484
       },
@@ -855,9 +855,9 @@
     {
       "time": 4620,
       "values": {
-        "t_tank_top": 12.5666,
-        "t_tank_bottom": 11.82,
-        "t_collector": 14.012,
+        "t_tank_top": 12.4422,
+        "t_tank_bottom": 11.6994,
+        "t_collector": 13.8961,
         "t_greenhouse": 11.4643,
         "t_outdoor": 10.3702
       },
@@ -866,9 +866,9 @@
     {
       "time": 4680,
       "values": {
-        "t_tank_top": 12.5959,
-        "t_tank_bottom": 11.8467,
-        "t_collector": 14.048,
+        "t_tank_top": 12.4721,
+        "t_tank_bottom": 11.726,
+        "t_collector": 13.9319,
         "t_greenhouse": 11.4865,
         "t_outdoor": 10.3919
       },
@@ -877,9 +877,9 @@
     {
       "time": 4740,
       "values": {
-        "t_tank_top": 12.6254,
-        "t_tank_bottom": 11.8735,
-        "t_collector": 14.084,
+        "t_tank_top": 12.502,
+        "t_tank_bottom": 11.7527,
+        "t_collector": 13.9678,
         "t_greenhouse": 11.5089,
         "t_outdoor": 10.4137
       },
@@ -888,9 +888,9 @@
     {
       "time": 4800,
       "values": {
-        "t_tank_top": 12.6551,
-        "t_tank_bottom": 11.9004,
-        "t_collector": 14.12,
+        "t_tank_top": 12.5321,
+        "t_tank_bottom": 11.7795,
+        "t_collector": 14.0038,
         "t_greenhouse": 11.5315,
         "t_outdoor": 10.4354
       },
@@ -899,9 +899,9 @@
     {
       "time": 4860,
       "values": {
-        "t_tank_top": 12.6849,
-        "t_tank_bottom": 11.9274,
-        "t_collector": 14.1562,
+        "t_tank_top": 12.5623,
+        "t_tank_bottom": 11.8064,
+        "t_collector": 14.0398,
         "t_greenhouse": 11.5543,
         "t_outdoor": 10.4571
       },
@@ -910,9 +910,9 @@
     {
       "time": 4920,
       "values": {
-        "t_tank_top": 12.7148,
-        "t_tank_bottom": 11.9545,
-        "t_collector": 14.1923,
+        "t_tank_top": 12.5926,
+        "t_tank_bottom": 11.8335,
+        "t_collector": 14.0759,
         "t_greenhouse": 11.5772,
         "t_outdoor": 10.4789
       },
@@ -921,9 +921,9 @@
     {
       "time": 4980,
       "values": {
-        "t_tank_top": 12.7449,
-        "t_tank_bottom": 11.9817,
-        "t_collector": 14.2286,
+        "t_tank_top": 12.623,
+        "t_tank_bottom": 11.8607,
+        "t_collector": 14.1121,
         "t_greenhouse": 11.6003,
         "t_outdoor": 10.5006
       },
@@ -932,9 +932,9 @@
     {
       "time": 5040,
       "values": {
-        "t_tank_top": 12.7751,
-        "t_tank_bottom": 12.009,
-        "t_collector": 14.2649,
+        "t_tank_top": 12.6535,
+        "t_tank_bottom": 11.8879,
+        "t_collector": 14.1484,
         "t_greenhouse": 11.6236,
         "t_outdoor": 10.5223
       },
@@ -943,9 +943,9 @@
     {
       "time": 5100,
       "values": {
-        "t_tank_top": 12.8054,
-        "t_tank_bottom": 12.0364,
-        "t_collector": 14.3013,
+        "t_tank_top": 12.6841,
+        "t_tank_bottom": 11.9153,
+        "t_collector": 14.1847,
         "t_greenhouse": 11.647,
         "t_outdoor": 10.544
       },
@@ -954,9 +954,9 @@
     {
       "time": 5160,
       "values": {
-        "t_tank_top": 12.8359,
-        "t_tank_bottom": 12.0639,
-        "t_collector": 14.3377,
+        "t_tank_top": 12.7148,
+        "t_tank_bottom": 11.9429,
+        "t_collector": 14.2211,
         "t_greenhouse": 11.6705,
         "t_outdoor": 10.5657
       },
@@ -965,9 +965,9 @@
     {
       "time": 5220,
       "values": {
-        "t_tank_top": 12.8665,
-        "t_tank_bottom": 12.0915,
-        "t_collector": 14.3742,
+        "t_tank_top": 12.7457,
+        "t_tank_bottom": 11.9705,
+        "t_collector": 14.2576,
         "t_greenhouse": 11.6942,
         "t_outdoor": 10.5873
       },
@@ -976,9 +976,9 @@
     {
       "time": 5280,
       "values": {
-        "t_tank_top": 12.8972,
-        "t_tank_bottom": 12.1192,
-        "t_collector": 14.4108,
+        "t_tank_top": 12.7766,
+        "t_tank_bottom": 11.9982,
+        "t_collector": 14.2942,
         "t_greenhouse": 11.7181,
         "t_outdoor": 10.609
       },
@@ -987,9 +987,9 @@
     {
       "time": 5340,
       "values": {
-        "t_tank_top": 12.928,
-        "t_tank_bottom": 12.147,
-        "t_collector": 14.4474,
+        "t_tank_top": 12.8076,
+        "t_tank_bottom": 12.0261,
+        "t_collector": 14.3309,
         "t_greenhouse": 11.7421,
         "t_outdoor": 10.6306
       },
@@ -998,9 +998,9 @@
     {
       "time": 5400,
       "values": {
-        "t_tank_top": 12.959,
-        "t_tank_bottom": 12.175,
-        "t_collector": 14.4841,
+        "t_tank_top": 12.8388,
+        "t_tank_bottom": 12.0541,
+        "t_collector": 14.3676,
         "t_greenhouse": 11.7662,
         "t_outdoor": 10.6523
       },
@@ -1009,9 +1009,9 @@
     {
       "time": 5460,
       "values": {
-        "t_tank_top": 12.9901,
-        "t_tank_bottom": 12.203,
-        "t_collector": 14.5209,
+        "t_tank_top": 12.87,
+        "t_tank_bottom": 12.0821,
+        "t_collector": 14.4044,
         "t_greenhouse": 11.7905,
         "t_outdoor": 10.6739
       },
@@ -1020,9 +1020,9 @@
     {
       "time": 5520,
       "values": {
-        "t_tank_top": 13.0212,
-        "t_tank_bottom": 12.2311,
-        "t_collector": 14.5577,
+        "t_tank_top": 12.9013,
+        "t_tank_bottom": 12.1103,
+        "t_collector": 14.4413,
         "t_greenhouse": 11.8148,
         "t_outdoor": 10.6955
       },
@@ -1031,9 +1031,9 @@
     {
       "time": 5580,
       "values": {
-        "t_tank_top": 13.0525,
-        "t_tank_bottom": 12.2594,
-        "t_collector": 14.5946,
+        "t_tank_top": 12.9328,
+        "t_tank_bottom": 12.1386,
+        "t_collector": 14.4782,
         "t_greenhouse": 11.8393,
         "t_outdoor": 10.7171
       },
@@ -1042,9 +1042,9 @@
     {
       "time": 5640,
       "values": {
-        "t_tank_top": 13.0839,
-        "t_tank_bottom": 12.2878,
-        "t_collector": 14.6316,
+        "t_tank_top": 12.9643,
+        "t_tank_bottom": 12.1671,
+        "t_collector": 14.5152,
         "t_greenhouse": 11.8639,
         "t_outdoor": 10.7387
       },
@@ -1053,9 +1053,9 @@
     {
       "time": 5700,
       "values": {
-        "t_tank_top": 13.1154,
-        "t_tank_bottom": 12.3162,
-        "t_collector": 14.6687,
+        "t_tank_top": 12.996,
+        "t_tank_bottom": 12.1956,
+        "t_collector": 14.5523,
         "t_greenhouse": 11.8887,
         "t_outdoor": 10.7603
       },
@@ -1064,9 +1064,9 @@
     {
       "time": 5760,
       "values": {
-        "t_tank_top": 13.147,
-        "t_tank_bottom": 12.3448,
-        "t_collector": 14.7058,
+        "t_tank_top": 13.0277,
+        "t_tank_bottom": 12.2242,
+        "t_collector": 14.5895,
         "t_greenhouse": 11.9135,
         "t_outdoor": 10.7818
       },
@@ -1075,9 +1075,9 @@
     {
       "time": 5820,
       "values": {
-        "t_tank_top": 13.1787,
-        "t_tank_bottom": 12.3735,
-        "t_collector": 14.743,
+        "t_tank_top": 13.0595,
+        "t_tank_bottom": 12.253,
+        "t_collector": 14.6268,
         "t_greenhouse": 11.9384,
         "t_outdoor": 10.8034
       },
@@ -1086,9 +1086,9 @@
     {
       "time": 5880,
       "values": {
-        "t_tank_top": 13.2105,
-        "t_tank_bottom": 12.4023,
-        "t_collector": 14.7802,
+        "t_tank_top": 13.0915,
+        "t_tank_bottom": 12.2818,
+        "t_collector": 14.6641,
         "t_greenhouse": 11.9635,
         "t_outdoor": 10.8249
       },
@@ -1097,9 +1097,9 @@
     {
       "time": 5940,
       "values": {
-        "t_tank_top": 13.2424,
-        "t_tank_bottom": 12.4312,
-        "t_collector": 14.8175,
+        "t_tank_top": 13.1235,
+        "t_tank_bottom": 12.3108,
+        "t_collector": 14.7015,
         "t_greenhouse": 11.9886,
         "t_outdoor": 10.8464
       },
@@ -1108,9 +1108,9 @@
     {
       "time": 6000,
       "values": {
-        "t_tank_top": 13.2744,
-        "t_tank_bottom": 12.4602,
-        "t_collector": 14.8549,
+        "t_tank_top": 13.1556,
+        "t_tank_bottom": 12.3399,
+        "t_collector": 14.7389,
         "t_greenhouse": 12.0139,
         "t_outdoor": 10.8679
       },
@@ -1119,9 +1119,9 @@
     {
       "time": 6060,
       "values": {
-        "t_tank_top": 13.3065,
-        "t_tank_bottom": 12.4893,
-        "t_collector": 14.8924,
+        "t_tank_top": 13.1879,
+        "t_tank_bottom": 12.3691,
+        "t_collector": 14.7764,
         "t_greenhouse": 12.0392,
         "t_outdoor": 10.8894
       },
@@ -1130,9 +1130,9 @@
     {
       "time": 6120,
       "values": {
-        "t_tank_top": 13.3387,
-        "t_tank_bottom": 12.5185,
-        "t_collector": 14.9299,
+        "t_tank_top": 13.2202,
+        "t_tank_bottom": 12.3984,
+        "t_collector": 14.814,
         "t_greenhouse": 12.0646,
         "t_outdoor": 10.9108
       },
@@ -1141,9 +1141,9 @@
     {
       "time": 6180,
       "values": {
-        "t_tank_top": 13.371,
-        "t_tank_bottom": 12.5479,
-        "t_collector": 14.9675,
+        "t_tank_top": 13.2526,
+        "t_tank_bottom": 12.4278,
+        "t_collector": 14.8517,
         "t_greenhouse": 12.0901,
         "t_outdoor": 10.9323
       },
@@ -1152,9 +1152,9 @@
     {
       "time": 6240,
       "values": {
-        "t_tank_top": 13.4034,
-        "t_tank_bottom": 12.5773,
-        "t_collector": 15.0052,
+        "t_tank_top": 13.2851,
+        "t_tank_bottom": 12.4573,
+        "t_collector": 14.8894,
         "t_greenhouse": 12.1157,
         "t_outdoor": 10.9537
       },
@@ -1163,9 +1163,9 @@
     {
       "time": 6300,
       "values": {
-        "t_tank_top": 13.4359,
-        "t_tank_bottom": 12.6068,
-        "t_collector": 15.0429,
+        "t_tank_top": 13.3177,
+        "t_tank_bottom": 12.4869,
+        "t_collector": 14.9272,
         "t_greenhouse": 12.1414,
         "t_outdoor": 10.9751
       },
@@ -1174,9 +1174,9 @@
     {
       "time": 6360,
       "values": {
-        "t_tank_top": 13.4685,
-        "t_tank_bottom": 12.6365,
-        "t_collector": 15.0807,
+        "t_tank_top": 13.3504,
+        "t_tank_bottom": 12.5166,
+        "t_collector": 14.9651,
         "t_greenhouse": 12.1671,
         "t_outdoor": 10.9965
       },
@@ -1185,9 +1185,9 @@
     {
       "time": 6420,
       "values": {
-        "t_tank_top": 13.5012,
-        "t_tank_bottom": 12.6662,
-        "t_collector": 15.1185,
+        "t_tank_top": 13.3832,
+        "t_tank_bottom": 12.5465,
+        "t_collector": 15.003,
         "t_greenhouse": 12.1929,
         "t_outdoor": 11.0179
       },
@@ -1196,9 +1196,9 @@
     {
       "time": 6480,
       "values": {
-        "t_tank_top": 13.534,
-        "t_tank_bottom": 12.6961,
-        "t_collector": 15.1564,
+        "t_tank_top": 13.4161,
+        "t_tank_bottom": 12.5764,
+        "t_collector": 15.041,
         "t_greenhouse": 12.2188,
         "t_outdoor": 11.0392
       },
@@ -1207,9 +1207,9 @@
     {
       "time": 6540,
       "values": {
-        "t_tank_top": 13.5669,
-        "t_tank_bottom": 12.726,
-        "t_collector": 15.1944,
+        "t_tank_top": 13.449,
+        "t_tank_bottom": 12.6064,
+        "t_collector": 15.0791,
         "t_greenhouse": 12.2448,
         "t_outdoor": 11.0605
       },
@@ -1218,9 +1218,9 @@
     {
       "time": 6600,
       "values": {
-        "t_tank_top": 13.5998,
-        "t_tank_bottom": 12.7561,
-        "t_collector": 15.2325,
+        "t_tank_top": 13.4821,
+        "t_tank_bottom": 12.6366,
+        "t_collector": 15.1172,
         "t_greenhouse": 12.2708,
         "t_outdoor": 11.0818
       },
@@ -1229,9 +1229,9 @@
     {
       "time": 6660,
       "values": {
-        "t_tank_top": 13.6329,
-        "t_tank_bottom": 12.7863,
-        "t_collector": 15.2706,
+        "t_tank_top": 13.5152,
+        "t_tank_bottom": 12.6668,
+        "t_collector": 15.1554,
         "t_greenhouse": 12.2968,
         "t_outdoor": 11.1031
       },
@@ -1240,9 +1240,9 @@
     {
       "time": 6720,
       "values": {
-        "t_tank_top": 13.666,
-        "t_tank_bottom": 12.8165,
-        "t_collector": 15.3087,
+        "t_tank_top": 13.5485,
+        "t_tank_bottom": 12.6972,
+        "t_collector": 15.1936,
         "t_greenhouse": 12.323,
         "t_outdoor": 11.1244
       },
@@ -1251,9 +1251,9 @@
     {
       "time": 6780,
       "values": {
-        "t_tank_top": 13.6992,
-        "t_tank_bottom": 12.8469,
-        "t_collector": 15.347,
+        "t_tank_top": 13.5818,
+        "t_tank_bottom": 12.7276,
+        "t_collector": 15.2319,
         "t_greenhouse": 12.3492,
         "t_outdoor": 11.1456
       },
@@ -1262,9 +1262,9 @@
     {
       "time": 6840,
       "values": {
-        "t_tank_top": 13.7326,
-        "t_tank_bottom": 12.8774,
-        "t_collector": 15.3853,
+        "t_tank_top": 13.6152,
+        "t_tank_bottom": 12.7582,
+        "t_collector": 15.2703,
         "t_greenhouse": 12.3754,
         "t_outdoor": 11.1669
       },
@@ -1273,9 +1273,9 @@
     {
       "time": 6900,
       "values": {
-        "t_tank_top": 13.766,
-        "t_tank_bottom": 12.9079,
-        "t_collector": 15.4236,
+        "t_tank_top": 13.6487,
+        "t_tank_bottom": 12.7888,
+        "t_collector": 15.3087,
         "t_greenhouse": 12.4017,
         "t_outdoor": 11.1881
       },
@@ -1284,9 +1284,9 @@
     {
       "time": 6960,
       "values": {
-        "t_tank_top": 13.7995,
-        "t_tank_bottom": 12.9386,
-        "t_collector": 15.462,
+        "t_tank_top": 13.6823,
+        "t_tank_bottom": 12.8196,
+        "t_collector": 15.3472,
         "t_greenhouse": 12.4281,
         "t_outdoor": 11.2093
       },
@@ -1295,9 +1295,9 @@
     {
       "time": 7020,
       "values": {
-        "t_tank_top": 13.833,
-        "t_tank_bottom": 12.9694,
-        "t_collector": 15.5005,
+        "t_tank_top": 13.7159,
+        "t_tank_bottom": 12.8504,
+        "t_collector": 15.3858,
         "t_greenhouse": 12.4545,
         "t_outdoor": 11.2304
       },
@@ -1306,9 +1306,9 @@
     {
       "time": 7080,
       "values": {
-        "t_tank_top": 13.8667,
-        "t_tank_bottom": 13.0002,
-        "t_collector": 15.5391,
+        "t_tank_top": 13.7497,
+        "t_tank_bottom": 12.8814,
+        "t_collector": 15.4244,
         "t_greenhouse": 12.4809,
         "t_outdoor": 11.2515
       },
@@ -1317,9 +1317,9 @@
     {
       "time": 7140,
       "values": {
-        "t_tank_top": 13.9005,
-        "t_tank_bottom": 13.0312,
-        "t_collector": 15.5776,
+        "t_tank_top": 13.7835,
+        "t_tank_bottom": 12.9124,
+        "t_collector": 15.4631,
         "t_greenhouse": 12.5074,
         "t_outdoor": 11.2727
       },
@@ -1328,9 +1328,9 @@
     {
       "time": 7200,
       "values": {
-        "t_tank_top": 13.9343,
-        "t_tank_bottom": 13.0623,
-        "t_collector": 15.6163,
+        "t_tank_top": 13.8175,
+        "t_tank_bottom": 12.9436,
+        "t_collector": 15.5018,
         "t_greenhouse": 12.5339,
         "t_outdoor": 11.2937
       },
@@ -1339,9 +1339,9 @@
     {
       "time": 7260,
       "values": {
-        "t_tank_top": 13.9682,
-        "t_tank_bottom": 13.0934,
-        "t_collector": 15.655,
+        "t_tank_top": 13.8515,
+        "t_tank_bottom": 12.9748,
+        "t_collector": 15.5406,
         "t_greenhouse": 12.5605,
         "t_outdoor": 11.3148
       },
@@ -1350,9 +1350,9 @@
     {
       "time": 7320,
       "values": {
-        "t_tank_top": 14.0022,
-        "t_tank_bottom": 13.1247,
-        "t_collector": 15.6938,
+        "t_tank_top": 13.8856,
+        "t_tank_bottom": 13.0062,
+        "t_collector": 15.5794,
         "t_greenhouse": 12.587,
         "t_outdoor": 11.3358
       },
@@ -1361,9 +1361,9 @@
     {
       "time": 7380,
       "values": {
-        "t_tank_top": 14.0363,
-        "t_tank_bottom": 13.1561,
-        "t_collector": 15.7326,
+        "t_tank_top": 13.9197,
+        "t_tank_bottom": 13.0376,
+        "t_collector": 15.6183,
         "t_greenhouse": 12.6137,
         "t_outdoor": 11.3569
       },
@@ -1372,9 +1372,9 @@
     {
       "time": 7440,
       "values": {
-        "t_tank_top": 14.0705,
-        "t_tank_bottom": 13.1875,
-        "t_collector": 15.7714,
+        "t_tank_top": 13.954,
+        "t_tank_bottom": 13.0691,
+        "t_collector": 15.6573,
         "t_greenhouse": 12.6403,
         "t_outdoor": 11.3778
       },
@@ -1383,9 +1383,9 @@
     {
       "time": 7500,
       "values": {
-        "t_tank_top": 14.1047,
-        "t_tank_bottom": 13.2191,
-        "t_collector": 15.8104,
+        "t_tank_top": 13.9883,
+        "t_tank_bottom": 13.1008,
+        "t_collector": 15.6963,
         "t_greenhouse": 12.667,
         "t_outdoor": 11.3988
       },
@@ -1394,9 +1394,9 @@
     {
       "time": 7560,
       "values": {
-        "t_tank_top": 14.1391,
-        "t_tank_bottom": 13.2507,
-        "t_collector": 15.8494,
+        "t_tank_top": 14.0227,
+        "t_tank_bottom": 13.1325,
+        "t_collector": 15.7353,
         "t_greenhouse": 12.6937,
         "t_outdoor": 11.4197
       },
@@ -1405,9 +1405,9 @@
     {
       "time": 7620,
       "values": {
-        "t_tank_top": 14.1735,
-        "t_tank_bottom": 13.2824,
-        "t_collector": 15.8884,
+        "t_tank_top": 14.0572,
+        "t_tank_bottom": 13.1643,
+        "t_collector": 15.7745,
         "t_greenhouse": 12.7204,
         "t_outdoor": 11.4406
       },
@@ -1416,9 +1416,9 @@
     {
       "time": 7680,
       "values": {
-        "t_tank_top": 14.208,
-        "t_tank_bottom": 13.3143,
-        "t_collector": 15.9275,
+        "t_tank_top": 14.0918,
+        "t_tank_bottom": 13.1963,
+        "t_collector": 15.8136,
         "t_greenhouse": 12.7472,
         "t_outdoor": 11.4615
       },
@@ -1427,9 +1427,9 @@
     {
       "time": 7740,
       "values": {
-        "t_tank_top": 14.2425,
-        "t_tank_bottom": 13.3462,
-        "t_collector": 15.9666,
+        "t_tank_top": 14.1265,
+        "t_tank_bottom": 13.2283,
+        "t_collector": 15.8529,
         "t_greenhouse": 12.774,
         "t_outdoor": 11.4824
       },
@@ -1438,9 +1438,9 @@
     {
       "time": 7800,
       "values": {
-        "t_tank_top": 14.2772,
-        "t_tank_bottom": 13.3782,
-        "t_collector": 16.0058,
+        "t_tank_top": 14.1612,
+        "t_tank_bottom": 13.2604,
+        "t_collector": 15.8921,
         "t_greenhouse": 12.8007,
         "t_outdoor": 11.5032
       },
@@ -1449,9 +1449,9 @@
     {
       "time": 7860,
       "values": {
-        "t_tank_top": 14.3119,
-        "t_tank_bottom": 13.4103,
-        "t_collector": 16.045,
+        "t_tank_top": 14.196,
+        "t_tank_bottom": 13.2926,
+        "t_collector": 15.9314,
         "t_greenhouse": 12.8275,
         "t_outdoor": 11.524
       },
@@ -1460,9 +1460,9 @@
     {
       "time": 7920,
       "values": {
-        "t_tank_top": 14.3467,
-        "t_tank_bottom": 13.4426,
-        "t_collector": 16.0843,
+        "t_tank_top": 14.2309,
+        "t_tank_bottom": 13.3249,
+        "t_collector": 15.9708,
         "t_greenhouse": 12.8544,
         "t_outdoor": 11.5447
       },
@@ -1471,9 +1471,9 @@
     {
       "time": 7980,
       "values": {
-        "t_tank_top": 14.3816,
-        "t_tank_bottom": 13.4749,
-        "t_collector": 16.1237,
+        "t_tank_top": 14.2659,
+        "t_tank_bottom": 13.3573,
+        "t_collector": 16.0102,
         "t_greenhouse": 12.8812,
         "t_outdoor": 11.5655
       },
@@ -1482,9 +1482,9 @@
     {
       "time": 8040,
       "values": {
-        "t_tank_top": 14.4165,
-        "t_tank_bottom": 13.5072,
-        "t_collector": 16.1631,
+        "t_tank_top": 14.3009,
+        "t_tank_bottom": 13.3897,
+        "t_collector": 16.0497,
         "t_greenhouse": 12.908,
         "t_outdoor": 11.5862
       },
@@ -1493,9 +1493,9 @@
     {
       "time": 8100,
       "values": {
-        "t_tank_top": 14.4516,
-        "t_tank_bottom": 13.5397,
-        "t_collector": 16.2025,
+        "t_tank_top": 14.336,
+        "t_tank_bottom": 13.4223,
+        "t_collector": 16.0892,
         "t_greenhouse": 12.9349,
         "t_outdoor": 11.6069
       },
@@ -1504,9 +1504,9 @@
     {
       "time": 8160,
       "values": {
-        "t_tank_top": 14.4867,
-        "t_tank_bottom": 13.5723,
-        "t_collector": 16.242,
+        "t_tank_top": 14.3712,
+        "t_tank_bottom": 13.4549,
+        "t_collector": 16.1288,
         "t_greenhouse": 12.9618,
         "t_outdoor": 11.6275
       },
@@ -1515,9 +1515,9 @@
     {
       "time": 8220,
       "values": {
-        "t_tank_top": 14.5219,
-        "t_tank_bottom": 13.605,
-        "t_collector": 16.2815,
+        "t_tank_top": 14.4065,
+        "t_tank_bottom": 13.4877,
+        "t_collector": 16.1684,
         "t_greenhouse": 12.9886,
         "t_outdoor": 11.6481
       },
@@ -1526,9 +1526,9 @@
     {
       "time": 8280,
       "values": {
-        "t_tank_top": 14.5571,
-        "t_tank_bottom": 13.6377,
-        "t_collector": 16.3211,
+        "t_tank_top": 14.4418,
+        "t_tank_bottom": 13.5205,
+        "t_collector": 16.2081,
         "t_greenhouse": 13.0155,
         "t_outdoor": 11.6687
       },
@@ -1537,9 +1537,9 @@
     {
       "time": 8340,
       "values": {
-        "t_tank_top": 14.5924,
-        "t_tank_bottom": 13.6705,
-        "t_collector": 16.3607,
+        "t_tank_top": 14.4772,
+        "t_tank_bottom": 13.5534,
+        "t_collector": 16.2478,
         "t_greenhouse": 13.0424,
         "t_outdoor": 11.6892
       },
@@ -1548,9 +1548,9 @@
     {
       "time": 8400,
       "values": {
-        "t_tank_top": 14.6278,
-        "t_tank_bottom": 13.7035,
-        "t_collector": 16.4004,
+        "t_tank_top": 14.5127,
+        "t_tank_bottom": 13.5864,
+        "t_collector": 16.2875,
         "t_greenhouse": 13.0692,
         "t_outdoor": 11.7098
       },
@@ -1559,9 +1559,9 @@
     {
       "time": 8460,
       "values": {
-        "t_tank_top": 14.6633,
-        "t_tank_bottom": 13.7365,
-        "t_collector": 16.4401,
+        "t_tank_top": 14.5483,
+        "t_tank_bottom": 13.6195,
+        "t_collector": 16.3273,
         "t_greenhouse": 13.0961,
         "t_outdoor": 11.7302
       },
@@ -1570,9 +1570,9 @@
     {
       "time": 8520,
       "values": {
-        "t_tank_top": 14.6989,
-        "t_tank_bottom": 13.7696,
-        "t_collector": 16.4798,
+        "t_tank_top": 14.5839,
+        "t_tank_bottom": 13.6527,
+        "t_collector": 16.3671,
         "t_greenhouse": 13.123,
         "t_outdoor": 11.7507
       },
@@ -1581,9 +1581,9 @@
     {
       "time": 8580,
       "values": {
-        "t_tank_top": 14.7345,
-        "t_tank_bottom": 13.8027,
-        "t_collector": 16.5196,
+        "t_tank_top": 14.6196,
+        "t_tank_bottom": 13.686,
+        "t_collector": 16.407,
         "t_greenhouse": 13.1498,
         "t_outdoor": 11.7711
       },
@@ -1592,9 +1592,9 @@
     {
       "time": 8640,
       "values": {
-        "t_tank_top": 14.7702,
-        "t_tank_bottom": 13.836,
-        "t_collector": 16.5595,
+        "t_tank_top": 14.6553,
+        "t_tank_bottom": 13.7193,
+        "t_collector": 16.4469,
         "t_greenhouse": 13.1767,
         "t_outdoor": 11.7915
       },
@@ -1603,9 +1603,9 @@
     {
       "time": 8700,
       "values": {
-        "t_tank_top": 14.8059,
-        "t_tank_bottom": 13.8694,
-        "t_collector": 16.5994,
+        "t_tank_top": 14.6912,
+        "t_tank_bottom": 13.7528,
+        "t_collector": 16.4869,
         "t_greenhouse": 13.2035,
         "t_outdoor": 11.8119
       },
@@ -1614,9 +1614,9 @@
     {
       "time": 8760,
       "values": {
-        "t_tank_top": 14.8417,
-        "t_tank_bottom": 13.9028,
-        "t_collector": 16.6393,
+        "t_tank_top": 14.7271,
+        "t_tank_bottom": 13.7863,
+        "t_collector": 16.5269,
         "t_greenhouse": 13.2304,
         "t_outdoor": 11.8322
       },
@@ -1625,9 +1625,9 @@
     {
       "time": 8820,
       "values": {
-        "t_tank_top": 14.8776,
-        "t_tank_bottom": 13.9363,
-        "t_collector": 16.6792,
+        "t_tank_top": 14.7631,
+        "t_tank_bottom": 13.8199,
+        "t_collector": 16.5669,
         "t_greenhouse": 13.2572,
         "t_outdoor": 11.8524
       },
@@ -1636,9 +1636,9 @@
     {
       "time": 8880,
       "values": {
-        "t_tank_top": 14.9136,
-        "t_tank_bottom": 13.9699,
-        "t_collector": 16.7192,
+        "t_tank_top": 14.7991,
+        "t_tank_bottom": 13.8536,
+        "t_collector": 16.607,
         "t_greenhouse": 13.284,
         "t_outdoor": 11.8727
       },
@@ -1647,9 +1647,9 @@
     {
       "time": 8940,
       "values": {
-        "t_tank_top": 14.9496,
-        "t_tank_bottom": 14.0036,
-        "t_collector": 16.7593,
+        "t_tank_top": 14.8352,
+        "t_tank_bottom": 13.8874,
+        "t_collector": 16.6471,
         "t_greenhouse": 13.3108,
         "t_outdoor": 11.8929
       },
@@ -1658,9 +1658,9 @@
     {
       "time": 9000,
       "values": {
-        "t_tank_top": 14.9857,
-        "t_tank_bottom": 14.0374,
-        "t_collector": 16.7994,
+        "t_tank_top": 14.8714,
+        "t_tank_bottom": 13.9212,
+        "t_collector": 16.6873,
         "t_greenhouse": 13.3376,
         "t_outdoor": 11.9131
       },
@@ -1669,9 +1669,9 @@
     {
       "time": 9060,
       "values": {
-        "t_tank_top": 15.0219,
-        "t_tank_bottom": 14.0712,
-        "t_collector": 16.8395,
+        "t_tank_top": 14.9076,
+        "t_tank_bottom": 13.9551,
+        "t_collector": 16.7275,
         "t_greenhouse": 13.3644,
         "t_outdoor": 11.9332
       },
@@ -1680,9 +1680,9 @@
     {
       "time": 9120,
       "values": {
-        "t_tank_top": 15.0581,
-        "t_tank_bottom": 14.1052,
-        "t_collector": 16.8796,
+        "t_tank_top": 14.9439,
+        "t_tank_bottom": 13.9892,
+        "t_collector": 16.7677,
         "t_greenhouse": 13.3911,
         "t_outdoor": 11.9533
       },
@@ -1691,9 +1691,9 @@
     {
       "time": 9180,
       "values": {
-        "t_tank_top": 15.0944,
-        "t_tank_bottom": 14.1392,
-        "t_collector": 16.9198,
+        "t_tank_top": 14.9803,
+        "t_tank_bottom": 14.0232,
+        "t_collector": 16.808,
         "t_greenhouse": 13.4179,
         "t_outdoor": 11.9734
       },
@@ -1702,9 +1702,9 @@
     {
       "time": 9240,
       "values": {
-        "t_tank_top": 15.1307,
-        "t_tank_bottom": 14.1733,
-        "t_collector": 16.96,
+        "t_tank_top": 15.0167,
+        "t_tank_bottom": 14.0574,
+        "t_collector": 16.8483,
         "t_greenhouse": 13.4446,
         "t_outdoor": 11.9934
       },
@@ -1713,9 +1713,9 @@
     {
       "time": 9300,
       "values": {
-        "t_tank_top": 15.1671,
-        "t_tank_bottom": 14.2074,
-        "t_collector": 17.0003,
+        "t_tank_top": 15.0532,
+        "t_tank_bottom": 14.0917,
+        "t_collector": 16.8886,
         "t_greenhouse": 13.4713,
         "t_outdoor": 12.0134
       },
@@ -1724,9 +1724,9 @@
     {
       "time": 9360,
       "values": {
-        "t_tank_top": 15.2036,
-        "t_tank_bottom": 14.2417,
-        "t_collector": 17.0406,
+        "t_tank_top": 15.0898,
+        "t_tank_bottom": 14.126,
+        "t_collector": 16.929,
         "t_greenhouse": 13.498,
         "t_outdoor": 12.0334
       },
@@ -1735,9 +1735,9 @@
     {
       "time": 9420,
       "values": {
-        "t_tank_top": 15.2401,
-        "t_tank_bottom": 14.276,
-        "t_collector": 17.0809,
+        "t_tank_top": 15.1264,
+        "t_tank_bottom": 14.1604,
+        "t_collector": 16.9694,
         "t_greenhouse": 13.5246,
         "t_outdoor": 12.0533
       },
@@ -1746,9 +1746,9 @@
     {
       "time": 9480,
       "values": {
-        "t_tank_top": 15.2767,
-        "t_tank_bottom": 14.3104,
-        "t_collector": 17.1213,
+        "t_tank_top": 15.1631,
+        "t_tank_bottom": 14.1949,
+        "t_collector": 17.0099,
         "t_greenhouse": 13.5513,
         "t_outdoor": 12.0731
       },
@@ -1757,9 +1757,9 @@
     {
       "time": 9540,
       "values": {
-        "t_tank_top": 15.3134,
-        "t_tank_bottom": 14.3449,
-        "t_collector": 17.1617,
+        "t_tank_top": 15.1998,
+        "t_tank_bottom": 14.2295,
+        "t_collector": 17.0503,
         "t_greenhouse": 13.5779,
         "t_outdoor": 12.093
       },
@@ -1768,9 +1768,9 @@
     {
       "time": 9600,
       "values": {
-        "t_tank_top": 15.3501,
-        "t_tank_bottom": 14.3794,
-        "t_collector": 17.2021,
+        "t_tank_top": 15.2366,
+        "t_tank_bottom": 14.2641,
+        "t_collector": 17.0908,
         "t_greenhouse": 13.6044,
         "t_outdoor": 12.1128
       },
@@ -1779,9 +1779,9 @@
     {
       "time": 9660,
       "values": {
-        "t_tank_top": 15.3869,
-        "t_tank_bottom": 14.4141,
-        "t_collector": 17.2425,
+        "t_tank_top": 15.2735,
+        "t_tank_bottom": 14.2988,
+        "t_collector": 17.1314,
         "t_greenhouse": 13.631,
         "t_outdoor": 12.1325
       },
@@ -1790,9 +1790,9 @@
     {
       "time": 9720,
       "values": {
-        "t_tank_top": 15.4237,
-        "t_tank_bottom": 14.4488,
-        "t_collector": 17.283,
+        "t_tank_top": 15.3104,
+        "t_tank_bottom": 14.3336,
+        "t_collector": 17.1719,
         "t_greenhouse": 13.6575,
         "t_outdoor": 12.1522
       },
@@ -1801,9 +1801,9 @@
     {
       "time": 9780,
       "values": {
-        "t_tank_top": 15.4606,
-        "t_tank_bottom": 14.4836,
-        "t_collector": 17.3235,
+        "t_tank_top": 15.3474,
+        "t_tank_bottom": 14.3685,
+        "t_collector": 17.2125,
         "t_greenhouse": 13.684,
         "t_outdoor": 12.1719
       },
@@ -1812,9 +1812,9 @@
     {
       "time": 9840,
       "values": {
-        "t_tank_top": 15.4976,
-        "t_tank_bottom": 14.5184,
-        "t_collector": 17.3641,
+        "t_tank_top": 15.3844,
+        "t_tank_bottom": 14.4034,
+        "t_collector": 17.2531,
         "t_greenhouse": 13.7105,
         "t_outdoor": 12.1915
       },
@@ -1823,9 +1823,9 @@
     {
       "time": 9900,
       "values": {
-        "t_tank_top": 15.5346,
-        "t_tank_bottom": 14.5533,
-        "t_collector": 17.4047,
+        "t_tank_top": 15.4215,
+        "t_tank_bottom": 14.4384,
+        "t_collector": 17.2938,
         "t_greenhouse": 13.7369,
         "t_outdoor": 12.2111
       },
@@ -1834,9 +1834,9 @@
     {
       "time": 9960,
       "values": {
-        "t_tank_top": 15.5717,
-        "t_tank_bottom": 14.5883,
-        "t_collector": 17.4453,
+        "t_tank_top": 15.4587,
+        "t_tank_bottom": 14.4735,
+        "t_collector": 17.3345,
         "t_greenhouse": 13.7633,
         "t_outdoor": 12.2307
       },
@@ -1845,9 +1845,9 @@
     {
       "time": 10020,
       "values": {
-        "t_tank_top": 15.6088,
-        "t_tank_bottom": 14.6234,
-        "t_collector": 17.4859,
+        "t_tank_top": 15.4959,
+        "t_tank_bottom": 14.5086,
+        "t_collector": 17.3752,
         "t_greenhouse": 13.7896,
         "t_outdoor": 12.2502
       },
@@ -1856,9 +1856,9 @@
     {
       "time": 10080,
       "values": {
-        "t_tank_top": 15.646,
-        "t_tank_bottom": 14.6585,
-        "t_collector": 17.5265,
+        "t_tank_top": 15.5331,
+        "t_tank_bottom": 14.5439,
+        "t_collector": 17.4159,
         "t_greenhouse": 13.8159,
         "t_outdoor": 12.2696
       },
@@ -1867,9 +1867,9 @@
     {
       "time": 10140,
       "values": {
-        "t_tank_top": 15.6832,
-        "t_tank_bottom": 14.6938,
-        "t_collector": 17.5672,
+        "t_tank_top": 15.5705,
+        "t_tank_bottom": 14.5792,
+        "t_collector": 17.4567,
         "t_greenhouse": 13.8422,
         "t_outdoor": 12.289
       },
@@ -1878,9 +1878,9 @@
     {
       "time": 10200,
       "values": {
-        "t_tank_top": 15.7205,
-        "t_tank_bottom": 14.729,
-        "t_collector": 17.6079,
+        "t_tank_top": 15.6078,
+        "t_tank_bottom": 14.6145,
+        "t_collector": 17.4974,
         "t_greenhouse": 13.8685,
         "t_outdoor": 12.3084
       },
@@ -1889,9 +1889,9 @@
     {
       "time": 10260,
       "values": {
-        "t_tank_top": 15.7578,
-        "t_tank_bottom": 14.7644,
-        "t_collector": 17.6486,
+        "t_tank_top": 15.6452,
+        "t_tank_bottom": 14.65,
+        "t_collector": 17.5382,
         "t_greenhouse": 13.8947,
         "t_outdoor": 12.3278
       },
@@ -1900,9 +1900,9 @@
     {
       "time": 10320,
       "values": {
-        "t_tank_top": 15.7952,
-        "t_tank_bottom": 14.7998,
-        "t_collector": 17.6894,
+        "t_tank_top": 15.6827,
+        "t_tank_bottom": 14.6855,
+        "t_collector": 17.5791,
         "t_greenhouse": 13.9208,
         "t_outdoor": 12.347
       },
@@ -1911,9 +1911,9 @@
     {
       "time": 10380,
       "values": {
-        "t_tank_top": 15.8327,
-        "t_tank_bottom": 14.8353,
-        "t_collector": 17.7301,
+        "t_tank_top": 15.7202,
+        "t_tank_bottom": 14.721,
+        "t_collector": 17.6199,
         "t_greenhouse": 13.9469,
         "t_outdoor": 12.3663
       },
@@ -1922,9 +1922,9 @@
     {
       "time": 10440,
       "values": {
-        "t_tank_top": 15.8702,
-        "t_tank_bottom": 14.8709,
-        "t_collector": 17.7709,
+        "t_tank_top": 15.7578,
+        "t_tank_bottom": 14.7567,
+        "t_collector": 17.6608,
         "t_greenhouse": 13.973,
         "t_outdoor": 12.3855
       },
@@ -1933,9 +1933,9 @@
     {
       "time": 10500,
       "values": {
-        "t_tank_top": 15.9077,
-        "t_tank_bottom": 14.9065,
-        "t_collector": 17.8118,
+        "t_tank_top": 15.7955,
+        "t_tank_bottom": 14.7924,
+        "t_collector": 17.7017,
         "t_greenhouse": 13.9991,
         "t_outdoor": 12.4046
       },
@@ -1944,9 +1944,9 @@
     {
       "time": 10560,
       "values": {
-        "t_tank_top": 15.9453,
-        "t_tank_bottom": 14.9422,
-        "t_collector": 17.8526,
+        "t_tank_top": 15.8331,
+        "t_tank_bottom": 14.8282,
+        "t_collector": 17.7426,
         "t_greenhouse": 14.0251,
         "t_outdoor": 12.4237
       },
@@ -1955,9 +1955,9 @@
     {
       "time": 10620,
       "values": {
-        "t_tank_top": 15.983,
-        "t_tank_bottom": 14.9779,
-        "t_collector": 17.8934,
+        "t_tank_top": 15.8709,
+        "t_tank_bottom": 14.864,
+        "t_collector": 17.7835,
         "t_greenhouse": 14.051,
         "t_outdoor": 12.4428
       },
@@ -1966,9 +1966,9 @@
     {
       "time": 10680,
       "values": {
-        "t_tank_top": 16.0207,
-        "t_tank_bottom": 15.0138,
-        "t_collector": 17.9343,
+        "t_tank_top": 15.9086,
+        "t_tank_bottom": 14.8999,
+        "t_collector": 17.8245,
         "t_greenhouse": 14.0769,
         "t_outdoor": 12.4618
       },
@@ -1977,9 +1977,9 @@
     {
       "time": 10740,
       "values": {
-        "t_tank_top": 16.0584,
-        "t_tank_bottom": 15.0496,
-        "t_collector": 17.9752,
+        "t_tank_top": 15.9465,
+        "t_tank_bottom": 14.9359,
+        "t_collector": 17.8655,
         "t_greenhouse": 14.1028,
         "t_outdoor": 12.4808
       },
@@ -1988,9 +1988,9 @@
     {
       "time": 10800,
       "values": {
-        "t_tank_top": 16.0962,
-        "t_tank_bottom": 15.0856,
-        "t_collector": 18.0161,
+        "t_tank_top": 15.9843,
+        "t_tank_bottom": 14.9719,
+        "t_collector": 17.9065,
         "t_greenhouse": 14.1286,
         "t_outdoor": 12.4997
       },
@@ -1999,9 +1999,9 @@
     {
       "time": 10860,
       "values": {
-        "t_tank_top": 16.1341,
-        "t_tank_bottom": 15.1216,
-        "t_collector": 18.0571,
+        "t_tank_top": 16.0223,
+        "t_tank_bottom": 15.008,
+        "t_collector": 17.9475,
         "t_greenhouse": 14.1543,
         "t_outdoor": 12.5186
       },
@@ -2010,9 +2010,9 @@
     {
       "time": 10920,
       "values": {
-        "t_tank_top": 16.1719,
-        "t_tank_bottom": 15.1577,
-        "t_collector": 18.098,
+        "t_tank_top": 16.0602,
+        "t_tank_bottom": 15.0442,
+        "t_collector": 17.9885,
         "t_greenhouse": 14.18,
         "t_outdoor": 12.5374
       },
@@ -2021,9 +2021,9 @@
     {
       "time": 10980,
       "values": {
-        "t_tank_top": 16.2099,
-        "t_tank_bottom": 15.1938,
-        "t_collector": 18.139,
+        "t_tank_top": 16.0982,
+        "t_tank_bottom": 15.0804,
+        "t_collector": 18.0295,
         "t_greenhouse": 14.2057,
         "t_outdoor": 12.5562
       },
@@ -2032,9 +2032,9 @@
     {
       "time": 11040,
       "values": {
-        "t_tank_top": 16.2479,
-        "t_tank_bottom": 15.23,
-        "t_collector": 18.1799,
+        "t_tank_top": 16.1363,
+        "t_tank_bottom": 15.1167,
+        "t_collector": 18.0706,
         "t_greenhouse": 14.2313,
         "t_outdoor": 12.5749
       },
@@ -2043,9 +2043,9 @@
     {
       "time": 11100,
       "values": {
-        "t_tank_top": 16.2859,
-        "t_tank_bottom": 15.2663,
-        "t_collector": 18.2209,
+        "t_tank_top": 16.1744,
+        "t_tank_bottom": 15.153,
+        "t_collector": 18.1116,
         "t_greenhouse": 14.2569,
         "t_outdoor": 12.5936
       },
@@ -2054,9 +2054,9 @@
     {
       "time": 11160,
       "values": {
-        "t_tank_top": 16.3239,
-        "t_tank_bottom": 15.3026,
-        "t_collector": 18.2619,
+        "t_tank_top": 16.2126,
+        "t_tank_bottom": 15.1894,
+        "t_collector": 18.1527,
         "t_greenhouse": 14.2824,
         "t_outdoor": 12.6122
       },
@@ -2065,9 +2065,9 @@
     {
       "time": 11220,
       "values": {
-        "t_tank_top": 16.3621,
-        "t_tank_bottom": 15.339,
-        "t_collector": 18.3029,
+        "t_tank_top": 16.2507,
+        "t_tank_bottom": 15.2259,
+        "t_collector": 18.1938,
         "t_greenhouse": 14.3078,
         "t_outdoor": 12.6308
       },
@@ -2076,9 +2076,9 @@
     {
       "time": 11280,
       "values": {
-        "t_tank_top": 16.4002,
-        "t_tank_bottom": 15.3754,
-        "t_collector": 18.344,
+        "t_tank_top": 16.289,
+        "t_tank_bottom": 15.2624,
+        "t_collector": 18.2349,
         "t_greenhouse": 14.3332,
         "t_outdoor": 12.6493
       },
@@ -2087,9 +2087,9 @@
     {
       "time": 11340,
       "values": {
-        "t_tank_top": 16.4384,
-        "t_tank_bottom": 15.4119,
-        "t_collector": 18.385,
+        "t_tank_top": 16.3272,
+        "t_tank_bottom": 15.299,
+        "t_collector": 18.2761,
         "t_greenhouse": 14.3586,
         "t_outdoor": 12.6678
       },
@@ -2098,9 +2098,9 @@
     {
       "time": 11400,
       "values": {
-        "t_tank_top": 16.4766,
-        "t_tank_bottom": 15.4485,
-        "t_collector": 18.4261,
+        "t_tank_top": 16.3656,
+        "t_tank_bottom": 15.3356,
+        "t_collector": 18.3172,
         "t_greenhouse": 14.3839,
         "t_outdoor": 12.6862
       },
@@ -2109,9 +2109,9 @@
     {
       "time": 11460,
       "values": {
-        "t_tank_top": 16.5149,
-        "t_tank_bottom": 15.4851,
-        "t_collector": 18.4671,
+        "t_tank_top": 16.4039,
+        "t_tank_bottom": 15.3723,
+        "t_collector": 18.3583,
         "t_greenhouse": 14.4091,
         "t_outdoor": 12.7046
       },
@@ -2120,9 +2120,9 @@
     {
       "time": 11520,
       "values": {
-        "t_tank_top": 16.5532,
-        "t_tank_bottom": 15.5218,
-        "t_collector": 18.5082,
+        "t_tank_top": 16.4423,
+        "t_tank_bottom": 15.4091,
+        "t_collector": 18.3995,
         "t_greenhouse": 14.4342,
         "t_outdoor": 12.7229
       },
@@ -2131,9 +2131,9 @@
     {
       "time": 11580,
       "values": {
-        "t_tank_top": 16.5916,
-        "t_tank_bottom": 15.5585,
-        "t_collector": 18.5493,
+        "t_tank_top": 16.4807,
+        "t_tank_bottom": 15.4459,
+        "t_collector": 18.4406,
         "t_greenhouse": 14.4594,
         "t_outdoor": 12.7412
       },
@@ -2142,9 +2142,9 @@
     {
       "time": 11640,
       "values": {
-        "t_tank_top": 16.63,
-        "t_tank_bottom": 15.5953,
-        "t_collector": 18.5904,
+        "t_tank_top": 16.5192,
+        "t_tank_bottom": 15.4828,
+        "t_collector": 18.4818,
         "t_greenhouse": 14.4844,
         "t_outdoor": 12.7594
       },
@@ -2153,9 +2153,9 @@
     {
       "time": 11700,
       "values": {
-        "t_tank_top": 16.6684,
-        "t_tank_bottom": 15.6322,
-        "t_collector": 18.6315,
+        "t_tank_top": 16.5577,
+        "t_tank_bottom": 15.5197,
+        "t_collector": 18.523,
         "t_greenhouse": 14.5094,
         "t_outdoor": 12.7775
       },
@@ -2164,9 +2164,9 @@
     {
       "time": 11760,
       "values": {
-        "t_tank_top": 16.7069,
-        "t_tank_bottom": 15.669,
-        "t_collector": 18.6726,
+        "t_tank_top": 16.5963,
+        "t_tank_bottom": 15.5567,
+        "t_collector": 18.5642,
         "t_greenhouse": 14.5343,
         "t_outdoor": 12.7957
       },
@@ -2175,9 +2175,9 @@
     {
       "time": 11820,
       "values": {
-        "t_tank_top": 16.7454,
-        "t_tank_bottom": 15.706,
-        "t_collector": 18.7137,
+        "t_tank_top": 16.6349,
+        "t_tank_bottom": 15.5937,
+        "t_collector": 18.6054,
         "t_greenhouse": 14.5592,
         "t_outdoor": 12.8137
       },
@@ -2186,9 +2186,9 @@
     {
       "time": 11880,
       "values": {
-        "t_tank_top": 16.7839,
-        "t_tank_bottom": 15.743,
-        "t_collector": 18.7548,
+        "t_tank_top": 16.6735,
+        "t_tank_bottom": 15.6308,
+        "t_collector": 18.6466,
         "t_greenhouse": 14.584,
         "t_outdoor": 12.8317
       },
@@ -2197,9 +2197,9 @@
     {
       "time": 11940,
       "values": {
-        "t_tank_top": 16.8225,
-        "t_tank_bottom": 15.78,
-        "t_collector": 18.7959,
+        "t_tank_top": 16.7121,
+        "t_tank_bottom": 15.6679,
+        "t_collector": 18.6878,
         "t_greenhouse": 14.6088,
         "t_outdoor": 12.8497
       },
@@ -2208,9 +2208,9 @@
     {
       "time": 12000,
       "values": {
-        "t_tank_top": 16.8611,
-        "t_tank_bottom": 15.8172,
-        "t_collector": 18.8371,
+        "t_tank_top": 16.7508,
+        "t_tank_bottom": 15.7051,
+        "t_collector": 18.729,
         "t_greenhouse": 14.6334,
         "t_outdoor": 12.8676
       },
@@ -2219,9 +2219,9 @@
     {
       "time": 12060,
       "values": {
-        "t_tank_top": 16.8998,
-        "t_tank_bottom": 15.8543,
-        "t_collector": 18.8782,
+        "t_tank_top": 16.7896,
+        "t_tank_bottom": 15.7423,
+        "t_collector": 18.7702,
         "t_greenhouse": 14.6581,
         "t_outdoor": 12.8854
       },
@@ -2230,9 +2230,9 @@
     {
       "time": 12120,
       "values": {
-        "t_tank_top": 16.9384,
-        "t_tank_bottom": 15.8915,
-        "t_collector": 18.9193,
+        "t_tank_top": 16.8283,
+        "t_tank_bottom": 15.7796,
+        "t_collector": 18.8114,
         "t_greenhouse": 14.6826,
         "t_outdoor": 12.9032
       },
@@ -2241,9 +2241,9 @@
     {
       "time": 12180,
       "values": {
-        "t_tank_top": 16.9772,
-        "t_tank_bottom": 15.9288,
-        "t_collector": 18.9605,
+        "t_tank_top": 16.8671,
+        "t_tank_bottom": 15.8169,
+        "t_collector": 18.8526,
         "t_greenhouse": 14.7071,
         "t_outdoor": 12.921
       },
@@ -2252,9 +2252,9 @@
     {
       "time": 12240,
       "values": {
-        "t_tank_top": 17.0159,
-        "t_tank_bottom": 15.9661,
-        "t_collector": 19.0016,
+        "t_tank_top": 16.9059,
+        "t_tank_bottom": 15.8543,
+        "t_collector": 18.8938,
         "t_greenhouse": 14.7315,
         "t_outdoor": 12.9386
       },
@@ -2263,9 +2263,9 @@
     {
       "time": 12300,
       "values": {
-        "t_tank_top": 17.0547,
-        "t_tank_bottom": 16.0034,
-        "t_collector": 19.0428,
+        "t_tank_top": 16.9448,
+        "t_tank_bottom": 15.8918,
+        "t_collector": 18.935,
         "t_greenhouse": 14.7559,
         "t_outdoor": 12.9563
       },
@@ -2274,9 +2274,9 @@
     {
       "time": 12360,
       "values": {
-        "t_tank_top": 17.0935,
-        "t_tank_bottom": 16.0408,
-        "t_collector": 19.0839,
+        "t_tank_top": 16.9837,
+        "t_tank_bottom": 15.9292,
+        "t_collector": 18.9763,
         "t_greenhouse": 14.7802,
         "t_outdoor": 12.9738
       },
@@ -2285,9 +2285,9 @@
     {
       "time": 12420,
       "values": {
-        "t_tank_top": 17.1323,
-        "t_tank_bottom": 16.0783,
-        "t_collector": 19.125,
+        "t_tank_top": 17.0226,
+        "t_tank_bottom": 15.9668,
+        "t_collector": 19.0175,
         "t_greenhouse": 14.8044,
         "t_outdoor": 12.9913
       },
@@ -2296,9 +2296,9 @@
     {
       "time": 12480,
       "values": {
-        "t_tank_top": 17.1712,
-        "t_tank_bottom": 16.1158,
-        "t_collector": 19.1662,
+        "t_tank_top": 17.0615,
+        "t_tank_bottom": 16.0044,
+        "t_collector": 19.0587,
         "t_greenhouse": 14.8285,
         "t_outdoor": 13.0088
       },
@@ -2307,9 +2307,9 @@
     {
       "time": 12540,
       "values": {
-        "t_tank_top": 17.2101,
-        "t_tank_bottom": 16.1533,
-        "t_collector": 19.2073,
+        "t_tank_top": 17.1005,
+        "t_tank_bottom": 16.042,
+        "t_collector": 19.0999,
         "t_greenhouse": 14.8526,
         "t_outdoor": 13.0262
       },
@@ -2318,9 +2318,9 @@
     {
       "time": 12600,
       "values": {
-        "t_tank_top": 17.249,
-        "t_tank_bottom": 16.1909,
-        "t_collector": 19.2484,
+        "t_tank_top": 17.1395,
+        "t_tank_bottom": 16.0796,
+        "t_collector": 19.1411,
         "t_greenhouse": 14.8766,
         "t_outdoor": 13.0435
       },
@@ -2329,9 +2329,9 @@
     {
       "time": 12660,
       "values": {
-        "t_tank_top": 17.288,
-        "t_tank_bottom": 16.2285,
-        "t_collector": 19.2896,
+        "t_tank_top": 17.1786,
+        "t_tank_bottom": 16.1174,
+        "t_collector": 19.1823,
         "t_greenhouse": 14.9006,
         "t_outdoor": 13.0608
       },
@@ -2340,9 +2340,9 @@
     {
       "time": 12720,
       "values": {
-        "t_tank_top": 17.3269,
-        "t_tank_bottom": 16.2662,
-        "t_collector": 19.3307,
+        "t_tank_top": 17.2176,
+        "t_tank_bottom": 16.1551,
+        "t_collector": 19.2235,
         "t_greenhouse": 14.9244,
         "t_outdoor": 13.078
       },
@@ -2351,9 +2351,9 @@
     {
       "time": 12780,
       "values": {
-        "t_tank_top": 17.366,
-        "t_tank_bottom": 16.3039,
-        "t_collector": 19.3718,
+        "t_tank_top": 17.2567,
+        "t_tank_bottom": 16.1929,
+        "t_collector": 19.2647,
         "t_greenhouse": 14.9482,
         "t_outdoor": 13.0952
       },
@@ -2362,9 +2362,9 @@
     {
       "time": 12840,
       "values": {
-        "t_tank_top": 17.405,
-        "t_tank_bottom": 16.3417,
-        "t_collector": 19.4129,
+        "t_tank_top": 17.2958,
+        "t_tank_bottom": 16.2308,
+        "t_collector": 19.3059,
         "t_greenhouse": 14.9719,
         "t_outdoor": 13.1123
       },
@@ -2373,9 +2373,9 @@
     {
       "time": 12900,
       "values": {
-        "t_tank_top": 17.444,
-        "t_tank_bottom": 16.3795,
-        "t_collector": 19.4541,
+        "t_tank_top": 17.335,
+        "t_tank_bottom": 16.2686,
+        "t_collector": 19.3471,
         "t_greenhouse": 14.9956,
         "t_outdoor": 13.1293
       },
@@ -2384,9 +2384,9 @@
     {
       "time": 12960,
       "values": {
-        "t_tank_top": 17.4831,
-        "t_tank_bottom": 16.4174,
-        "t_collector": 19.4952,
+        "t_tank_top": 17.3741,
+        "t_tank_bottom": 16.3066,
+        "t_collector": 19.3883,
         "t_greenhouse": 15.0192,
         "t_outdoor": 13.1463
       },
@@ -2395,9 +2395,9 @@
     {
       "time": 13020,
       "values": {
-        "t_tank_top": 17.5222,
-        "t_tank_bottom": 16.4553,
-        "t_collector": 19.5363,
+        "t_tank_top": 17.4133,
+        "t_tank_bottom": 16.3445,
+        "t_collector": 19.4295,
         "t_greenhouse": 15.0426,
         "t_outdoor": 13.1632
       },
@@ -2406,9 +2406,9 @@
     {
       "time": 13080,
       "values": {
-        "t_tank_top": 17.5614,
-        "t_tank_bottom": 16.4932,
-        "t_collector": 19.5773,
+        "t_tank_top": 17.4525,
+        "t_tank_bottom": 16.3826,
+        "t_collector": 19.4706,
         "t_greenhouse": 15.0661,
         "t_outdoor": 13.1801
       },
@@ -2417,9 +2417,9 @@
     {
       "time": 13140,
       "values": {
-        "t_tank_top": 17.6005,
-        "t_tank_bottom": 16.5311,
-        "t_collector": 19.6184,
+        "t_tank_top": 17.4917,
+        "t_tank_bottom": 16.4206,
+        "t_collector": 19.5118,
         "t_greenhouse": 15.0894,
         "t_outdoor": 13.1969
       },
@@ -2428,9 +2428,9 @@
     {
       "time": 13200,
       "values": {
-        "t_tank_top": 17.6397,
-        "t_tank_bottom": 16.5692,
-        "t_collector": 19.6595,
+        "t_tank_top": 17.531,
+        "t_tank_bottom": 16.4587,
+        "t_collector": 19.5529,
         "t_greenhouse": 15.1127,
         "t_outdoor": 13.2137
       },
@@ -2439,9 +2439,9 @@
     {
       "time": 13260,
       "values": {
-        "t_tank_top": 17.6789,
-        "t_tank_bottom": 16.6072,
-        "t_collector": 19.7006,
+        "t_tank_top": 17.5703,
+        "t_tank_bottom": 16.4968,
+        "t_collector": 19.5941,
         "t_greenhouse": 15.1359,
         "t_outdoor": 13.2303
       },
@@ -2450,9 +2450,9 @@
     {
       "time": 13320,
       "values": {
-        "t_tank_top": 17.7181,
-        "t_tank_bottom": 16.6453,
-        "t_collector": 19.7416,
+        "t_tank_top": 17.6096,
+        "t_tank_bottom": 16.535,
+        "t_collector": 19.6352,
         "t_greenhouse": 15.159,
         "t_outdoor": 13.247
       },
@@ -2461,9 +2461,9 @@
     {
       "time": 13380,
       "values": {
-        "t_tank_top": 17.7573,
-        "t_tank_bottom": 16.6834,
-        "t_collector": 19.7827,
+        "t_tank_top": 17.6489,
+        "t_tank_bottom": 16.5732,
+        "t_collector": 19.6763,
         "t_greenhouse": 15.182,
         "t_outdoor": 13.2635
       },
@@ -2472,9 +2472,9 @@
     {
       "time": 13440,
       "values": {
-        "t_tank_top": 17.7966,
-        "t_tank_bottom": 16.7216,
-        "t_collector": 19.8237,
+        "t_tank_top": 17.6882,
+        "t_tank_bottom": 16.6114,
+        "t_collector": 19.7174,
         "t_greenhouse": 15.205,
         "t_outdoor": 13.28
       },
@@ -2483,9 +2483,9 @@
     {
       "time": 13500,
       "values": {
-        "t_tank_top": 17.8359,
-        "t_tank_bottom": 16.7598,
-        "t_collector": 19.8647,
+        "t_tank_top": 17.7276,
+        "t_tank_bottom": 16.6497,
+        "t_collector": 19.7585,
         "t_greenhouse": 15.2279,
         "t_outdoor": 13.2965
       },
@@ -2494,9 +2494,9 @@
     {
       "time": 13560,
       "values": {
-        "t_tank_top": 17.8752,
-        "t_tank_bottom": 16.798,
-        "t_collector": 19.9057,
+        "t_tank_top": 17.7669,
+        "t_tank_bottom": 16.688,
+        "t_collector": 19.7996,
         "t_greenhouse": 15.2507,
         "t_outdoor": 13.3128
       },
@@ -2505,9 +2505,9 @@
     {
       "time": 13620,
       "values": {
-        "t_tank_top": 17.9145,
-        "t_tank_bottom": 16.8363,
-        "t_collector": 19.9467,
+        "t_tank_top": 17.8063,
+        "t_tank_bottom": 16.7263,
+        "t_collector": 19.8407,
         "t_greenhouse": 15.2734,
         "t_outdoor": 13.3291
       },
@@ -2516,9 +2516,9 @@
     {
       "time": 13680,
       "values": {
-        "t_tank_top": 17.9538,
-        "t_tank_bottom": 16.8746,
-        "t_collector": 19.9877,
+        "t_tank_top": 17.8457,
+        "t_tank_bottom": 16.7647,
+        "t_collector": 19.8817,
         "t_greenhouse": 15.296,
         "t_outdoor": 13.3454
       },
@@ -2527,9 +2527,9 @@
     {
       "time": 13740,
       "values": {
-        "t_tank_top": 17.9931,
-        "t_tank_bottom": 16.9129,
-        "t_collector": 20.0286,
+        "t_tank_top": 17.8851,
+        "t_tank_bottom": 16.8031,
+        "t_collector": 19.9228,
         "t_greenhouse": 15.3186,
         "t_outdoor": 13.3616
       },
@@ -2538,9 +2538,9 @@
     {
       "time": 13800,
       "values": {
-        "t_tank_top": 18.0325,
-        "t_tank_bottom": 16.9513,
-        "t_collector": 20.0696,
+        "t_tank_top": 17.9246,
+        "t_tank_bottom": 16.8416,
+        "t_collector": 19.9638,
         "t_greenhouse": 15.3411,
         "t_outdoor": 13.3777
       },
@@ -2549,9 +2549,9 @@
     {
       "time": 13860,
       "values": {
-        "t_tank_top": 18.0719,
-        "t_tank_bottom": 16.9897,
-        "t_collector": 20.1105,
+        "t_tank_top": 17.964,
+        "t_tank_bottom": 16.8801,
+        "t_collector": 20.0048,
         "t_greenhouse": 15.3634,
         "t_outdoor": 13.3937
       },
@@ -2560,9 +2560,9 @@
     {
       "time": 13920,
       "values": {
-        "t_tank_top": 18.1112,
-        "t_tank_bottom": 17.0281,
-        "t_collector": 20.1514,
+        "t_tank_top": 18.0035,
+        "t_tank_bottom": 16.9186,
+        "t_collector": 20.0458,
         "t_greenhouse": 15.3858,
         "t_outdoor": 13.4097
       },
@@ -2571,9 +2571,9 @@
     {
       "time": 13980,
       "values": {
-        "t_tank_top": 18.1506,
-        "t_tank_bottom": 17.0665,
-        "t_collector": 20.1923,
+        "t_tank_top": 18.043,
+        "t_tank_bottom": 16.9571,
+        "t_collector": 20.0867,
         "t_greenhouse": 15.408,
         "t_outdoor": 13.4257
       },
@@ -2582,9 +2582,9 @@
     {
       "time": 14040,
       "values": {
-        "t_tank_top": 18.1901,
-        "t_tank_bottom": 17.105,
-        "t_collector": 20.2332,
+        "t_tank_top": 18.0824,
+        "t_tank_bottom": 16.9957,
+        "t_collector": 20.1277,
         "t_greenhouse": 15.4301,
         "t_outdoor": 13.4415
       },
@@ -2593,9 +2593,9 @@
     {
       "time": 14100,
       "values": {
-        "t_tank_top": 18.2295,
-        "t_tank_bottom": 17.1436,
-        "t_collector": 20.274,
+        "t_tank_top": 18.1219,
+        "t_tank_bottom": 17.0343,
+        "t_collector": 20.1686,
         "t_greenhouse": 15.4522,
         "t_outdoor": 13.4573
       },
@@ -2604,9 +2604,9 @@
     {
       "time": 14160,
       "values": {
-        "t_tank_top": 18.2689,
-        "t_tank_bottom": 17.1821,
-        "t_collector": 20.3149,
+        "t_tank_top": 18.1615,
+        "t_tank_bottom": 17.0729,
+        "t_collector": 20.2095,
         "t_greenhouse": 15.4741,
         "t_outdoor": 13.473
       },
@@ -2615,9 +2615,9 @@
     {
       "time": 14220,
       "values": {
-        "t_tank_top": 18.3084,
-        "t_tank_bottom": 17.2207,
-        "t_collector": 20.3557,
+        "t_tank_top": 18.201,
+        "t_tank_bottom": 17.1116,
+        "t_collector": 20.2504,
         "t_greenhouse": 15.496,
         "t_outdoor": 13.4887
       },
@@ -2626,9 +2626,9 @@
     {
       "time": 14280,
       "values": {
-        "t_tank_top": 18.3478,
-        "t_tank_bottom": 17.2593,
-        "t_collector": 20.3965,
+        "t_tank_top": 18.2405,
+        "t_tank_bottom": 17.1502,
+        "t_collector": 20.2913,
         "t_greenhouse": 15.5178,
         "t_outdoor": 13.5043
       },
@@ -2637,9 +2637,9 @@
     {
       "time": 14340,
       "values": {
-        "t_tank_top": 18.3873,
-        "t_tank_bottom": 17.2979,
-        "t_collector": 20.4372,
+        "t_tank_top": 18.2801,
+        "t_tank_bottom": 17.1889,
+        "t_collector": 20.3321,
         "t_greenhouse": 15.5395,
         "t_outdoor": 13.5198
       },
@@ -2648,9 +2648,9 @@
     {
       "time": 14400,
       "values": {
-        "t_tank_top": 18.4268,
-        "t_tank_bottom": 17.3366,
-        "t_collector": 20.478,
+        "t_tank_top": 18.3196,
+        "t_tank_bottom": 17.2277,
+        "t_collector": 20.373,
         "t_greenhouse": 15.5612,
         "t_outdoor": 13.5353
       },
@@ -2659,9 +2659,9 @@
     {
       "time": 14460,
       "values": {
-        "t_tank_top": 18.4662,
-        "t_tank_bottom": 17.3753,
-        "t_collector": 20.5187,
+        "t_tank_top": 18.3592,
+        "t_tank_bottom": 17.2664,
+        "t_collector": 20.4138,
         "t_greenhouse": 15.5827,
         "t_outdoor": 13.5507
       },
@@ -2670,9 +2670,9 @@
     {
       "time": 14520,
       "values": {
-        "t_tank_top": 18.5057,
-        "t_tank_bottom": 17.414,
-        "t_collector": 20.5594,
+        "t_tank_top": 18.3987,
+        "t_tank_bottom": 17.3052,
+        "t_collector": 20.4545,
         "t_greenhouse": 15.6042,
         "t_outdoor": 13.566
       },
@@ -2681,9 +2681,9 @@
     {
       "time": 14580,
       "values": {
-        "t_tank_top": 18.5452,
-        "t_tank_bottom": 17.4527,
-        "t_collector": 20.6001,
+        "t_tank_top": 18.4383,
+        "t_tank_bottom": 17.344,
+        "t_collector": 20.4953,
         "t_greenhouse": 15.6255,
         "t_outdoor": 13.5813
       },
@@ -2692,9 +2692,9 @@
     {
       "time": 14640,
       "values": {
-        "t_tank_top": 18.5847,
-        "t_tank_bottom": 17.4915,
-        "t_collector": 20.6407,
+        "t_tank_top": 18.4779,
+        "t_tank_bottom": 17.3829,
+        "t_collector": 20.536,
         "t_greenhouse": 15.6468,
         "t_outdoor": 13.5964
       },
@@ -2703,9 +2703,9 @@
     {
       "time": 14700,
       "values": {
-        "t_tank_top": 18.6242,
-        "t_tank_bottom": 17.5302,
-        "t_collector": 20.6814,
+        "t_tank_top": 18.5175,
+        "t_tank_bottom": 17.4217,
+        "t_collector": 20.5767,
         "t_greenhouse": 15.668,
         "t_outdoor": 13.6116
       },
@@ -2714,9 +2714,9 @@
     {
       "time": 14760,
       "values": {
-        "t_tank_top": 18.6637,
-        "t_tank_bottom": 17.569,
-        "t_collector": 20.722,
+        "t_tank_top": 18.5571,
+        "t_tank_bottom": 17.4606,
+        "t_collector": 20.6174,
         "t_greenhouse": 15.6891,
         "t_outdoor": 13.6266
       },
@@ -2725,9 +2725,9 @@
     {
       "time": 14820,
       "values": {
-        "t_tank_top": 18.7033,
-        "t_tank_bottom": 17.6079,
-        "t_collector": 20.7625,
+        "t_tank_top": 18.5967,
+        "t_tank_bottom": 17.4995,
+        "t_collector": 20.658,
         "t_greenhouse": 15.7101,
         "t_outdoor": 13.6416
       },
@@ -2736,9 +2736,9 @@
     {
       "time": 14880,
       "values": {
-        "t_tank_top": 18.7428,
-        "t_tank_bottom": 17.6467,
-        "t_collector": 20.8031,
+        "t_tank_top": 18.6363,
+        "t_tank_bottom": 17.5384,
+        "t_collector": 20.6986,
         "t_greenhouse": 15.731,
         "t_outdoor": 13.6565
       },
@@ -2747,9 +2747,9 @@
     {
       "time": 14940,
       "values": {
-        "t_tank_top": 18.7823,
-        "t_tank_bottom": 17.6856,
-        "t_collector": 20.8436,
+        "t_tank_top": 18.6759,
+        "t_tank_bottom": 17.5774,
+        "t_collector": 20.7392,
         "t_greenhouse": 15.7518,
         "t_outdoor": 13.6714
       },
@@ -2758,9 +2758,9 @@
     {
       "time": 15000,
       "values": {
-        "t_tank_top": 18.8218,
-        "t_tank_bottom": 17.7245,
-        "t_collector": 20.8841,
+        "t_tank_top": 18.7155,
+        "t_tank_bottom": 17.6164,
+        "t_collector": 20.7798,
         "t_greenhouse": 15.7725,
         "t_outdoor": 13.6861
       },
@@ -2769,9 +2769,9 @@
     {
       "time": 15060,
       "values": {
-        "t_tank_top": 18.8614,
-        "t_tank_bottom": 17.7634,
-        "t_collector": 20.9245,
+        "t_tank_top": 18.7551,
+        "t_tank_bottom": 17.6553,
+        "t_collector": 20.8203,
         "t_greenhouse": 15.7931,
         "t_outdoor": 13.7008
       },
@@ -2780,9 +2780,9 @@
     {
       "time": 15120,
       "values": {
-        "t_tank_top": 18.9009,
-        "t_tank_bottom": 17.8023,
-        "t_collector": 20.9649,
+        "t_tank_top": 18.7947,
+        "t_tank_bottom": 17.6943,
+        "t_collector": 20.8608,
         "t_greenhouse": 15.8137,
         "t_outdoor": 13.7155
       },
@@ -2791,9 +2791,9 @@
     {
       "time": 15180,
       "values": {
-        "t_tank_top": 18.9404,
-        "t_tank_bottom": 17.8412,
-        "t_collector": 21.0053,
+        "t_tank_top": 18.8343,
+        "t_tank_bottom": 17.7334,
+        "t_collector": 20.9013,
         "t_greenhouse": 15.8341,
         "t_outdoor": 13.73
       },
@@ -2802,9 +2802,9 @@
     {
       "time": 15240,
       "values": {
-        "t_tank_top": 18.98,
-        "t_tank_bottom": 17.8802,
-        "t_collector": 21.0457,
+        "t_tank_top": 18.8739,
+        "t_tank_bottom": 17.7724,
+        "t_collector": 20.9417,
         "t_greenhouse": 15.8545,
         "t_outdoor": 13.7445
       },
@@ -2813,9 +2813,9 @@
     {
       "time": 15300,
       "values": {
-        "t_tank_top": 19.0195,
-        "t_tank_bottom": 17.9192,
-        "t_collector": 21.086,
+        "t_tank_top": 18.9135,
+        "t_tank_bottom": 17.8114,
+        "t_collector": 20.9821,
         "t_greenhouse": 15.8747,
         "t_outdoor": 13.759
       },
@@ -2824,9 +2824,9 @@
     {
       "time": 15360,
       "values": {
-        "t_tank_top": 19.059,
-        "t_tank_bottom": 17.9582,
-        "t_collector": 21.1263,
+        "t_tank_top": 18.9531,
+        "t_tank_bottom": 17.8505,
+        "t_collector": 21.0225,
         "t_greenhouse": 15.8949,
         "t_outdoor": 13.7733
       },
@@ -2835,9 +2835,9 @@
     {
       "time": 15420,
       "values": {
-        "t_tank_top": 19.0985,
-        "t_tank_bottom": 17.9972,
-        "t_collector": 21.1666,
+        "t_tank_top": 18.9927,
+        "t_tank_bottom": 17.8896,
+        "t_collector": 21.0628,
         "t_greenhouse": 15.915,
         "t_outdoor": 13.7876
       },
@@ -2846,9 +2846,9 @@
     {
       "time": 15480,
       "values": {
-        "t_tank_top": 19.138,
-        "t_tank_bottom": 18.0362,
-        "t_collector": 21.2068,
+        "t_tank_top": 19.0323,
+        "t_tank_bottom": 17.9287,
+        "t_collector": 21.1031,
         "t_greenhouse": 15.9349,
         "t_outdoor": 13.8018
       },
@@ -2857,9 +2857,9 @@
     {
       "time": 15540,
       "values": {
-        "t_tank_top": 19.1776,
-        "t_tank_bottom": 18.0752,
-        "t_collector": 21.247,
+        "t_tank_top": 19.0719,
+        "t_tank_bottom": 17.9678,
+        "t_collector": 21.1434,
         "t_greenhouse": 15.9548,
         "t_outdoor": 13.8159
       },
@@ -2868,9 +2868,9 @@
     {
       "time": 15600,
       "values": {
-        "t_tank_top": 19.2171,
-        "t_tank_bottom": 18.1143,
-        "t_collector": 21.2871,
+        "t_tank_top": 19.1115,
+        "t_tank_bottom": 18.0069,
+        "t_collector": 21.1836,
         "t_greenhouse": 15.9746,
         "t_outdoor": 13.83
       },
@@ -2879,9 +2879,9 @@
     {
       "time": 15660,
       "values": {
-        "t_tank_top": 19.2566,
-        "t_tank_bottom": 18.1533,
-        "t_collector": 21.3272,
+        "t_tank_top": 19.151,
+        "t_tank_bottom": 18.0461,
+        "t_collector": 21.2238,
         "t_greenhouse": 15.9943,
         "t_outdoor": 13.844
       },
@@ -2890,9 +2890,9 @@
     {
       "time": 15720,
       "values": {
-        "t_tank_top": 19.2961,
-        "t_tank_bottom": 18.1924,
-        "t_collector": 21.3673,
+        "t_tank_top": 19.1906,
+        "t_tank_bottom": 18.0852,
+        "t_collector": 21.2639,
         "t_greenhouse": 16.0139,
         "t_outdoor": 13.8579
       },
@@ -2901,9 +2901,9 @@
     {
       "time": 15780,
       "values": {
-        "t_tank_top": 19.3356,
-        "t_tank_bottom": 18.2315,
-        "t_collector": 21.4074,
+        "t_tank_top": 19.2302,
+        "t_tank_bottom": 18.1244,
+        "t_collector": 21.3041,
         "t_greenhouse": 16.0333,
         "t_outdoor": 13.8717
       },
@@ -2912,9 +2912,9 @@
     {
       "time": 15840,
       "values": {
-        "t_tank_top": 19.3751,
-        "t_tank_bottom": 18.2706,
-        "t_collector": 21.4474,
+        "t_tank_top": 19.2698,
+        "t_tank_bottom": 18.1636,
+        "t_collector": 21.3441,
         "t_greenhouse": 16.0527,
         "t_outdoor": 13.8855
       },
@@ -2923,9 +2923,9 @@
     {
       "time": 15900,
       "values": {
-        "t_tank_top": 19.4145,
-        "t_tank_bottom": 18.3097,
-        "t_collector": 21.4873,
+        "t_tank_top": 19.3093,
+        "t_tank_bottom": 18.2027,
+        "t_collector": 21.3842,
         "t_greenhouse": 16.072,
         "t_outdoor": 13.8992
       },
@@ -2934,9 +2934,9 @@
     {
       "time": 15960,
       "values": {
-        "t_tank_top": 19.454,
-        "t_tank_bottom": 18.3488,
-        "t_collector": 21.5272,
+        "t_tank_top": 19.3489,
+        "t_tank_bottom": 18.2419,
+        "t_collector": 21.4242,
         "t_greenhouse": 16.0912,
         "t_outdoor": 13.9128
       },
@@ -2945,9 +2945,9 @@
     {
       "time": 16020,
       "values": {
-        "t_tank_top": 19.4935,
-        "t_tank_bottom": 18.3879,
-        "t_collector": 21.5671,
+        "t_tank_top": 19.3884,
+        "t_tank_bottom": 18.2811,
+        "t_collector": 21.4641,
         "t_greenhouse": 16.1103,
         "t_outdoor": 13.9264
       },
@@ -2956,9 +2956,9 @@
     {
       "time": 16080,
       "values": {
-        "t_tank_top": 19.5329,
-        "t_tank_bottom": 18.4271,
-        "t_collector": 21.607,
+        "t_tank_top": 19.4279,
+        "t_tank_bottom": 18.3204,
+        "t_collector": 21.504,
         "t_greenhouse": 16.1293,
         "t_outdoor": 13.9398
       },
@@ -2967,9 +2967,9 @@
     {
       "time": 16140,
       "values": {
-        "t_tank_top": 19.5724,
-        "t_tank_bottom": 18.4662,
-        "t_collector": 21.6468,
+        "t_tank_top": 19.4674,
+        "t_tank_bottom": 18.3596,
+        "t_collector": 21.5439,
         "t_greenhouse": 16.1482,
         "t_outdoor": 13.9532
       },
@@ -2978,9 +2978,9 @@
     {
       "time": 16200,
       "values": {
-        "t_tank_top": 19.6118,
-        "t_tank_bottom": 18.5054,
-        "t_collector": 21.6865,
+        "t_tank_top": 19.507,
+        "t_tank_bottom": 18.3988,
+        "t_collector": 21.5837,
         "t_greenhouse": 16.167,
         "t_outdoor": 13.9665
       },
@@ -2989,9 +2989,9 @@
     {
       "time": 16260,
       "values": {
-        "t_tank_top": 19.6512,
-        "t_tank_bottom": 18.5445,
-        "t_collector": 21.7262,
+        "t_tank_top": 19.5465,
+        "t_tank_bottom": 18.438,
+        "t_collector": 21.6235,
         "t_greenhouse": 16.1857,
         "t_outdoor": 13.9798
       },
@@ -3000,9 +3000,9 @@
     {
       "time": 16320,
       "values": {
-        "t_tank_top": 19.6906,
-        "t_tank_bottom": 18.5837,
-        "t_collector": 21.7659,
+        "t_tank_top": 19.5859,
+        "t_tank_bottom": 18.4773,
+        "t_collector": 21.6632,
         "t_greenhouse": 16.2043,
         "t_outdoor": 13.993
       },
@@ -3011,9 +3011,9 @@
     {
       "time": 16380,
       "values": {
-        "t_tank_top": 19.73,
-        "t_tank_bottom": 18.6228,
-        "t_collector": 21.8055,
+        "t_tank_top": 19.6254,
+        "t_tank_bottom": 18.5165,
+        "t_collector": 21.7029,
         "t_greenhouse": 16.2228,
         "t_outdoor": 14.0061
       },
@@ -3022,9 +3022,9 @@
     {
       "time": 16440,
       "values": {
-        "t_tank_top": 19.7694,
-        "t_tank_bottom": 18.662,
-        "t_collector": 21.8451,
+        "t_tank_top": 19.6649,
+        "t_tank_bottom": 18.5557,
+        "t_collector": 21.7426,
         "t_greenhouse": 16.2412,
         "t_outdoor": 14.0191
       },
@@ -3033,9 +3033,9 @@
     {
       "time": 16500,
       "values": {
-        "t_tank_top": 19.8088,
-        "t_tank_bottom": 18.7012,
-        "t_collector": 21.8846,
+        "t_tank_top": 19.7043,
+        "t_tank_bottom": 18.595,
+        "t_collector": 21.7822,
         "t_greenhouse": 16.2594,
         "t_outdoor": 14.032
       },
@@ -3044,9 +3044,9 @@
     {
       "time": 16560,
       "values": {
-        "t_tank_top": 19.8481,
-        "t_tank_bottom": 18.7403,
-        "t_collector": 21.9241,
+        "t_tank_top": 19.7437,
+        "t_tank_bottom": 18.6342,
+        "t_collector": 21.8218,
         "t_greenhouse": 16.2776,
         "t_outdoor": 14.0449
       },
@@ -3055,9 +3055,9 @@
     {
       "time": 16620,
       "values": {
-        "t_tank_top": 19.8875,
-        "t_tank_bottom": 18.7795,
-        "t_collector": 21.9635,
+        "t_tank_top": 19.7832,
+        "t_tank_bottom": 18.6735,
+        "t_collector": 21.8613,
         "t_greenhouse": 16.2957,
         "t_outdoor": 14.0577
       },
@@ -3066,9 +3066,9 @@
     {
       "time": 16680,
       "values": {
-        "t_tank_top": 19.9268,
-        "t_tank_bottom": 18.8187,
-        "t_collector": 22.0029,
+        "t_tank_top": 19.8225,
+        "t_tank_bottom": 18.7128,
+        "t_collector": 21.9007,
         "t_greenhouse": 16.3137,
         "t_outdoor": 14.0704
       },
@@ -3077,9 +3077,9 @@
     {
       "time": 16740,
       "values": {
-        "t_tank_top": 19.9661,
-        "t_tank_bottom": 18.8579,
-        "t_collector": 22.0423,
+        "t_tank_top": 19.8619,
+        "t_tank_bottom": 18.752,
+        "t_collector": 21.9401,
         "t_greenhouse": 16.3315,
         "t_outdoor": 14.083
       },
@@ -3088,9 +3088,9 @@
     {
       "time": 16800,
       "values": {
-        "t_tank_top": 20.0054,
-        "t_tank_bottom": 18.8971,
-        "t_collector": 22.0816,
+        "t_tank_top": 19.9013,
+        "t_tank_bottom": 18.7913,
+        "t_collector": 21.9795,
         "t_greenhouse": 16.3493,
         "t_outdoor": 14.0956
       },
@@ -3099,9 +3099,9 @@
     {
       "time": 16860,
       "values": {
-        "t_tank_top": 20.0447,
-        "t_tank_bottom": 18.9362,
-        "t_collector": 22.1208,
+        "t_tank_top": 19.9406,
+        "t_tank_bottom": 18.8305,
+        "t_collector": 22.0188,
         "t_greenhouse": 16.367,
         "t_outdoor": 14.108
       },
@@ -3110,9 +3110,9 @@
     {
       "time": 16920,
       "values": {
-        "t_tank_top": 20.0839,
-        "t_tank_bottom": 18.9754,
-        "t_collector": 22.16,
+        "t_tank_top": 19.98,
+        "t_tank_bottom": 18.8698,
+        "t_collector": 22.0581,
         "t_greenhouse": 16.3845,
         "t_outdoor": 14.1204
       },
@@ -3121,9 +3121,9 @@
     {
       "time": 16980,
       "values": {
-        "t_tank_top": 20.1231,
-        "t_tank_bottom": 19.0146,
-        "t_collector": 22.1991,
+        "t_tank_top": 20.0193,
+        "t_tank_bottom": 18.909,
+        "t_collector": 22.0973,
         "t_greenhouse": 16.402,
         "t_outdoor": 14.1327
       },
@@ -3132,9 +3132,9 @@
     {
       "time": 17040,
       "values": {
-        "t_tank_top": 20.1624,
-        "t_tank_bottom": 19.0538,
-        "t_collector": 22.2382,
+        "t_tank_top": 20.0586,
+        "t_tank_bottom": 18.9483,
+        "t_collector": 22.1365,
         "t_greenhouse": 16.4193,
         "t_outdoor": 14.145
       },
@@ -3143,9 +3143,9 @@
     {
       "time": 17100,
       "values": {
-        "t_tank_top": 20.2015,
-        "t_tank_bottom": 19.0929,
-        "t_collector": 22.2772,
+        "t_tank_top": 20.0978,
+        "t_tank_bottom": 18.9875,
+        "t_collector": 22.1756,
         "t_greenhouse": 16.4366,
         "t_outdoor": 14.1571
       },
@@ -3154,9 +3154,9 @@
     {
       "time": 17160,
       "values": {
-        "t_tank_top": 20.2407,
-        "t_tank_bottom": 19.1321,
-        "t_collector": 22.3162,
+        "t_tank_top": 20.1371,
+        "t_tank_bottom": 19.0268,
+        "t_collector": 22.2146,
         "t_greenhouse": 16.4537,
         "t_outdoor": 14.1692
       },
@@ -3165,9 +3165,9 @@
     {
       "time": 17220,
       "values": {
-        "t_tank_top": 20.2799,
-        "t_tank_bottom": 19.1713,
-        "t_collector": 22.3552,
+        "t_tank_top": 20.1763,
+        "t_tank_bottom": 19.066,
+        "t_collector": 22.2536,
         "t_greenhouse": 16.4707,
         "t_outdoor": 14.1812
       },
@@ -3176,9 +3176,9 @@
     {
       "time": 17280,
       "values": {
-        "t_tank_top": 20.319,
-        "t_tank_bottom": 19.2104,
-        "t_collector": 22.394,
+        "t_tank_top": 20.2155,
+        "t_tank_bottom": 19.1052,
+        "t_collector": 22.2926,
         "t_greenhouse": 16.4876,
         "t_outdoor": 14.1932
       },
@@ -3187,9 +3187,9 @@
     {
       "time": 17340,
       "values": {
-        "t_tank_top": 20.3581,
-        "t_tank_bottom": 19.2496,
-        "t_collector": 22.4328,
+        "t_tank_top": 20.2547,
+        "t_tank_bottom": 19.1445,
+        "t_collector": 22.3315,
         "t_greenhouse": 16.5045,
         "t_outdoor": 14.205
       },
@@ -3198,9 +3198,9 @@
     {
       "time": 17400,
       "values": {
-        "t_tank_top": 20.3972,
-        "t_tank_bottom": 19.2887,
-        "t_collector": 22.4716,
+        "t_tank_top": 20.2938,
+        "t_tank_bottom": 19.1837,
+        "t_collector": 22.3703,
         "t_greenhouse": 16.5212,
         "t_outdoor": 14.2168
       },
@@ -3209,9 +3209,9 @@
     {
       "time": 17460,
       "values": {
-        "t_tank_top": 20.4362,
-        "t_tank_bottom": 19.3279,
-        "t_collector": 22.5103,
+        "t_tank_top": 20.3329,
+        "t_tank_bottom": 19.2229,
+        "t_collector": 22.4091,
         "t_greenhouse": 16.5378,
         "t_outdoor": 14.2284
       },
@@ -3220,9 +3220,9 @@
     {
       "time": 17520,
       "values": {
-        "t_tank_top": 20.4752,
-        "t_tank_bottom": 19.367,
-        "t_collector": 22.549,
+        "t_tank_top": 20.372,
+        "t_tank_bottom": 19.2621,
+        "t_collector": 22.4478,
         "t_greenhouse": 16.5542,
         "t_outdoor": 14.24
       },
@@ -3231,9 +3231,9 @@
     {
       "time": 17580,
       "values": {
-        "t_tank_top": 20.5142,
-        "t_tank_bottom": 19.4061,
-        "t_collector": 22.5876,
+        "t_tank_top": 20.4111,
+        "t_tank_bottom": 19.3013,
+        "t_collector": 22.4864,
         "t_greenhouse": 16.5706,
         "t_outdoor": 14.2516
       },
@@ -3242,9 +3242,9 @@
     {
       "time": 17640,
       "values": {
-        "t_tank_top": 20.5532,
-        "t_tank_bottom": 19.4453,
-        "t_collector": 22.6261,
+        "t_tank_top": 20.4502,
+        "t_tank_bottom": 19.3405,
+        "t_collector": 22.5251,
         "t_greenhouse": 16.5869,
         "t_outdoor": 14.263
       },
@@ -3253,9 +3253,9 @@
     {
       "time": 17700,
       "values": {
-        "t_tank_top": 20.5922,
-        "t_tank_bottom": 19.4844,
-        "t_collector": 22.6646,
+        "t_tank_top": 20.4892,
+        "t_tank_bottom": 19.3797,
+        "t_collector": 22.5636,
         "t_greenhouse": 16.6031,
         "t_outdoor": 14.2744
       },
@@ -3264,9 +3264,9 @@
     {
       "time": 17760,
       "values": {
-        "t_tank_top": 20.6311,
-        "t_tank_bottom": 19.5235,
-        "t_collector": 22.703,
+        "t_tank_top": 20.5282,
+        "t_tank_bottom": 19.4189,
+        "t_collector": 22.6021,
         "t_greenhouse": 16.6191,
         "t_outdoor": 14.2856
       },
@@ -3275,9 +3275,9 @@
     {
       "time": 17820,
       "values": {
-        "t_tank_top": 20.67,
-        "t_tank_bottom": 19.5626,
-        "t_collector": 22.7413,
+        "t_tank_top": 20.5671,
+        "t_tank_bottom": 19.458,
+        "t_collector": 22.6405,
         "t_greenhouse": 16.635,
         "t_outdoor": 14.2968
       },
@@ -3286,9 +3286,9 @@
     {
       "time": 17880,
       "values": {
-        "t_tank_top": 20.7088,
-        "t_tank_bottom": 19.6016,
-        "t_collector": 22.7796,
+        "t_tank_top": 20.6061,
+        "t_tank_bottom": 19.4972,
+        "t_collector": 22.6789,
         "t_greenhouse": 16.6509,
         "t_outdoor": 14.308
       },
@@ -3297,9 +3297,9 @@
     {
       "time": 17940,
       "values": {
-        "t_tank_top": 20.7477,
-        "t_tank_bottom": 19.6407,
-        "t_collector": 22.8178,
+        "t_tank_top": 20.645,
+        "t_tank_bottom": 19.5363,
+        "t_collector": 22.7172,
         "t_greenhouse": 16.6666,
         "t_outdoor": 14.319
       },
@@ -3308,9 +3308,9 @@
     {
       "time": 18000,
       "values": {
-        "t_tank_top": 20.7865,
-        "t_tank_bottom": 19.6797,
-        "t_collector": 22.856,
+        "t_tank_top": 20.6839,
+        "t_tank_bottom": 19.5755,
+        "t_collector": 22.7554,
         "t_greenhouse": 16.6822,
         "t_outdoor": 14.3299
       },
@@ -3319,9 +3319,9 @@
     {
       "time": 18060,
       "values": {
-        "t_tank_top": 20.8252,
-        "t_tank_bottom": 19.7188,
-        "t_collector": 22.8941,
+        "t_tank_top": 20.7227,
+        "t_tank_bottom": 19.6146,
+        "t_collector": 22.7936,
         "t_greenhouse": 16.6977,
         "t_outdoor": 14.3408
       },
@@ -3330,9 +3330,9 @@
     {
       "time": 18120,
       "values": {
-        "t_tank_top": 20.864,
-        "t_tank_bottom": 19.7578,
-        "t_collector": 22.9322,
+        "t_tank_top": 20.7615,
+        "t_tank_bottom": 19.6537,
+        "t_collector": 22.8317,
         "t_greenhouse": 16.7131,
         "t_outdoor": 14.3516
       },
@@ -3341,9 +3341,9 @@
     {
       "time": 18180,
       "values": {
-        "t_tank_top": 20.9027,
-        "t_tank_bottom": 19.7968,
-        "t_collector": 22.9701,
+        "t_tank_top": 20.8003,
+        "t_tank_bottom": 19.6927,
+        "t_collector": 22.8698,
         "t_greenhouse": 16.7283,
         "t_outdoor": 14.3623
       },
@@ -3352,9 +3352,9 @@
     {
       "time": 18240,
       "values": {
-        "t_tank_top": 20.9414,
-        "t_tank_bottom": 19.8358,
-        "t_collector": 23.0081,
+        "t_tank_top": 20.839,
+        "t_tank_bottom": 19.7318,
+        "t_collector": 22.9077,
         "t_greenhouse": 16.7435,
         "t_outdoor": 14.3729
       },
@@ -3363,9 +3363,9 @@
     {
       "time": 18300,
       "values": {
-        "t_tank_top": 20.98,
-        "t_tank_bottom": 19.8748,
-        "t_collector": 23.0459,
+        "t_tank_top": 20.8778,
+        "t_tank_bottom": 19.7709,
+        "t_collector": 22.9457,
         "t_greenhouse": 16.7586,
         "t_outdoor": 14.3835
       },
@@ -3374,9 +3374,9 @@
     {
       "time": 18360,
       "values": {
-        "t_tank_top": 21.0186,
-        "t_tank_bottom": 19.9137,
-        "t_collector": 23.0837,
+        "t_tank_top": 20.9164,
+        "t_tank_bottom": 19.8099,
+        "t_collector": 22.9835,
         "t_greenhouse": 16.7735,
         "t_outdoor": 14.3939
       },
@@ -3385,9 +3385,9 @@
     {
       "time": 18420,
       "values": {
-        "t_tank_top": 21.0572,
-        "t_tank_bottom": 19.9527,
-        "t_collector": 23.1214,
+        "t_tank_top": 20.9551,
+        "t_tank_bottom": 19.8489,
+        "t_collector": 23.0213,
         "t_greenhouse": 16.7883,
         "t_outdoor": 14.4043
       },
@@ -3396,9 +3396,9 @@
     {
       "time": 18480,
       "values": {
-        "t_tank_top": 21.0957,
-        "t_tank_bottom": 19.9916,
-        "t_collector": 23.159,
+        "t_tank_top": 20.9937,
+        "t_tank_bottom": 19.8879,
+        "t_collector": 23.059,
         "t_greenhouse": 16.803,
         "t_outdoor": 14.4146
       },
@@ -3407,9 +3407,9 @@
     {
       "time": 18540,
       "values": {
-        "t_tank_top": 21.1342,
-        "t_tank_bottom": 20.0305,
-        "t_collector": 23.1966,
+        "t_tank_top": 21.0323,
+        "t_tank_bottom": 19.9269,
+        "t_collector": 23.0967,
         "t_greenhouse": 16.8176,
         "t_outdoor": 14.4248
       },
@@ -3418,9 +3418,9 @@
     {
       "time": 18600,
       "values": {
-        "t_tank_top": 21.1727,
-        "t_tank_bottom": 20.0694,
-        "t_collector": 23.2341,
+        "t_tank_top": 21.0708,
+        "t_tank_bottom": 19.9659,
+        "t_collector": 23.1343,
         "t_greenhouse": 16.8321,
         "t_outdoor": 14.4349
       },
@@ -3429,9 +3429,9 @@
     {
       "time": 18660,
       "values": {
-        "t_tank_top": 21.2111,
-        "t_tank_bottom": 20.1083,
-        "t_collector": 23.2716,
+        "t_tank_top": 21.1093,
+        "t_tank_bottom": 20.0048,
+        "t_collector": 23.1718,
         "t_greenhouse": 16.8464,
         "t_outdoor": 14.4449
       },
@@ -3440,9 +3440,9 @@
     {
       "time": 18720,
       "values": {
-        "t_tank_top": 21.2495,
-        "t_tank_bottom": 20.1471,
-        "t_collector": 23.309,
+        "t_tank_top": 21.1478,
+        "t_tank_bottom": 20.0437,
+        "t_collector": 23.2092,
         "t_greenhouse": 16.8607,
         "t_outdoor": 14.4549
       },
@@ -3451,9 +3451,9 @@
     {
       "time": 18780,
       "values": {
-        "t_tank_top": 21.2878,
-        "t_tank_bottom": 20.186,
-        "t_collector": 23.3463,
+        "t_tank_top": 21.1862,
+        "t_tank_bottom": 20.0826,
+        "t_collector": 23.2466,
         "t_greenhouse": 16.8748,
         "t_outdoor": 14.4647
       },
@@ -3462,9 +3462,9 @@
     {
       "time": 18840,
       "values": {
-        "t_tank_top": 21.3261,
-        "t_tank_bottom": 20.2248,
-        "t_collector": 23.3835,
+        "t_tank_top": 21.2246,
+        "t_tank_bottom": 20.1215,
+        "t_collector": 23.2839,
         "t_greenhouse": 16.8889,
         "t_outdoor": 14.4745
       },
@@ -3473,9 +3473,9 @@
     {
       "time": 18900,
       "values": {
-        "t_tank_top": 21.3644,
-        "t_tank_bottom": 20.2635,
-        "t_collector": 23.4206,
+        "t_tank_top": 21.2629,
+        "t_tank_bottom": 20.1604,
+        "t_collector": 23.3211,
         "t_greenhouse": 16.9028,
         "t_outdoor": 14.4842
       },
@@ -3484,9 +3484,9 @@
     {
       "time": 18960,
       "values": {
-        "t_tank_top": 21.4026,
-        "t_tank_bottom": 20.3023,
-        "t_collector": 23.4577,
+        "t_tank_top": 21.3012,
+        "t_tank_bottom": 20.1992,
+        "t_collector": 23.3583,
         "t_greenhouse": 16.9165,
         "t_outdoor": 14.4938
       },
@@ -3495,9 +3495,9 @@
     {
       "time": 19020,
       "values": {
-        "t_tank_top": 21.4408,
-        "t_tank_bottom": 20.341,
-        "t_collector": 23.4948,
+        "t_tank_top": 21.3395,
+        "t_tank_bottom": 20.238,
+        "t_collector": 23.3954,
         "t_greenhouse": 16.9302,
         "t_outdoor": 14.5033
       },
@@ -3506,9 +3506,9 @@
     {
       "time": 19080,
       "values": {
-        "t_tank_top": 21.479,
-        "t_tank_bottom": 20.3797,
-        "t_collector": 23.5317,
+        "t_tank_top": 21.3777,
+        "t_tank_bottom": 20.2768,
+        "t_collector": 23.4324,
         "t_greenhouse": 16.9438,
         "t_outdoor": 14.5128
       },
@@ -3517,9 +3517,9 @@
     {
       "time": 19140,
       "values": {
-        "t_tank_top": 21.5171,
-        "t_tank_bottom": 20.4184,
-        "t_collector": 23.5686,
+        "t_tank_top": 21.4158,
+        "t_tank_bottom": 20.3156,
+        "t_collector": 23.4693,
         "t_greenhouse": 16.9572,
         "t_outdoor": 14.5221
       },
@@ -3528,9 +3528,9 @@
     {
       "time": 19200,
       "values": {
-        "t_tank_top": 21.5551,
-        "t_tank_bottom": 20.4571,
-        "t_collector": 23.6054,
+        "t_tank_top": 21.454,
+        "t_tank_bottom": 20.3543,
+        "t_collector": 23.5062,
         "t_greenhouse": 16.9705,
         "t_outdoor": 14.5314
       },
@@ -3539,9 +3539,9 @@
     {
       "time": 19260,
       "values": {
-        "t_tank_top": 21.5931,
-        "t_tank_bottom": 20.4957,
-        "t_collector": 23.6421,
+        "t_tank_top": 21.4921,
+        "t_tank_bottom": 20.393,
+        "t_collector": 23.543,
         "t_greenhouse": 16.9837,
         "t_outdoor": 14.5406
       },
@@ -3550,9 +3550,9 @@
     {
       "time": 19320,
       "values": {
-        "t_tank_top": 21.6311,
-        "t_tank_bottom": 20.5343,
-        "t_collector": 23.6787,
+        "t_tank_top": 21.5301,
+        "t_tank_bottom": 20.4317,
+        "t_collector": 23.5797,
         "t_greenhouse": 16.9968,
         "t_outdoor": 14.5497
       },
@@ -3561,9 +3561,9 @@
     {
       "time": 19380,
       "values": {
-        "t_tank_top": 21.669,
-        "t_tank_bottom": 20.5729,
-        "t_collector": 23.7153,
+        "t_tank_top": 21.5681,
+        "t_tank_bottom": 20.4703,
+        "t_collector": 23.6163,
         "t_greenhouse": 17.0098,
         "t_outdoor": 14.5587
       },
@@ -3572,9 +3572,9 @@
     {
       "time": 19440,
       "values": {
-        "t_tank_top": 21.7069,
-        "t_tank_bottom": 20.6115,
-        "t_collector": 23.7518,
+        "t_tank_top": 21.6061,
+        "t_tank_bottom": 20.509,
+        "t_collector": 23.6529,
         "t_greenhouse": 17.0227,
         "t_outdoor": 14.5676
       },
@@ -3583,9 +3583,9 @@
     {
       "time": 19500,
       "values": {
-        "t_tank_top": 21.7447,
-        "t_tank_bottom": 20.65,
-        "t_collector": 23.7882,
+        "t_tank_top": 21.644,
+        "t_tank_bottom": 20.5476,
+        "t_collector": 23.6894,
         "t_greenhouse": 17.0354,
         "t_outdoor": 14.5764
       },
@@ -3594,9 +3594,9 @@
     {
       "time": 19560,
       "values": {
-        "t_tank_top": 21.7825,
-        "t_tank_bottom": 20.6885,
-        "t_collector": 23.8245,
+        "t_tank_top": 21.6818,
+        "t_tank_bottom": 20.5861,
+        "t_collector": 23.7258,
         "t_greenhouse": 17.048,
         "t_outdoor": 14.5852
       },
@@ -3605,9 +3605,9 @@
     {
       "time": 19620,
       "values": {
-        "t_tank_top": 21.8203,
-        "t_tank_bottom": 20.727,
-        "t_collector": 23.8608,
+        "t_tank_top": 21.7196,
+        "t_tank_bottom": 20.6247,
+        "t_collector": 23.7621,
         "t_greenhouse": 17.0605,
         "t_outdoor": 14.5938
       },
@@ -3616,9 +3616,9 @@
     {
       "time": 19680,
       "values": {
-        "t_tank_top": 21.858,
-        "t_tank_bottom": 20.7654,
-        "t_collector": 23.8969,
+        "t_tank_top": 21.7574,
+        "t_tank_bottom": 20.6632,
+        "t_collector": 23.7983,
         "t_greenhouse": 17.0729,
         "t_outdoor": 14.6024
       },
@@ -3627,9 +3627,9 @@
     {
       "time": 19740,
       "values": {
-        "t_tank_top": 21.8956,
-        "t_tank_bottom": 20.8038,
-        "t_collector": 23.933,
+        "t_tank_top": 21.7951,
+        "t_tank_bottom": 20.7017,
+        "t_collector": 23.8345,
         "t_greenhouse": 17.0851,
         "t_outdoor": 14.6109
       },
@@ -3638,9 +3638,9 @@
     {
       "time": 19800,
       "values": {
-        "t_tank_top": 21.9332,
-        "t_tank_bottom": 20.8422,
-        "t_collector": 23.969,
+        "t_tank_top": 21.8328,
+        "t_tank_bottom": 20.7401,
+        "t_collector": 23.8706,
         "t_greenhouse": 17.0973,
         "t_outdoor": 14.6193
       },
@@ -3649,9 +3649,9 @@
     {
       "time": 19860,
       "values": {
-        "t_tank_top": 21.9707,
-        "t_tank_bottom": 20.8805,
-        "t_collector": 24.005,
+        "t_tank_top": 21.8704,
+        "t_tank_bottom": 20.7785,
+        "t_collector": 23.9066,
         "t_greenhouse": 17.1093,
         "t_outdoor": 14.6276
       },
@@ -3660,9 +3660,9 @@
     {
       "time": 19920,
       "values": {
-        "t_tank_top": 22.0082,
-        "t_tank_bottom": 20.9188,
-        "t_collector": 24.0408,
+        "t_tank_top": 21.9079,
+        "t_tank_bottom": 20.8169,
+        "t_collector": 23.9425,
         "t_greenhouse": 17.1212,
         "t_outdoor": 14.6358
       },
@@ -3671,9 +3671,9 @@
     {
       "time": 19980,
       "values": {
-        "t_tank_top": 22.0457,
-        "t_tank_bottom": 20.9571,
-        "t_collector": 24.0766,
+        "t_tank_top": 21.9455,
+        "t_tank_bottom": 20.8552,
+        "t_collector": 23.9783,
         "t_greenhouse": 17.133,
         "t_outdoor": 14.6439
       },
@@ -3682,9 +3682,9 @@
     {
       "time": 20040,
       "values": {
-        "t_tank_top": 22.083,
-        "t_tank_bottom": 20.9953,
-        "t_collector": 24.1123,
+        "t_tank_top": 21.9829,
+        "t_tank_bottom": 20.8935,
+        "t_collector": 24.0141,
         "t_greenhouse": 17.1446,
         "t_outdoor": 14.652
       },
@@ -3693,9 +3693,9 @@
     {
       "time": 20100,
       "values": {
-        "t_tank_top": 22.1204,
-        "t_tank_bottom": 21.0335,
-        "t_collector": 24.1479,
+        "t_tank_top": 22.0203,
+        "t_tank_bottom": 20.9318,
+        "t_collector": 24.0498,
         "t_greenhouse": 17.1562,
         "t_outdoor": 14.6599
       },
@@ -3704,9 +3704,9 @@
     {
       "time": 20160,
       "values": {
-        "t_tank_top": 22.1577,
-        "t_tank_bottom": 21.0717,
-        "t_collector": 24.1834,
+        "t_tank_top": 22.0577,
+        "t_tank_bottom": 20.9701,
+        "t_collector": 24.0853,
         "t_greenhouse": 17.1676,
         "t_outdoor": 14.6678
       },
@@ -3715,9 +3715,9 @@
     {
       "time": 20220,
       "values": {
-        "t_tank_top": 22.1949,
-        "t_tank_bottom": 21.1098,
-        "t_collector": 24.2188,
+        "t_tank_top": 22.095,
+        "t_tank_bottom": 21.0083,
+        "t_collector": 24.1208,
         "t_greenhouse": 17.1789,
         "t_outdoor": 14.6755
       },
@@ -3726,9 +3726,9 @@
     {
       "time": 20280,
       "values": {
-        "t_tank_top": 22.2321,
-        "t_tank_bottom": 21.1479,
-        "t_collector": 24.2541,
+        "t_tank_top": 22.1322,
+        "t_tank_bottom": 21.0464,
+        "t_collector": 24.1563,
         "t_greenhouse": 17.1901,
         "t_outdoor": 14.6832
       },
@@ -3737,9 +3737,9 @@
     {
       "time": 20340,
       "values": {
-        "t_tank_top": 22.2692,
-        "t_tank_bottom": 21.1859,
-        "t_collector": 24.2894,
+        "t_tank_top": 22.1694,
+        "t_tank_bottom": 21.0845,
+        "t_collector": 24.1916,
         "t_greenhouse": 17.2011,
         "t_outdoor": 14.6908
       },
@@ -3748,9 +3748,9 @@
     {
       "time": 20400,
       "values": {
-        "t_tank_top": 22.3062,
-        "t_tank_bottom": 21.224,
-        "t_collector": 24.3246,
+        "t_tank_top": 22.2065,
+        "t_tank_bottom": 21.1226,
+        "t_collector": 24.2268,
         "t_greenhouse": 17.212,
         "t_outdoor": 14.6983
       },
@@ -3759,9 +3759,9 @@
     {
       "time": 20460,
       "values": {
-        "t_tank_top": 22.3432,
-        "t_tank_bottom": 21.2619,
-        "t_collector": 24.3597,
+        "t_tank_top": 22.2436,
+        "t_tank_bottom": 21.1607,
+        "t_collector": 24.262,
         "t_greenhouse": 17.2229,
         "t_outdoor": 14.7058
       },
@@ -3770,9 +3770,9 @@
     {
       "time": 20520,
       "values": {
-        "t_tank_top": 22.3802,
-        "t_tank_bottom": 21.2999,
-        "t_collector": 24.3946,
+        "t_tank_top": 22.2806,
+        "t_tank_bottom": 21.1987,
+        "t_collector": 24.297,
         "t_greenhouse": 17.2335,
         "t_outdoor": 14.7131
       },
@@ -3781,9 +3781,9 @@
     {
       "time": 20580,
       "values": {
-        "t_tank_top": 22.4171,
-        "t_tank_bottom": 21.3378,
-        "t_collector": 24.4296,
+        "t_tank_top": 22.3176,
+        "t_tank_bottom": 21.2367,
+        "t_collector": 24.332,
         "t_greenhouse": 17.2441,
         "t_outdoor": 14.7203
       },
@@ -3792,9 +3792,9 @@
     {
       "time": 20640,
       "values": {
-        "t_tank_top": 22.4539,
-        "t_tank_bottom": 21.3756,
-        "t_collector": 24.4644,
+        "t_tank_top": 22.3545,
+        "t_tank_bottom": 21.2746,
+        "t_collector": 24.3669,
         "t_greenhouse": 17.2545,
         "t_outdoor": 14.7275
       },
@@ -3803,9 +3803,9 @@
     {
       "time": 20700,
       "values": {
-        "t_tank_top": 22.4907,
-        "t_tank_bottom": 21.4134,
-        "t_collector": 24.4991,
+        "t_tank_top": 22.3913,
+        "t_tank_bottom": 21.3125,
+        "t_collector": 24.4017,
         "t_greenhouse": 17.2649,
         "t_outdoor": 14.7345
       },
@@ -3814,9 +3814,9 @@
     {
       "time": 20760,
       "values": {
-        "t_tank_top": 22.5274,
-        "t_tank_bottom": 21.4512,
-        "t_collector": 24.5337,
+        "t_tank_top": 22.4281,
+        "t_tank_bottom": 21.3503,
+        "t_collector": 24.4364,
         "t_greenhouse": 17.2751,
         "t_outdoor": 14.7415
       },
@@ -3825,9 +3825,9 @@
     {
       "time": 20820,
       "values": {
-        "t_tank_top": 22.5641,
-        "t_tank_bottom": 21.4889,
-        "t_collector": 24.5683,
+        "t_tank_top": 22.4648,
+        "t_tank_bottom": 21.3881,
+        "t_collector": 24.471,
         "t_greenhouse": 17.2851,
         "t_outdoor": 14.7484
       },
@@ -3836,9 +3836,9 @@
     {
       "time": 20880,
       "values": {
-        "t_tank_top": 22.6006,
-        "t_tank_bottom": 21.5266,
-        "t_collector": 24.6027,
+        "t_tank_top": 22.5015,
+        "t_tank_bottom": 21.4259,
+        "t_collector": 24.5056,
         "t_greenhouse": 17.2951,
         "t_outdoor": 14.7552
       },
@@ -3847,9 +3847,9 @@
     {
       "time": 20940,
       "values": {
-        "t_tank_top": 22.6372,
-        "t_tank_bottom": 21.5643,
-        "t_collector": 24.6371,
+        "t_tank_top": 22.5381,
+        "t_tank_bottom": 21.4636,
+        "t_collector": 24.54,
         "t_greenhouse": 17.3049,
         "t_outdoor": 14.7619
       },
@@ -3858,9 +3858,9 @@
     {
       "time": 21000,
       "values": {
-        "t_tank_top": 22.6736,
-        "t_tank_bottom": 21.6019,
-        "t_collector": 24.6714,
+        "t_tank_top": 22.5747,
+        "t_tank_bottom": 21.5013,
+        "t_collector": 24.5743,
         "t_greenhouse": 17.3146,
         "t_outdoor": 14.7685
       },
@@ -3869,9 +3869,9 @@
     {
       "time": 21060,
       "values": {
-        "t_tank_top": 22.7101,
-        "t_tank_bottom": 21.6394,
-        "t_collector": 24.7055,
+        "t_tank_top": 22.6111,
+        "t_tank_bottom": 21.5389,
+        "t_collector": 24.6086,
         "t_greenhouse": 17.3242,
         "t_outdoor": 14.775
       },
@@ -3880,9 +3880,9 @@
     {
       "time": 21120,
       "values": {
-        "t_tank_top": 22.7464,
-        "t_tank_bottom": 21.6769,
-        "t_collector": 24.7396,
+        "t_tank_top": 22.6475,
+        "t_tank_bottom": 21.5765,
+        "t_collector": 24.6427,
         "t_greenhouse": 17.3337,
         "t_outdoor": 14.7814
       },
@@ -3891,9 +3891,9 @@
     {
       "time": 21180,
       "values": {
-        "t_tank_top": 22.7827,
-        "t_tank_bottom": 21.7144,
-        "t_collector": 24.7736,
+        "t_tank_top": 22.6839,
+        "t_tank_bottom": 21.614,
+        "t_collector": 24.6768,
         "t_greenhouse": 17.343,
         "t_outdoor": 14.7878
       },
@@ -3902,9 +3902,9 @@
     {
       "time": 21240,
       "values": {
-        "t_tank_top": 22.8189,
-        "t_tank_bottom": 21.7518,
-        "t_collector": 24.8075,
+        "t_tank_top": 22.7202,
+        "t_tank_bottom": 21.6515,
+        "t_collector": 24.7108,
         "t_greenhouse": 17.3522,
         "t_outdoor": 14.794
       },
@@ -3913,9 +3913,9 @@
     {
       "time": 21300,
       "values": {
-        "t_tank_top": 22.855,
-        "t_tank_bottom": 21.7892,
-        "t_collector": 24.8413,
+        "t_tank_top": 22.7564,
+        "t_tank_bottom": 21.6889,
+        "t_collector": 24.7446,
         "t_greenhouse": 17.3613,
         "t_outdoor": 14.8001
       },
@@ -3924,9 +3924,9 @@
     {
       "time": 21360,
       "values": {
-        "t_tank_top": 22.8911,
-        "t_tank_bottom": 21.8265,
-        "t_collector": 24.875,
+        "t_tank_top": 22.7926,
+        "t_tank_bottom": 21.7263,
+        "t_collector": 24.7784,
         "t_greenhouse": 17.3702,
         "t_outdoor": 14.8062
       },
@@ -3935,9 +3935,9 @@
     {
       "time": 21420,
       "values": {
-        "t_tank_top": 22.9271,
-        "t_tank_bottom": 21.8637,
-        "t_collector": 24.9086,
+        "t_tank_top": 22.8287,
+        "t_tank_bottom": 21.7636,
+        "t_collector": 24.8121,
         "t_greenhouse": 17.3791,
         "t_outdoor": 14.8122
       },
@@ -3946,9 +3946,9 @@
     {
       "time": 21480,
       "values": {
-        "t_tank_top": 22.9631,
-        "t_tank_bottom": 21.901,
-        "t_collector": 24.9421,
+        "t_tank_top": 22.8647,
+        "t_tank_bottom": 21.8009,
+        "t_collector": 24.8456,
         "t_greenhouse": 17.3878,
         "t_outdoor": 14.8181
       },
@@ -3957,9 +3957,9 @@
     {
       "time": 21540,
       "values": {
-        "t_tank_top": 22.999,
-        "t_tank_bottom": 21.9381,
-        "t_collector": 24.9755,
+        "t_tank_top": 22.9006,
+        "t_tank_bottom": 21.8382,
+        "t_collector": 24.8791,
         "t_greenhouse": 17.3963,
         "t_outdoor": 14.8238
       },
@@ -3968,9 +3968,9 @@
     {
       "time": 21600,
       "values": {
-        "t_tank_top": 23.0348,
-        "t_tank_bottom": 21.9752,
-        "t_collector": 25.0088,
+        "t_tank_top": 22.9365,
+        "t_tank_bottom": 21.8754,
+        "t_collector": 24.9125,
         "t_greenhouse": 17.4048,
         "t_outdoor": 14.8295
       },
@@ -3979,9 +3979,9 @@
     {
       "time": 21660,
       "values": {
-        "t_tank_top": 23.0705,
-        "t_tank_bottom": 22.0123,
-        "t_collector": 25.0421,
+        "t_tank_top": 22.9723,
+        "t_tank_bottom": 21.9125,
+        "t_collector": 24.9458,
         "t_greenhouse": 17.4131,
         "t_outdoor": 14.8351
       },
@@ -3990,9 +3990,9 @@
     {
       "time": 21720,
       "values": {
-        "t_tank_top": 23.1062,
-        "t_tank_bottom": 22.0493,
-        "t_collector": 25.0752,
+        "t_tank_top": 23.0081,
+        "t_tank_bottom": 21.9496,
+        "t_collector": 24.979,
         "t_greenhouse": 17.4213,
         "t_outdoor": 14.8406
       },
@@ -4001,9 +4001,9 @@
     {
       "time": 21780,
       "values": {
-        "t_tank_top": 23.1418,
-        "t_tank_bottom": 22.0863,
-        "t_collector": 25.1082,
+        "t_tank_top": 23.0438,
+        "t_tank_bottom": 21.9866,
+        "t_collector": 25.0121,
         "t_greenhouse": 17.4294,
         "t_outdoor": 14.8461
       },
@@ -4012,9 +4012,9 @@
     {
       "time": 21840,
       "values": {
-        "t_tank_top": 23.1774,
-        "t_tank_bottom": 22.1232,
-        "t_collector": 25.1411,
+        "t_tank_top": 23.0794,
+        "t_tank_bottom": 22.0236,
+        "t_collector": 25.045,
         "t_greenhouse": 17.4374,
         "t_outdoor": 14.8514
       },
@@ -4023,9 +4023,9 @@
     {
       "time": 21900,
       "values": {
-        "t_tank_top": 23.2128,
-        "t_tank_bottom": 22.16,
-        "t_collector": 25.1739,
+        "t_tank_top": 23.1149,
+        "t_tank_bottom": 22.0605,
+        "t_collector": 25.0779,
         "t_greenhouse": 17.4452,
         "t_outdoor": 14.8566
       },
@@ -4034,9 +4034,9 @@
     {
       "time": 21960,
       "values": {
-        "t_tank_top": 23.2482,
-        "t_tank_bottom": 22.1968,
-        "t_collector": 25.2066,
+        "t_tank_top": 23.1504,
+        "t_tank_bottom": 22.0974,
+        "t_collector": 25.1107,
         "t_greenhouse": 17.4529,
         "t_outdoor": 14.8618
       },
@@ -4045,9 +4045,9 @@
     {
       "time": 22020,
       "values": {
-        "t_tank_top": 23.2836,
-        "t_tank_bottom": 22.2336,
-        "t_collector": 25.2392,
+        "t_tank_top": 23.1858,
+        "t_tank_bottom": 22.1342,
+        "t_collector": 25.1434,
         "t_greenhouse": 17.4604,
         "t_outdoor": 14.8668
       },
@@ -4056,9 +4056,9 @@
     {
       "time": 22080,
       "values": {
-        "t_tank_top": 23.3188,
-        "t_tank_bottom": 22.2702,
-        "t_collector": 25.2717,
+        "t_tank_top": 23.2211,
+        "t_tank_bottom": 22.1709,
+        "t_collector": 25.1759,
         "t_greenhouse": 17.4679,
         "t_outdoor": 14.8718
       },
@@ -4067,9 +4067,9 @@
     {
       "time": 22140,
       "values": {
-        "t_tank_top": 23.354,
-        "t_tank_bottom": 22.3069,
-        "t_collector": 25.3041,
+        "t_tank_top": 23.2563,
+        "t_tank_bottom": 22.2076,
+        "t_collector": 25.2084,
         "t_greenhouse": 17.4752,
         "t_outdoor": 14.8766
       },
@@ -4078,9 +4078,9 @@
     {
       "time": 22200,
       "values": {
-        "t_tank_top": 23.3891,
-        "t_tank_bottom": 22.3434,
-        "t_collector": 25.3364,
+        "t_tank_top": 23.2915,
+        "t_tank_bottom": 22.2443,
+        "t_collector": 25.2408,
         "t_greenhouse": 17.4824,
         "t_outdoor": 14.8814
       },
@@ -4089,9 +4089,9 @@
     {
       "time": 22260,
       "values": {
-        "t_tank_top": 23.4241,
-        "t_tank_bottom": 22.38,
-        "t_collector": 25.3686,
+        "t_tank_top": 23.3266,
+        "t_tank_bottom": 22.2809,
+        "t_collector": 25.273,
         "t_greenhouse": 17.4895,
         "t_outdoor": 14.8861
       },
@@ -4100,9 +4100,9 @@
     {
       "time": 22320,
       "values": {
-        "t_tank_top": 23.4591,
-        "t_tank_bottom": 22.4164,
-        "t_collector": 25.4007,
+        "t_tank_top": 23.3616,
+        "t_tank_bottom": 22.3174,
+        "t_collector": 25.3052,
         "t_greenhouse": 17.4964,
         "t_outdoor": 14.8907
       },
@@ -4111,9 +4111,9 @@
     {
       "time": 22380,
       "values": {
-        "t_tank_top": 23.4939,
-        "t_tank_bottom": 22.4528,
-        "t_collector": 25.4327,
+        "t_tank_top": 23.3966,
+        "t_tank_bottom": 22.3539,
+        "t_collector": 25.3372,
         "t_greenhouse": 17.5032,
         "t_outdoor": 14.8952
       },
@@ -4122,9 +4122,9 @@
     {
       "time": 22440,
       "values": {
-        "t_tank_top": 23.5287,
-        "t_tank_bottom": 22.4892,
-        "t_collector": 25.4646,
+        "t_tank_top": 23.4315,
+        "t_tank_bottom": 22.3903,
+        "t_collector": 25.3692,
         "t_greenhouse": 17.5099,
         "t_outdoor": 14.8996
       },
@@ -4133,9 +4133,9 @@
     {
       "time": 22500,
       "values": {
-        "t_tank_top": 23.5635,
-        "t_tank_bottom": 22.5254,
-        "t_collector": 25.4963,
+        "t_tank_top": 23.4662,
+        "t_tank_bottom": 22.4266,
+        "t_collector": 25.401,
         "t_greenhouse": 17.5164,
         "t_outdoor": 14.9039
       },
@@ -4144,9 +4144,9 @@
     {
       "time": 22560,
       "values": {
-        "t_tank_top": 23.5981,
-        "t_tank_bottom": 22.5616,
-        "t_collector": 25.528,
+        "t_tank_top": 23.501,
+        "t_tank_bottom": 22.4629,
+        "t_collector": 25.4328,
         "t_greenhouse": 17.5229,
         "t_outdoor": 14.9081
       },
@@ -4155,9 +4155,9 @@
     {
       "time": 22620,
       "values": {
-        "t_tank_top": 23.6327,
-        "t_tank_bottom": 22.5978,
-        "t_collector": 25.5596,
+        "t_tank_top": 23.5356,
+        "t_tank_bottom": 22.4991,
+        "t_collector": 25.4644,
         "t_greenhouse": 17.5291,
         "t_outdoor": 14.9122
       },
@@ -4166,9 +4166,9 @@
     {
       "time": 22680,
       "values": {
-        "t_tank_top": 23.6672,
-        "t_tank_bottom": 22.6339,
-        "t_collector": 25.591,
+        "t_tank_top": 23.5702,
+        "t_tank_bottom": 22.5353,
+        "t_collector": 25.4959,
         "t_greenhouse": 17.5353,
         "t_outdoor": 14.9162
       },
@@ -4177,9 +4177,9 @@
     {
       "time": 22740,
       "values": {
-        "t_tank_top": 23.7016,
-        "t_tank_bottom": 22.6699,
-        "t_collector": 25.6223,
+        "t_tank_top": 23.6046,
+        "t_tank_bottom": 22.5714,
+        "t_collector": 25.5273,
         "t_greenhouse": 17.5414,
         "t_outdoor": 14.9201
       },
@@ -4188,9 +4188,9 @@
     {
       "time": 22800,
       "values": {
-        "t_tank_top": 23.7359,
-        "t_tank_bottom": 22.7059,
-        "t_collector": 25.6536,
+        "t_tank_top": 23.639,
+        "t_tank_bottom": 22.6074,
+        "t_collector": 25.5586,
         "t_greenhouse": 17.5473,
         "t_outdoor": 14.924
       },
@@ -4199,9 +4199,9 @@
     {
       "time": 22860,
       "values": {
-        "t_tank_top": 23.7702,
-        "t_tank_bottom": 22.7418,
-        "t_collector": 25.6847,
+        "t_tank_top": 23.6734,
+        "t_tank_bottom": 22.6434,
+        "t_collector": 25.5898,
         "t_greenhouse": 17.553,
         "t_outdoor": 14.9277
       },
@@ -4210,9 +4210,9 @@
     {
       "time": 22920,
       "values": {
-        "t_tank_top": 23.8043,
-        "t_tank_bottom": 22.7776,
-        "t_collector": 25.7157,
+        "t_tank_top": 23.7076,
+        "t_tank_bottom": 22.6793,
+        "t_collector": 25.6209,
         "t_greenhouse": 17.5587,
         "t_outdoor": 14.9314
       },
@@ -4221,9 +4221,9 @@
     {
       "time": 22980,
       "values": {
-        "t_tank_top": 23.8384,
-        "t_tank_bottom": 22.8134,
-        "t_collector": 25.7466,
+        "t_tank_top": 23.7418,
+        "t_tank_bottom": 22.7152,
+        "t_collector": 25.6518,
         "t_greenhouse": 17.5642,
         "t_outdoor": 14.9349
       },
@@ -4232,9 +4232,9 @@
     {
       "time": 23040,
       "values": {
-        "t_tank_top": 23.8724,
-        "t_tank_bottom": 22.8491,
-        "t_collector": 25.7774,
+        "t_tank_top": 23.7758,
+        "t_tank_bottom": 22.751,
+        "t_collector": 25.6827,
         "t_greenhouse": 17.5696,
         "t_outdoor": 14.9384
       },
@@ -4243,9 +4243,9 @@
     {
       "time": 23100,
       "values": {
-        "t_tank_top": 23.9064,
-        "t_tank_bottom": 22.8848,
-        "t_collector": 25.8081,
+        "t_tank_top": 23.8098,
+        "t_tank_bottom": 22.7867,
+        "t_collector": 25.7134,
         "t_greenhouse": 17.5749,
         "t_outdoor": 14.9418
       },
@@ -4254,9 +4254,9 @@
     {
       "time": 23160,
       "values": {
-        "t_tank_top": 23.9402,
-        "t_tank_bottom": 22.9203,
-        "t_collector": 25.8386,
+        "t_tank_top": 23.8437,
+        "t_tank_bottom": 22.8223,
+        "t_collector": 25.7441,
         "t_greenhouse": 17.58,
         "t_outdoor": 14.945
       },
@@ -4265,9 +4265,9 @@
     {
       "time": 23220,
       "values": {
-        "t_tank_top": 23.974,
-        "t_tank_bottom": 22.9558,
-        "t_collector": 25.8691,
+        "t_tank_top": 23.8776,
+        "t_tank_bottom": 22.8579,
+        "t_collector": 25.7746,
         "t_greenhouse": 17.585,
         "t_outdoor": 14.9482
       },
@@ -4276,9 +4276,9 @@
     {
       "time": 23280,
       "values": {
-        "t_tank_top": 24.0076,
-        "t_tank_bottom": 22.9913,
-        "t_collector": 25.8994,
+        "t_tank_top": 23.9113,
+        "t_tank_bottom": 22.8934,
+        "t_collector": 25.805,
         "t_greenhouse": 17.5899,
         "t_outdoor": 14.9513
       },
@@ -4287,9 +4287,9 @@
     {
       "time": 23340,
       "values": {
-        "t_tank_top": 24.0412,
-        "t_tank_bottom": 23.0267,
-        "t_collector": 25.9296,
+        "t_tank_top": 23.945,
+        "t_tank_bottom": 22.9288,
+        "t_collector": 25.8353,
         "t_greenhouse": 17.5946,
         "t_outdoor": 14.9543
       },
@@ -4298,9 +4298,9 @@
     {
       "time": 23400,
       "values": {
-        "t_tank_top": 24.0747,
-        "t_tank_bottom": 23.062,
-        "t_collector": 25.9597,
+        "t_tank_top": 23.9785,
+        "t_tank_bottom": 22.9642,
+        "t_collector": 25.8654,
         "t_greenhouse": 17.5993,
         "t_outdoor": 14.9572
       },
@@ -4309,9 +4309,9 @@
     {
       "time": 23460,
       "values": {
-        "t_tank_top": 24.1081,
-        "t_tank_bottom": 23.0972,
-        "t_collector": 25.9897,
+        "t_tank_top": 24.012,
+        "t_tank_bottom": 22.9995,
+        "t_collector": 25.8955,
         "t_greenhouse": 17.6037,
         "t_outdoor": 14.96
       },
@@ -4320,9 +4320,9 @@
     {
       "time": 23520,
       "values": {
-        "t_tank_top": 24.1415,
-        "t_tank_bottom": 23.1324,
-        "t_collector": 26.0196,
+        "t_tank_top": 24.0454,
+        "t_tank_bottom": 23.0348,
+        "t_collector": 25.9254,
         "t_greenhouse": 17.6081,
         "t_outdoor": 14.9627
       },
@@ -4331,9 +4331,9 @@
     {
       "time": 23580,
       "values": {
-        "t_tank_top": 24.1747,
-        "t_tank_bottom": 23.1675,
-        "t_collector": 26.0493,
+        "t_tank_top": 24.0787,
+        "t_tank_bottom": 23.0699,
+        "t_collector": 25.9553,
         "t_greenhouse": 17.6123,
         "t_outdoor": 14.9653
       },
@@ -4342,9 +4342,9 @@
     {
       "time": 23640,
       "values": {
-        "t_tank_top": 24.2079,
-        "t_tank_bottom": 23.2025,
-        "t_collector": 26.079,
+        "t_tank_top": 24.112,
+        "t_tank_bottom": 23.105,
+        "t_collector": 25.985,
         "t_greenhouse": 17.6164,
         "t_outdoor": 14.9678
       },
@@ -4353,9 +4353,9 @@
     {
       "time": 23700,
       "values": {
-        "t_tank_top": 24.2409,
-        "t_tank_bottom": 23.2374,
-        "t_collector": 26.1085,
+        "t_tank_top": 24.1451,
+        "t_tank_bottom": 23.14,
+        "t_collector": 26.0146,
         "t_greenhouse": 17.6204,
         "t_outdoor": 14.9702
       },
@@ -4364,9 +4364,9 @@
     {
       "time": 23760,
       "values": {
-        "t_tank_top": 24.2739,
-        "t_tank_bottom": 23.2723,
-        "t_collector": 26.1379,
+        "t_tank_top": 24.1781,
+        "t_tank_bottom": 23.175,
+        "t_collector": 26.044,
         "t_greenhouse": 17.6242,
         "t_outdoor": 14.9726
       },
@@ -4375,9 +4375,9 @@
     {
       "time": 23820,
       "values": {
-        "t_tank_top": 24.3068,
-        "t_tank_bottom": 23.3071,
-        "t_collector": 26.1672,
+        "t_tank_top": 24.2111,
+        "t_tank_bottom": 23.2098,
+        "t_collector": 26.0734,
         "t_greenhouse": 17.6279,
         "t_outdoor": 14.9748
       },
@@ -4386,9 +4386,9 @@
     {
       "time": 23880,
       "values": {
-        "t_tank_top": 24.3396,
-        "t_tank_bottom": 23.3418,
-        "t_collector": 26.1964,
+        "t_tank_top": 24.244,
+        "t_tank_bottom": 23.2446,
+        "t_collector": 26.1026,
         "t_greenhouse": 17.6315,
         "t_outdoor": 14.9769
       },
@@ -4397,9 +4397,9 @@
     {
       "time": 23940,
       "values": {
-        "t_tank_top": 24.3723,
-        "t_tank_bottom": 23.3765,
-        "t_collector": 26.2254,
+        "t_tank_top": 24.2767,
+        "t_tank_bottom": 23.2794,
+        "t_collector": 26.1317,
         "t_greenhouse": 17.635,
         "t_outdoor": 14.979
       },
@@ -4408,9 +4408,9 @@
     {
       "time": 24000,
       "values": {
-        "t_tank_top": 24.4049,
-        "t_tank_bottom": 23.4111,
-        "t_collector": 26.2543,
+        "t_tank_top": 24.3094,
+        "t_tank_bottom": 23.314,
+        "t_collector": 26.1607,
         "t_greenhouse": 17.6383,
         "t_outdoor": 14.9809
       },
@@ -4419,9 +4419,9 @@
     {
       "time": 24060,
       "values": {
-        "t_tank_top": 24.4374,
-        "t_tank_bottom": 23.4456,
-        "t_collector": 26.2832,
+        "t_tank_top": 24.342,
+        "t_tank_bottom": 23.3486,
+        "t_collector": 26.1896,
         "t_greenhouse": 17.6415,
         "t_outdoor": 14.9828
       },
@@ -4430,9 +4430,9 @@
     {
       "time": 24120,
       "values": {
-        "t_tank_top": 24.4699,
-        "t_tank_bottom": 23.48,
-        "t_collector": 26.3118,
+        "t_tank_top": 24.3745,
+        "t_tank_bottom": 23.3831,
+        "t_collector": 26.2184,
         "t_greenhouse": 17.6445,
         "t_outdoor": 14.9846
       },
@@ -4441,9 +4441,9 @@
     {
       "time": 24180,
       "values": {
-        "t_tank_top": 24.5022,
-        "t_tank_bottom": 23.5143,
-        "t_collector": 26.3404,
+        "t_tank_top": 24.4069,
+        "t_tank_bottom": 23.4175,
+        "t_collector": 26.247,
         "t_greenhouse": 17.6474,
         "t_outdoor": 14.9862
       },
@@ -4452,9 +4452,9 @@
     {
       "time": 24240,
       "values": {
-        "t_tank_top": 24.5344,
-        "t_tank_bottom": 23.5486,
-        "t_collector": 26.3689,
+        "t_tank_top": 24.4392,
+        "t_tank_bottom": 23.4518,
+        "t_collector": 26.2755,
         "t_greenhouse": 17.6502,
         "t_outdoor": 14.9878
       },
@@ -4463,9 +4463,9 @@
     {
       "time": 24300,
       "values": {
-        "t_tank_top": 24.5666,
-        "t_tank_bottom": 23.5828,
-        "t_collector": 26.3972,
+        "t_tank_top": 24.4714,
+        "t_tank_bottom": 23.4861,
+        "t_collector": 26.3039,
         "t_greenhouse": 17.6529,
         "t_outdoor": 14.9893
       },
@@ -4474,9 +4474,9 @@
     {
       "time": 24360,
       "values": {
-        "t_tank_top": 24.5987,
-        "t_tank_bottom": 23.6169,
-        "t_collector": 26.4254,
+        "t_tank_top": 24.5036,
+        "t_tank_bottom": 23.5203,
+        "t_collector": 26.3322,
         "t_greenhouse": 17.6554,
         "t_outdoor": 14.9907
       },
@@ -4485,9 +4485,9 @@
     {
       "time": 24420,
       "values": {
-        "t_tank_top": 24.6306,
-        "t_tank_bottom": 23.651,
-        "t_collector": 26.4535,
+        "t_tank_top": 24.5356,
+        "t_tank_bottom": 23.5544,
+        "t_collector": 26.3603,
         "t_greenhouse": 17.6578,
         "t_outdoor": 14.9919
       },
@@ -4496,9 +4496,9 @@
     {
       "time": 24480,
       "values": {
-        "t_tank_top": 24.6625,
-        "t_tank_bottom": 23.6849,
-        "t_collector": 26.4814,
+        "t_tank_top": 24.5675,
+        "t_tank_bottom": 23.5884,
+        "t_collector": 26.3883,
         "t_greenhouse": 17.6601,
         "t_outdoor": 14.9931
       },
@@ -4507,9 +4507,9 @@
     {
       "time": 24540,
       "values": {
-        "t_tank_top": 24.6942,
-        "t_tank_bottom": 23.7188,
-        "t_collector": 26.5093,
+        "t_tank_top": 24.5994,
+        "t_tank_bottom": 23.6224,
+        "t_collector": 26.4162,
         "t_greenhouse": 17.6622,
         "t_outdoor": 14.9942
       },
@@ -4518,9 +4518,9 @@
     {
       "time": 24600,
       "values": {
-        "t_tank_top": 24.7259,
-        "t_tank_bottom": 23.7526,
-        "t_collector": 26.537,
+        "t_tank_top": 24.6311,
+        "t_tank_bottom": 23.6562,
+        "t_collector": 26.444,
         "t_greenhouse": 17.6642,
         "t_outdoor": 14.9952
       },
@@ -4529,9 +4529,9 @@
     {
       "time": 24660,
       "values": {
-        "t_tank_top": 24.7575,
-        "t_tank_bottom": 23.7863,
-        "t_collector": 26.5645,
+        "t_tank_top": 24.6628,
+        "t_tank_bottom": 23.69,
+        "t_collector": 26.4717,
         "t_greenhouse": 17.6661,
         "t_outdoor": 14.9961
       },
@@ -4540,9 +4540,9 @@
     {
       "time": 24720,
       "values": {
-        "t_tank_top": 24.789,
-        "t_tank_bottom": 23.8199,
-        "t_collector": 26.592,
+        "t_tank_top": 24.6943,
+        "t_tank_bottom": 23.7237,
+        "t_collector": 26.4992,
         "t_greenhouse": 17.6678,
         "t_outdoor": 14.9969
       },
@@ -4551,9 +4551,9 @@
     {
       "time": 24780,
       "values": {
-        "t_tank_top": 24.8204,
-        "t_tank_bottom": 23.8535,
-        "t_collector": 26.6193,
+        "t_tank_top": 24.7258,
+        "t_tank_bottom": 23.7574,
+        "t_collector": 26.5266,
         "t_greenhouse": 17.6694,
         "t_outdoor": 14.9977
       },
@@ -4562,9 +4562,9 @@
     {
       "time": 24840,
       "values": {
-        "t_tank_top": 24.8516,
-        "t_tank_bottom": 23.887,
-        "t_collector": 26.6465,
+        "t_tank_top": 24.7571,
+        "t_tank_bottom": 23.7909,
+        "t_collector": 26.5539,
         "t_greenhouse": 17.6709,
         "t_outdoor": 14.9983
       },
@@ -4573,9 +4573,9 @@
     {
       "time": 24900,
       "values": {
-        "t_tank_top": 24.8828,
-        "t_tank_bottom": 23.9203,
-        "t_collector": 26.6736,
+        "t_tank_top": 24.7884,
+        "t_tank_bottom": 23.8243,
+        "t_collector": 26.581,
         "t_greenhouse": 17.6723,
         "t_outdoor": 14.9988
       },
@@ -4584,9 +4584,9 @@
     {
       "time": 24960,
       "values": {
-        "t_tank_top": 24.9139,
-        "t_tank_bottom": 23.9536,
-        "t_collector": 26.7005,
+        "t_tank_top": 24.8195,
+        "t_tank_bottom": 23.8577,
+        "t_collector": 26.608,
         "t_greenhouse": 17.6735,
         "t_outdoor": 14.9992
       },
@@ -4595,9 +4595,9 @@
     {
       "time": 25020,
       "values": {
-        "t_tank_top": 24.9449,
-        "t_tank_bottom": 23.9869,
-        "t_collector": 26.7274,
+        "t_tank_top": 24.8506,
+        "t_tank_bottom": 23.891,
+        "t_collector": 26.6349,
         "t_greenhouse": 17.6746,
         "t_outdoor": 14.9996
       },
@@ -4606,9 +4606,9 @@
     {
       "time": 25080,
       "values": {
-        "t_tank_top": 24.9758,
-        "t_tank_bottom": 24.02,
-        "t_collector": 26.7541,
+        "t_tank_top": 24.8815,
+        "t_tank_bottom": 23.9242,
+        "t_collector": 26.6617,
         "t_greenhouse": 17.6755,
         "t_outdoor": 14.9998
       },
@@ -4617,9 +4617,9 @@
     {
       "time": 25140,
       "values": {
-        "t_tank_top": 25.0065,
-        "t_tank_bottom": 24.053,
-        "t_collector": 26.7806,
+        "t_tank_top": 24.9124,
+        "t_tank_bottom": 23.9573,
+        "t_collector": 26.6883,
         "t_greenhouse": 17.6763,
         "t_outdoor": 15
       },
@@ -4628,9 +4628,9 @@
     {
       "time": 25200,
       "values": {
-        "t_tank_top": 25.0372,
-        "t_tank_bottom": 24.086,
-        "t_collector": 26.8071,
+        "t_tank_top": 24.9431,
+        "t_tank_bottom": 23.9903,
+        "t_collector": 26.7148,
         "t_greenhouse": 17.677,
         "t_outdoor": 15
       },
@@ -4639,9 +4639,9 @@
     {
       "time": 25260,
       "values": {
-        "t_tank_top": 25.0678,
-        "t_tank_bottom": 24.1189,
-        "t_collector": 26.8334,
+        "t_tank_top": 24.9737,
+        "t_tank_bottom": 24.0233,
+        "t_collector": 26.7411,
         "t_greenhouse": 17.6776,
         "t_outdoor": 15
       },
@@ -4650,9 +4650,9 @@
     {
       "time": 25320,
       "values": {
-        "t_tank_top": 25.0983,
-        "t_tank_bottom": 24.1516,
-        "t_collector": 26.8595,
+        "t_tank_top": 25.0043,
+        "t_tank_bottom": 24.0561,
+        "t_collector": 26.7674,
         "t_greenhouse": 17.678,
         "t_outdoor": 14.9998
       },
@@ -4661,9 +4661,9 @@
     {
       "time": 25380,
       "values": {
-        "t_tank_top": 25.1286,
-        "t_tank_bottom": 24.1843,
-        "t_collector": 26.8856,
+        "t_tank_top": 25.0347,
+        "t_tank_bottom": 24.0889,
+        "t_collector": 26.7935,
         "t_greenhouse": 17.6783,
         "t_outdoor": 14.9996
       },
@@ -4672,9 +4672,9 @@
     {
       "time": 25440,
       "values": {
-        "t_tank_top": 25.1589,
-        "t_tank_bottom": 24.2169,
-        "t_collector": 26.9115,
+        "t_tank_top": 25.065,
+        "t_tank_bottom": 24.1216,
+        "t_collector": 26.8195,
         "t_greenhouse": 17.6785,
         "t_outdoor": 14.9992
       },
@@ -4683,9 +4683,9 @@
     {
       "time": 25500,
       "values": {
-        "t_tank_top": 25.1891,
-        "t_tank_bottom": 24.2495,
-        "t_collector": 26.9373,
+        "t_tank_top": 25.0953,
+        "t_tank_bottom": 24.1542,
+        "t_collector": 26.8453,
         "t_greenhouse": 17.6785,
         "t_outdoor": 14.9988
       },
@@ -4694,9 +4694,9 @@
     {
       "time": 25560,
       "values": {
-        "t_tank_top": 25.2191,
-        "t_tank_bottom": 24.2819,
-        "t_collector": 26.9629,
+        "t_tank_top": 25.1254,
+        "t_tank_bottom": 24.1866,
+        "t_collector": 26.871,
         "t_greenhouse": 17.6784,
         "t_outdoor": 14.9983
       },
@@ -4705,9 +4705,9 @@
     {
       "time": 25620,
       "values": {
-        "t_tank_top": 25.2491,
-        "t_tank_bottom": 24.3142,
-        "t_collector": 26.9884,
+        "t_tank_top": 25.1554,
+        "t_tank_bottom": 24.2191,
+        "t_collector": 26.8966,
         "t_greenhouse": 17.6781,
         "t_outdoor": 14.9977
       },
@@ -4716,9 +4716,9 @@
     {
       "time": 25680,
       "values": {
-        "t_tank_top": 25.2789,
-        "t_tank_bottom": 24.3465,
-        "t_collector": 27.0138,
+        "t_tank_top": 25.1853,
+        "t_tank_bottom": 24.2514,
+        "t_collector": 26.9221,
         "t_greenhouse": 17.6778,
         "t_outdoor": 14.997
       },
@@ -4727,9 +4727,9 @@
     {
       "time": 25740,
       "values": {
-        "t_tank_top": 25.3086,
-        "t_tank_bottom": 24.3786,
-        "t_collector": 27.039,
+        "t_tank_top": 25.2151,
+        "t_tank_bottom": 24.2836,
+        "t_collector": 26.9474,
         "t_greenhouse": 17.6773,
         "t_outdoor": 14.9962
       },
@@ -4738,9 +4738,9 @@
     {
       "time": 25800,
       "values": {
-        "t_tank_top": 25.3383,
-        "t_tank_bottom": 24.4107,
-        "t_collector": 27.0642,
+        "t_tank_top": 25.2448,
+        "t_tank_bottom": 24.3157,
+        "t_collector": 26.9726,
         "t_greenhouse": 17.6766,
         "t_outdoor": 14.9953
       },
@@ -4749,9 +4749,9 @@
     {
       "time": 25860,
       "values": {
-        "t_tank_top": 25.3678,
-        "t_tank_bottom": 24.4427,
-        "t_collector": 27.0891,
+        "t_tank_top": 25.2744,
+        "t_tank_bottom": 24.3478,
+        "t_collector": 26.9976,
         "t_greenhouse": 17.6759,
         "t_outdoor": 14.9943
       },
@@ -4760,9 +4760,9 @@
     {
       "time": 25920,
       "values": {
-        "t_tank_top": 25.3972,
-        "t_tank_bottom": 24.4745,
-        "t_collector": 27.114,
+        "t_tank_top": 25.3039,
+        "t_tank_bottom": 24.3797,
+        "t_collector": 27.0225,
         "t_greenhouse": 17.675,
         "t_outdoor": 14.9932
       },
@@ -4771,9 +4771,9 @@
     {
       "time": 25980,
       "values": {
-        "t_tank_top": 25.4265,
-        "t_tank_bottom": 24.5063,
-        "t_collector": 27.1387,
+        "t_tank_top": 25.3333,
+        "t_tank_bottom": 24.4116,
+        "t_collector": 27.0473,
         "t_greenhouse": 17.674,
         "t_outdoor": 14.992
       },
@@ -4782,9 +4782,9 @@
     {
       "time": 26040,
       "values": {
-        "t_tank_top": 25.4557,
-        "t_tank_bottom": 24.538,
-        "t_collector": 27.1633,
+        "t_tank_top": 25.3625,
+        "t_tank_bottom": 24.4433,
+        "t_collector": 27.0719,
         "t_greenhouse": 17.6728,
         "t_outdoor": 14.9907
       },
@@ -4793,9 +4793,9 @@
     {
       "time": 26100,
       "values": {
-        "t_tank_top": 25.4848,
-        "t_tank_bottom": 24.5696,
-        "t_collector": 27.1877,
+        "t_tank_top": 25.3917,
+        "t_tank_bottom": 24.475,
+        "t_collector": 27.0964,
         "t_greenhouse": 17.6715,
         "t_outdoor": 14.9893
       },
@@ -4804,9 +4804,9 @@
     {
       "time": 26160,
       "values": {
-        "t_tank_top": 25.5138,
-        "t_tank_bottom": 24.6011,
-        "t_collector": 27.212,
+        "t_tank_top": 25.4207,
+        "t_tank_bottom": 24.5065,
+        "t_collector": 27.1208,
         "t_greenhouse": 17.6701,
         "t_outdoor": 14.9878
       },
@@ -4815,9 +4815,9 @@
     {
       "time": 26220,
       "values": {
-        "t_tank_top": 25.5426,
-        "t_tank_bottom": 24.6325,
-        "t_collector": 27.2362,
+        "t_tank_top": 25.4497,
+        "t_tank_bottom": 24.538,
+        "t_collector": 27.145,
         "t_greenhouse": 17.6685,
         "t_outdoor": 14.9863
       },
@@ -4826,9 +4826,9 @@
     {
       "time": 26280,
       "values": {
-        "t_tank_top": 25.5714,
-        "t_tank_bottom": 24.6638,
-        "t_collector": 27.2602,
+        "t_tank_top": 25.4785,
+        "t_tank_bottom": 24.5694,
+        "t_collector": 27.1691,
         "t_greenhouse": 17.6669,
         "t_outdoor": 14.9846
       },
@@ -4837,9 +4837,9 @@
     {
       "time": 26340,
       "values": {
-        "t_tank_top": 25.6,
-        "t_tank_bottom": 24.695,
-        "t_collector": 27.2841,
+        "t_tank_top": 25.5072,
+        "t_tank_bottom": 24.6007,
+        "t_collector": 27.1931,
         "t_greenhouse": 17.665,
         "t_outdoor": 14.9829
       },
@@ -4848,9 +4848,9 @@
     {
       "time": 26400,
       "values": {
-        "t_tank_top": 25.6286,
-        "t_tank_bottom": 24.7261,
-        "t_collector": 27.3078,
+        "t_tank_top": 25.5358,
+        "t_tank_bottom": 24.6318,
+        "t_collector": 27.2169,
         "t_greenhouse": 17.6631,
         "t_outdoor": 14.981
       },
@@ -4859,9 +4859,9 @@
     {
       "time": 26460,
       "values": {
-        "t_tank_top": 25.657,
-        "t_tank_bottom": 24.7572,
-        "t_collector": 27.3314,
+        "t_tank_top": 25.5643,
+        "t_tank_bottom": 24.6629,
+        "t_collector": 27.2406,
         "t_greenhouse": 17.661,
         "t_outdoor": 14.9791
       },
@@ -4870,9 +4870,9 @@
     {
       "time": 26520,
       "values": {
-        "t_tank_top": 25.6853,
-        "t_tank_bottom": 24.7881,
-        "t_collector": 27.3549,
+        "t_tank_top": 25.5926,
+        "t_tank_bottom": 24.6939,
+        "t_collector": 27.2641,
         "t_greenhouse": 17.6588,
         "t_outdoor": 14.977
       },
@@ -4881,9 +4881,9 @@
     {
       "time": 26580,
       "values": {
-        "t_tank_top": 25.7135,
-        "t_tank_bottom": 24.8189,
-        "t_collector": 27.3783,
+        "t_tank_top": 25.6209,
+        "t_tank_bottom": 24.7248,
+        "t_collector": 27.2875,
         "t_greenhouse": 17.6564,
         "t_outdoor": 14.9749
       },
@@ -4892,9 +4892,9 @@
     {
       "time": 26640,
       "values": {
-        "t_tank_top": 25.7416,
-        "t_tank_bottom": 24.8496,
-        "t_collector": 27.4014,
+        "t_tank_top": 25.649,
+        "t_tank_bottom": 24.7556,
+        "t_collector": 27.3108,
         "t_greenhouse": 17.654,
         "t_outdoor": 14.9726
       },
@@ -4903,9 +4903,9 @@
     {
       "time": 26700,
       "values": {
-        "t_tank_top": 25.7695,
-        "t_tank_bottom": 24.8802,
-        "t_collector": 27.4245,
+        "t_tank_top": 25.6771,
+        "t_tank_bottom": 24.7863,
+        "t_collector": 27.3339,
         "t_greenhouse": 17.6514,
         "t_outdoor": 14.9703
       },
@@ -4914,9 +4914,9 @@
     {
       "time": 26760,
       "values": {
-        "t_tank_top": 25.7974,
-        "t_tank_bottom": 24.9107,
-        "t_collector": 27.4474,
+        "t_tank_top": 25.705,
+        "t_tank_bottom": 24.8169,
+        "t_collector": 27.3568,
         "t_greenhouse": 17.6486,
         "t_outdoor": 14.9679
       },
@@ -4925,9 +4925,9 @@
     {
       "time": 26820,
       "values": {
-        "t_tank_top": 25.8251,
-        "t_tank_bottom": 24.9412,
-        "t_collector": 27.4702,
+        "t_tank_top": 25.7328,
+        "t_tank_bottom": 24.8473,
+        "t_collector": 27.3797,
         "t_greenhouse": 17.6457,
         "t_outdoor": 14.9654
       },
@@ -4936,9 +4936,9 @@
     {
       "time": 26880,
       "values": {
-        "t_tank_top": 25.8527,
-        "t_tank_bottom": 24.9715,
-        "t_collector": 27.4928,
+        "t_tank_top": 25.7605,
+        "t_tank_bottom": 24.8777,
+        "t_collector": 27.4024,
         "t_greenhouse": 17.6427,
         "t_outdoor": 14.9628
       },
@@ -4947,9 +4947,9 @@
     {
       "time": 26940,
       "values": {
-        "t_tank_top": 25.8802,
-        "t_tank_bottom": 25.0017,
-        "t_collector": 27.5153,
+        "t_tank_top": 25.788,
+        "t_tank_bottom": 24.908,
+        "t_collector": 27.4249,
         "t_greenhouse": 17.6396,
         "t_outdoor": 14.9601
       },
@@ -4958,9 +4958,9 @@
     {
       "time": 27000,
       "values": {
-        "t_tank_top": 25.9076,
-        "t_tank_bottom": 25.0318,
-        "t_collector": 27.5376,
+        "t_tank_top": 25.8155,
+        "t_tank_bottom": 24.9382,
+        "t_collector": 27.4473,
         "t_greenhouse": 17.6363,
         "t_outdoor": 14.9573
       },
@@ -4969,9 +4969,9 @@
     {
       "time": 27060,
       "values": {
-        "t_tank_top": 25.9348,
-        "t_tank_bottom": 25.0618,
-        "t_collector": 27.5598,
+        "t_tank_top": 25.8428,
+        "t_tank_bottom": 24.9683,
+        "t_collector": 27.4696,
         "t_greenhouse": 17.6329,
         "t_outdoor": 14.9544
       },
@@ -4980,9 +4980,9 @@
     {
       "time": 27120,
       "values": {
-        "t_tank_top": 25.962,
-        "t_tank_bottom": 25.0917,
-        "t_collector": 27.5819,
+        "t_tank_top": 25.87,
+        "t_tank_bottom": 24.9982,
+        "t_collector": 27.4917,
         "t_greenhouse": 17.6294,
         "t_outdoor": 14.9514
       },
@@ -4991,9 +4991,9 @@
     {
       "time": 27180,
       "values": {
-        "t_tank_top": 25.989,
-        "t_tank_bottom": 25.1215,
-        "t_collector": 27.6038,
+        "t_tank_top": 25.8971,
+        "t_tank_bottom": 25.0281,
+        "t_collector": 27.5137,
         "t_greenhouse": 17.6257,
         "t_outdoor": 14.9483
       },
@@ -5002,9 +5002,9 @@
     {
       "time": 27240,
       "values": {
-        "t_tank_top": 26.0159,
-        "t_tank_bottom": 25.1512,
-        "t_collector": 27.6256,
+        "t_tank_top": 25.9241,
+        "t_tank_bottom": 25.0579,
+        "t_collector": 27.5355,
         "t_greenhouse": 17.622,
         "t_outdoor": 14.9451
       },
@@ -5013,9 +5013,9 @@
     {
       "time": 27300,
       "values": {
-        "t_tank_top": 26.0427,
-        "t_tank_bottom": 25.1808,
-        "t_collector": 27.6472,
+        "t_tank_top": 25.9509,
+        "t_tank_bottom": 25.0875,
+        "t_collector": 27.5572,
         "t_greenhouse": 17.618,
         "t_outdoor": 14.9419
       },
@@ -5024,9 +5024,9 @@
     {
       "time": 27360,
       "values": {
-        "t_tank_top": 26.0694,
-        "t_tank_bottom": 25.2103,
-        "t_collector": 27.6687,
+        "t_tank_top": 25.9777,
+        "t_tank_bottom": 25.1171,
+        "t_collector": 27.5788,
         "t_greenhouse": 17.614,
         "t_outdoor": 14.9385
       },
@@ -5035,9 +5035,9 @@
     {
       "time": 27420,
       "values": {
-        "t_tank_top": 26.0959,
-        "t_tank_bottom": 25.2396,
-        "t_collector": 27.69,
+        "t_tank_top": 26.0043,
+        "t_tank_bottom": 25.1465,
+        "t_collector": 27.6002,
         "t_greenhouse": 17.6098,
         "t_outdoor": 14.935
       },
@@ -5046,9 +5046,9 @@
     {
       "time": 27480,
       "values": {
-        "t_tank_top": 26.1224,
-        "t_tank_bottom": 25.2689,
-        "t_collector": 27.7112,
+        "t_tank_top": 26.0308,
+        "t_tank_bottom": 25.1758,
+        "t_collector": 27.6214,
         "t_greenhouse": 17.6055,
         "t_outdoor": 14.9315
       },
@@ -5057,9 +5057,9 @@
     {
       "time": 27540,
       "values": {
-        "t_tank_top": 26.1487,
-        "t_tank_bottom": 25.2981,
-        "t_collector": 27.7323,
+        "t_tank_top": 26.0572,
+        "t_tank_bottom": 25.2051,
+        "t_collector": 27.6425,
         "t_greenhouse": 17.601,
         "t_outdoor": 14.9278
       },
@@ -5068,9 +5068,9 @@
     {
       "time": 27600,
       "values": {
-        "t_tank_top": 26.1749,
-        "t_tank_bottom": 25.3271,
-        "t_collector": 27.7532,
+        "t_tank_top": 26.0834,
+        "t_tank_bottom": 25.2342,
+        "t_collector": 27.6635,
         "t_greenhouse": 17.5964,
         "t_outdoor": 14.9241
       },
@@ -5079,9 +5079,9 @@
     {
       "time": 27660,
       "values": {
-        "t_tank_top": 26.2009,
-        "t_tank_bottom": 25.3561,
-        "t_collector": 27.7739,
+        "t_tank_top": 26.1095,
+        "t_tank_bottom": 25.2632,
+        "t_collector": 27.6843,
         "t_greenhouse": 17.5917,
         "t_outdoor": 14.9203
       },
@@ -5090,9 +5090,9 @@
     {
       "time": 27720,
       "values": {
-        "t_tank_top": 26.2269,
-        "t_tank_bottom": 25.3849,
-        "t_collector": 27.7945,
+        "t_tank_top": 26.1355,
+        "t_tank_bottom": 25.2921,
+        "t_collector": 27.705,
         "t_greenhouse": 17.5869,
         "t_outdoor": 14.9163
       },
@@ -5101,9 +5101,9 @@
     {
       "time": 27780,
       "values": {
-        "t_tank_top": 26.2527,
-        "t_tank_bottom": 25.4137,
-        "t_collector": 27.815,
+        "t_tank_top": 26.1614,
+        "t_tank_bottom": 25.3209,
+        "t_collector": 27.7255,
         "t_greenhouse": 17.5819,
         "t_outdoor": 14.9123
       },
@@ -5112,9 +5112,9 @@
     {
       "time": 27840,
       "values": {
-        "t_tank_top": 26.2784,
-        "t_tank_bottom": 25.4423,
-        "t_collector": 27.8353,
+        "t_tank_top": 26.1872,
+        "t_tank_bottom": 25.3496,
+        "t_collector": 27.7459,
         "t_greenhouse": 17.5768,
         "t_outdoor": 14.9082
       },
@@ -5123,9 +5123,9 @@
     {
       "time": 27900,
       "values": {
-        "t_tank_top": 26.3039,
-        "t_tank_bottom": 25.4708,
-        "t_collector": 27.8554,
+        "t_tank_top": 26.2128,
+        "t_tank_bottom": 25.3782,
+        "t_collector": 27.7661,
         "t_greenhouse": 17.5716,
         "t_outdoor": 14.904
       },
@@ -5134,9 +5134,9 @@
     {
       "time": 27960,
       "values": {
-        "t_tank_top": 26.3294,
-        "t_tank_bottom": 25.4992,
-        "t_collector": 27.8754,
+        "t_tank_top": 26.2383,
+        "t_tank_bottom": 25.4066,
+        "t_collector": 27.7862,
         "t_greenhouse": 17.5662,
         "t_outdoor": 14.8997
       },
@@ -5145,9 +5145,9 @@
     {
       "time": 28020,
       "values": {
-        "t_tank_top": 26.3547,
-        "t_tank_bottom": 25.5275,
-        "t_collector": 27.8953,
+        "t_tank_top": 26.2637,
+        "t_tank_bottom": 25.435,
+        "t_collector": 27.8061,
         "t_greenhouse": 17.5607,
         "t_outdoor": 14.8953
       },
@@ -5156,9 +5156,9 @@
     {
       "time": 28080,
       "values": {
-        "t_tank_top": 26.3799,
-        "t_tank_bottom": 25.5556,
-        "t_collector": 27.915,
+        "t_tank_top": 26.289,
+        "t_tank_bottom": 25.4632,
+        "t_collector": 27.8259,
         "t_greenhouse": 17.5551,
         "t_outdoor": 14.8908
       },
@@ -5167,9 +5167,9 @@
     {
       "time": 28140,
       "values": {
-        "t_tank_top": 26.405,
-        "t_tank_bottom": 25.5837,
-        "t_collector": 27.9346,
+        "t_tank_top": 26.3141,
+        "t_tank_bottom": 25.4914,
+        "t_collector": 27.8455,
         "t_greenhouse": 17.5493,
         "t_outdoor": 14.8862
       },
@@ -5178,9 +5178,9 @@
     {
       "time": 28200,
       "values": {
-        "t_tank_top": 26.4299,
-        "t_tank_bottom": 25.6117,
-        "t_collector": 27.954,
+        "t_tank_top": 26.3391,
+        "t_tank_bottom": 25.5194,
+        "t_collector": 27.865,
         "t_greenhouse": 17.5434,
         "t_outdoor": 14.8816
       },
@@ -5189,9 +5189,9 @@
     {
       "time": 28260,
       "values": {
-        "t_tank_top": 26.4547,
-        "t_tank_bottom": 25.6395,
-        "t_collector": 27.9733,
+        "t_tank_top": 26.364,
+        "t_tank_bottom": 25.5473,
+        "t_collector": 27.8843,
         "t_greenhouse": 17.5374,
         "t_outdoor": 14.8768
       },
@@ -5200,9 +5200,9 @@
     {
       "time": 28320,
       "values": {
-        "t_tank_top": 26.4794,
-        "t_tank_bottom": 25.6672,
-        "t_collector": 27.9924,
+        "t_tank_top": 26.3888,
+        "t_tank_bottom": 25.5751,
+        "t_collector": 27.9035,
         "t_greenhouse": 17.5312,
         "t_outdoor": 14.8719
       },
@@ -5211,9 +5211,9 @@
     {
       "time": 28380,
       "values": {
-        "t_tank_top": 26.504,
-        "t_tank_bottom": 25.6948,
-        "t_collector": 28.0113,
+        "t_tank_top": 26.4134,
+        "t_tank_bottom": 25.6028,
+        "t_collector": 27.9225,
         "t_greenhouse": 17.525,
         "t_outdoor": 14.867
       },
@@ -5222,9 +5222,9 @@
     {
       "time": 28440,
       "values": {
-        "t_tank_top": 26.5284,
-        "t_tank_bottom": 25.7223,
-        "t_collector": 28.0301,
+        "t_tank_top": 26.4379,
+        "t_tank_bottom": 25.6303,
+        "t_collector": 27.9414,
         "t_greenhouse": 17.5186,
         "t_outdoor": 14.8619
       },
@@ -5233,9 +5233,9 @@
     {
       "time": 28500,
       "values": {
-        "t_tank_top": 26.5527,
-        "t_tank_bottom": 25.7497,
-        "t_collector": 28.0488,
+        "t_tank_top": 26.4623,
+        "t_tank_bottom": 25.6578,
+        "t_collector": 27.9601,
         "t_greenhouse": 17.512,
         "t_outdoor": 14.8568
       },
@@ -5244,9 +5244,9 @@
     {
       "time": 28560,
       "values": {
-        "t_tank_top": 26.5769,
-        "t_tank_bottom": 25.777,
-        "t_collector": 28.0673,
+        "t_tank_top": 26.4865,
+        "t_tank_bottom": 25.6851,
+        "t_collector": 27.9787,
         "t_greenhouse": 17.5053,
         "t_outdoor": 14.8516
       },
@@ -5255,9 +5255,9 @@
     {
       "time": 28620,
       "values": {
-        "t_tank_top": 26.6009,
-        "t_tank_bottom": 25.8041,
-        "t_collector": 28.0856,
+        "t_tank_top": 26.5106,
+        "t_tank_bottom": 25.7123,
+        "t_collector": 27.9971,
         "t_greenhouse": 17.4985,
         "t_outdoor": 14.8462
       },
@@ -5266,9 +5266,9 @@
     {
       "time": 28680,
       "values": {
-        "t_tank_top": 26.6249,
-        "t_tank_bottom": 25.8312,
-        "t_collector": 28.1038,
+        "t_tank_top": 26.5346,
+        "t_tank_bottom": 25.7394,
+        "t_collector": 28.0153,
         "t_greenhouse": 17.4916,
         "t_outdoor": 14.8408
       },
@@ -5277,9 +5277,9 @@
     {
       "time": 28740,
       "values": {
-        "t_tank_top": 26.6487,
-        "t_tank_bottom": 25.8581,
-        "t_collector": 28.1219,
+        "t_tank_top": 26.5584,
+        "t_tank_bottom": 25.7664,
+        "t_collector": 28.0335,
         "t_greenhouse": 17.4846,
         "t_outdoor": 14.8353
       },
@@ -5288,9 +5288,9 @@
     {
       "time": 28800,
       "values": {
-        "t_tank_top": 26.6723,
-        "t_tank_bottom": 25.8849,
-        "t_collector": 28.1398,
+        "t_tank_top": 26.5822,
+        "t_tank_bottom": 25.7933,
+        "t_collector": 28.0514,
         "t_greenhouse": 17.4774,
         "t_outdoor": 14.8297
       },
@@ -5299,9 +5299,9 @@
     {
       "time": 28860,
       "values": {
-        "t_tank_top": 26.6958,
-        "t_tank_bottom": 25.9116,
-        "t_collector": 28.1575,
+        "t_tank_top": 26.6058,
+        "t_tank_bottom": 25.82,
+        "t_collector": 28.0692,
         "t_greenhouse": 17.4701,
         "t_outdoor": 14.824
       },
@@ -5310,9 +5310,9 @@
     {
       "time": 28920,
       "values": {
-        "t_tank_top": 26.7192,
-        "t_tank_bottom": 25.9381,
-        "t_collector": 28.1751,
+        "t_tank_top": 26.6292,
+        "t_tank_bottom": 25.8466,
+        "t_collector": 28.0869,
         "t_greenhouse": 17.4626,
         "t_outdoor": 14.8182
       },
@@ -5321,9 +5321,9 @@
     {
       "time": 28980,
       "values": {
-        "t_tank_top": 26.7425,
-        "t_tank_bottom": 25.9646,
-        "t_collector": 28.1925,
+        "t_tank_top": 26.6525,
+        "t_tank_bottom": 25.8731,
+        "t_collector": 28.1044,
         "t_greenhouse": 17.455,
         "t_outdoor": 14.8124
       },
@@ -5332,9 +5332,9 @@
     {
       "time": 29040,
       "values": {
-        "t_tank_top": 26.7656,
-        "t_tank_bottom": 25.9909,
-        "t_collector": 28.2098,
+        "t_tank_top": 26.6757,
+        "t_tank_bottom": 25.8995,
+        "t_collector": 28.1217,
         "t_greenhouse": 17.4473,
         "t_outdoor": 14.8064
       },
@@ -5343,9 +5343,9 @@
     {
       "time": 29100,
       "values": {
-        "t_tank_top": 26.7886,
-        "t_tank_bottom": 26.0171,
-        "t_collector": 28.2269,
+        "t_tank_top": 26.6988,
+        "t_tank_bottom": 25.9258,
+        "t_collector": 28.1389,
         "t_greenhouse": 17.4395,
         "t_outdoor": 14.8004
       },
@@ -5354,9 +5354,9 @@
     {
       "time": 29160,
       "values": {
-        "t_tank_top": 26.8115,
-        "t_tank_bottom": 26.0432,
-        "t_collector": 28.2439,
+        "t_tank_top": 26.7217,
+        "t_tank_bottom": 25.952,
+        "t_collector": 28.1559,
         "t_greenhouse": 17.4315,
         "t_outdoor": 14.7942
       },
@@ -5365,9 +5365,9 @@
     {
       "time": 29220,
       "values": {
-        "t_tank_top": 26.8342,
-        "t_tank_bottom": 26.0691,
-        "t_collector": 28.2607,
+        "t_tank_top": 26.7445,
+        "t_tank_bottom": 25.978,
+        "t_collector": 28.1728,
         "t_greenhouse": 17.4234,
         "t_outdoor": 14.788
       },
@@ -5376,9 +5376,9 @@
     {
       "time": 29280,
       "values": {
-        "t_tank_top": 26.8568,
-        "t_tank_bottom": 26.095,
-        "t_collector": 28.2773,
+        "t_tank_top": 26.7672,
+        "t_tank_bottom": 26.0039,
+        "t_collector": 28.1895,
         "t_greenhouse": 17.4152,
         "t_outdoor": 14.7816
       },
@@ -5387,9 +5387,9 @@
     {
       "time": 29340,
       "values": {
-        "t_tank_top": 26.8793,
-        "t_tank_bottom": 26.1207,
-        "t_collector": 28.2938,
+        "t_tank_top": 26.7897,
+        "t_tank_bottom": 26.0297,
+        "t_collector": 28.206,
         "t_greenhouse": 17.4069,
         "t_outdoor": 14.7752
       },
@@ -5398,9 +5398,9 @@
     {
       "time": 29400,
       "values": {
-        "t_tank_top": 26.9016,
-        "t_tank_bottom": 26.1463,
-        "t_collector": 28.3102,
+        "t_tank_top": 26.8121,
+        "t_tank_bottom": 26.0553,
+        "t_collector": 28.2224,
         "t_greenhouse": 17.3984,
         "t_outdoor": 14.7687
       },
@@ -5409,9 +5409,9 @@
     {
       "time": 29460,
       "values": {
-        "t_tank_top": 26.9238,
-        "t_tank_bottom": 26.1718,
-        "t_collector": 28.3264,
+        "t_tank_top": 26.8344,
+        "t_tank_bottom": 26.0809,
+        "t_collector": 28.2387,
         "t_greenhouse": 17.3898,
         "t_outdoor": 14.7621
       },
@@ -5420,9 +5420,9 @@
     {
       "time": 29520,
       "values": {
-        "t_tank_top": 26.9459,
-        "t_tank_bottom": 26.1971,
-        "t_collector": 28.3424,
+        "t_tank_top": 26.8565,
+        "t_tank_bottom": 26.1063,
+        "t_collector": 28.2548,
         "t_greenhouse": 17.3811,
         "t_outdoor": 14.7554
       },
@@ -5431,9 +5431,9 @@
     {
       "time": 29580,
       "values": {
-        "t_tank_top": 26.9678,
-        "t_tank_bottom": 26.2224,
-        "t_collector": 28.3582,
+        "t_tank_top": 26.8785,
+        "t_tank_bottom": 26.1316,
+        "t_collector": 28.2707,
         "t_greenhouse": 17.3722,
         "t_outdoor": 14.7486
       },
@@ -5442,9 +5442,9 @@
     {
       "time": 29640,
       "values": {
-        "t_tank_top": 26.9896,
-        "t_tank_bottom": 26.2475,
-        "t_collector": 28.374,
+        "t_tank_top": 26.9003,
+        "t_tank_bottom": 26.1568,
+        "t_collector": 28.2865,
         "t_greenhouse": 17.3632,
         "t_outdoor": 14.7417
       },
@@ -5453,9 +5453,9 @@
     {
       "time": 29700,
       "values": {
-        "t_tank_top": 27.0112,
-        "t_tank_bottom": 26.2725,
-        "t_collector": 28.3895,
+        "t_tank_top": 26.922,
+        "t_tank_bottom": 26.1818,
+        "t_collector": 28.3021,
         "t_greenhouse": 17.3541,
         "t_outdoor": 14.7348
       },
@@ -5464,9 +5464,9 @@
     {
       "time": 29760,
       "values": {
-        "t_tank_top": 27.0327,
-        "t_tank_bottom": 26.2973,
-        "t_collector": 28.4049,
+        "t_tank_top": 26.9436,
+        "t_tank_bottom": 26.2067,
+        "t_collector": 28.3175,
         "t_greenhouse": 17.3449,
         "t_outdoor": 14.7277
       },
@@ -5475,9 +5475,9 @@
     {
       "time": 29820,
       "values": {
-        "t_tank_top": 27.0541,
-        "t_tank_bottom": 26.322,
-        "t_collector": 28.4201,
+        "t_tank_top": 26.9651,
+        "t_tank_bottom": 26.2315,
+        "t_collector": 28.3328,
         "t_greenhouse": 17.3355,
         "t_outdoor": 14.7206
       },
@@ -5486,9 +5486,9 @@
     {
       "time": 29880,
       "values": {
-        "t_tank_top": 27.0753,
-        "t_tank_bottom": 26.3466,
-        "t_collector": 28.4352,
+        "t_tank_top": 26.9864,
+        "t_tank_bottom": 26.2562,
+        "t_collector": 28.348,
         "t_greenhouse": 17.326,
         "t_outdoor": 14.7133
       },
@@ -5497,9 +5497,9 @@
     {
       "time": 29940,
       "values": {
-        "t_tank_top": 27.0964,
-        "t_tank_bottom": 26.3711,
-        "t_collector": 28.4501,
+        "t_tank_top": 27.0075,
+        "t_tank_bottom": 26.2808,
+        "t_collector": 28.3629,
         "t_greenhouse": 17.3164,
         "t_outdoor": 14.706
       },
@@ -5508,9 +5508,9 @@
     {
       "time": 30000,
       "values": {
-        "t_tank_top": 27.1174,
-        "t_tank_bottom": 26.3955,
-        "t_collector": 28.4649,
+        "t_tank_top": 27.0285,
+        "t_tank_bottom": 26.3052,
+        "t_collector": 28.3777,
         "t_greenhouse": 17.3066,
         "t_outdoor": 14.6986
       },
@@ -5519,9 +5519,9 @@
     {
       "time": 30060,
       "values": {
-        "t_tank_top": 27.1382,
-        "t_tank_bottom": 26.4197,
-        "t_collector": 28.4794,
+        "t_tank_top": 27.0494,
+        "t_tank_bottom": 26.3295,
+        "t_collector": 28.3924,
         "t_greenhouse": 17.2967,
         "t_outdoor": 14.6911
       },
@@ -5530,9 +5530,9 @@
     {
       "time": 30120,
       "values": {
-        "t_tank_top": 27.1589,
-        "t_tank_bottom": 26.4438,
-        "t_collector": 28.4939,
+        "t_tank_top": 27.0702,
+        "t_tank_bottom": 26.3536,
+        "t_collector": 28.4069,
         "t_greenhouse": 17.2867,
         "t_outdoor": 14.6835
       },
@@ -5541,9 +5541,9 @@
     {
       "time": 30180,
       "values": {
-        "t_tank_top": 27.1794,
-        "t_tank_bottom": 26.4678,
-        "t_collector": 28.5081,
+        "t_tank_top": 27.0908,
+        "t_tank_bottom": 26.3777,
+        "t_collector": 28.4212,
         "t_greenhouse": 17.2766,
         "t_outdoor": 14.6758
       },
@@ -5552,9 +5552,9 @@
     {
       "time": 30240,
       "values": {
-        "t_tank_top": 27.1998,
-        "t_tank_bottom": 26.4916,
-        "t_collector": 28.5222,
+        "t_tank_top": 27.1112,
+        "t_tank_bottom": 26.4016,
+        "t_collector": 28.4354,
         "t_greenhouse": 17.2663,
         "t_outdoor": 14.668
       },
@@ -5563,9 +5563,9 @@
     {
       "time": 30300,
       "values": {
-        "t_tank_top": 27.2201,
-        "t_tank_bottom": 26.5153,
-        "t_collector": 28.5362,
+        "t_tank_top": 27.1316,
+        "t_tank_bottom": 26.4254,
+        "t_collector": 28.4494,
         "t_greenhouse": 17.256,
         "t_outdoor": 14.6602
       },
@@ -5574,9 +5574,9 @@
     {
       "time": 30360,
       "values": {
-        "t_tank_top": 27.2402,
-        "t_tank_bottom": 26.5389,
-        "t_collector": 28.55,
+        "t_tank_top": 27.1518,
+        "t_tank_bottom": 26.449,
+        "t_collector": 28.4632,
         "t_greenhouse": 17.2454,
         "t_outdoor": 14.6522
       },
@@ -5585,9 +5585,9 @@
     {
       "time": 30420,
       "values": {
-        "t_tank_top": 27.2602,
-        "t_tank_bottom": 26.5624,
-        "t_collector": 28.5636,
+        "t_tank_top": 27.1718,
+        "t_tank_bottom": 26.4725,
+        "t_collector": 28.4769,
         "t_greenhouse": 17.2348,
         "t_outdoor": 14.6442
       },
@@ -5596,9 +5596,9 @@
     {
       "time": 30480,
       "values": {
-        "t_tank_top": 27.28,
-        "t_tank_bottom": 26.5857,
-        "t_collector": 28.5771,
+        "t_tank_top": 27.1917,
+        "t_tank_bottom": 26.4959,
+        "t_collector": 28.4905,
         "t_greenhouse": 17.2241,
         "t_outdoor": 14.6361
       },
@@ -5607,9 +5607,9 @@
     {
       "time": 30540,
       "values": {
-        "t_tank_top": 27.2997,
-        "t_tank_bottom": 26.6089,
-        "t_collector": 28.5904,
+        "t_tank_top": 27.2115,
+        "t_tank_bottom": 26.5192,
+        "t_collector": 28.5038,
         "t_greenhouse": 17.2132,
         "t_outdoor": 14.6278
       },
@@ -5618,9 +5618,9 @@
     {
       "time": 30600,
       "values": {
-        "t_tank_top": 27.3193,
-        "t_tank_bottom": 26.632,
-        "t_collector": 28.6035,
+        "t_tank_top": 27.2311,
+        "t_tank_bottom": 26.5423,
+        "t_collector": 28.517,
         "t_greenhouse": 17.2022,
         "t_outdoor": 14.6195
       },
@@ -5629,9 +5629,9 @@
     {
       "time": 30660,
       "values": {
-        "t_tank_top": 27.3387,
-        "t_tank_bottom": 26.6549,
-        "t_collector": 28.6165,
+        "t_tank_top": 27.2505,
+        "t_tank_bottom": 26.5653,
+        "t_collector": 28.53,
         "t_greenhouse": 17.191,
         "t_outdoor": 14.6111
       },
@@ -5640,9 +5640,9 @@
     {
       "time": 30720,
       "values": {
-        "t_tank_top": 27.358,
-        "t_tank_bottom": 26.6777,
-        "t_collector": 28.6293,
+        "t_tank_top": 27.2699,
+        "t_tank_bottom": 26.5882,
+        "t_collector": 28.5429,
         "t_greenhouse": 17.1798,
         "t_outdoor": 14.6027
       },
@@ -5651,9 +5651,9 @@
     {
       "time": 30780,
       "values": {
-        "t_tank_top": 27.3771,
-        "t_tank_bottom": 26.7004,
-        "t_collector": 28.6419,
+        "t_tank_top": 27.2891,
+        "t_tank_bottom": 26.6109,
+        "t_collector": 28.5556,
         "t_greenhouse": 17.1684,
         "t_outdoor": 14.5941
       },
@@ -5662,9 +5662,9 @@
     {
       "time": 30840,
       "values": {
-        "t_tank_top": 27.3961,
-        "t_tank_bottom": 26.7229,
-        "t_collector": 28.6544,
+        "t_tank_top": 27.3081,
+        "t_tank_bottom": 26.6335,
+        "t_collector": 28.5682,
         "t_greenhouse": 17.1569,
         "t_outdoor": 14.5854
       },
@@ -5673,9 +5673,9 @@
     {
       "time": 30900,
       "values": {
-        "t_tank_top": 27.4149,
-        "t_tank_bottom": 26.7453,
-        "t_collector": 28.6667,
+        "t_tank_top": 27.327,
+        "t_tank_bottom": 26.656,
+        "t_collector": 28.5805,
         "t_greenhouse": 17.1452,
         "t_outdoor": 14.5767
       },
@@ -5684,9 +5684,9 @@
     {
       "time": 30960,
       "values": {
-        "t_tank_top": 27.4336,
-        "t_tank_bottom": 26.7676,
-        "t_collector": 28.6789,
+        "t_tank_top": 27.3458,
+        "t_tank_bottom": 26.6783,
+        "t_collector": 28.5928,
         "t_greenhouse": 17.1335,
         "t_outdoor": 14.5679
       },
@@ -5695,9 +5695,9 @@
     {
       "time": 31020,
       "values": {
-        "t_tank_top": 27.4522,
-        "t_tank_bottom": 26.7897,
-        "t_collector": 28.6909,
+        "t_tank_top": 27.3644,
+        "t_tank_bottom": 26.7005,
+        "t_collector": 28.6048,
         "t_greenhouse": 17.1216,
         "t_outdoor": 14.559
       },
@@ -5706,9 +5706,9 @@
     {
       "time": 31080,
       "values": {
-        "t_tank_top": 27.4706,
-        "t_tank_bottom": 26.8118,
-        "t_collector": 28.7027,
+        "t_tank_top": 27.3828,
+        "t_tank_bottom": 26.7226,
+        "t_collector": 28.6167,
         "t_greenhouse": 17.1096,
         "t_outdoor": 14.55
       },
@@ -5717,9 +5717,9 @@
     {
       "time": 31140,
       "values": {
-        "t_tank_top": 27.4888,
-        "t_tank_bottom": 26.8336,
-        "t_collector": 28.7143,
+        "t_tank_top": 27.4012,
+        "t_tank_bottom": 26.7445,
+        "t_collector": 28.6284,
         "t_greenhouse": 17.0975,
         "t_outdoor": 14.5409
       },
@@ -5728,9 +5728,9 @@
     {
       "time": 31200,
       "values": {
-        "t_tank_top": 27.5069,
-        "t_tank_bottom": 26.8554,
-        "t_collector": 28.7258,
+        "t_tank_top": 27.4193,
+        "t_tank_bottom": 26.7663,
+        "t_collector": 28.64,
         "t_greenhouse": 17.0852,
         "t_outdoor": 14.5317
       },
@@ -5739,9 +5739,9 @@
     {
       "time": 31260,
       "values": {
-        "t_tank_top": 27.5249,
-        "t_tank_bottom": 26.877,
-        "t_collector": 28.7372,
+        "t_tank_top": 27.4374,
+        "t_tank_bottom": 26.788,
+        "t_collector": 28.6514,
         "t_greenhouse": 17.0728,
         "t_outdoor": 14.5224
       },
@@ -5750,9 +5750,9 @@
     {
       "time": 31320,
       "values": {
-        "t_tank_top": 27.5427,
-        "t_tank_bottom": 26.8984,
-        "t_collector": 28.7483,
+        "t_tank_top": 27.4552,
+        "t_tank_bottom": 26.8095,
+        "t_collector": 28.6626,
         "t_greenhouse": 17.0603,
         "t_outdoor": 14.5131
       },
@@ -5761,9 +5761,9 @@
     {
       "time": 31380,
       "values": {
-        "t_tank_top": 27.5604,
-        "t_tank_bottom": 26.9198,
-        "t_collector": 28.7593,
+        "t_tank_top": 27.473,
+        "t_tank_bottom": 26.8309,
+        "t_collector": 28.6736,
         "t_greenhouse": 17.0477,
         "t_outdoor": 14.5036
       },
@@ -5772,9 +5772,9 @@
     {
       "time": 31440,
       "values": {
-        "t_tank_top": 27.5779,
-        "t_tank_bottom": 26.941,
-        "t_collector": 28.7701,
+        "t_tank_top": 27.4906,
+        "t_tank_bottom": 26.8522,
+        "t_collector": 28.6845,
         "t_greenhouse": 17.035,
         "t_outdoor": 14.4941
       },
@@ -5783,9 +5783,9 @@
     {
       "time": 31500,
       "values": {
-        "t_tank_top": 27.5953,
-        "t_tank_bottom": 26.962,
-        "t_collector": 28.7808,
+        "t_tank_top": 27.508,
+        "t_tank_bottom": 26.8733,
+        "t_collector": 28.6953,
         "t_greenhouse": 17.0221,
         "t_outdoor": 14.4845
       },
@@ -5794,9 +5794,9 @@
     {
       "time": 31560,
       "values": {
-        "t_tank_top": 27.6125,
-        "t_tank_bottom": 26.9829,
-        "t_collector": 28.7913,
+        "t_tank_top": 27.5253,
+        "t_tank_bottom": 26.8943,
+        "t_collector": 28.7058,
         "t_greenhouse": 17.0091,
         "t_outdoor": 14.4748
       },
@@ -5805,9 +5805,9 @@
     {
       "time": 31620,
       "values": {
-        "t_tank_top": 27.6296,
-        "t_tank_bottom": 27.0037,
-        "t_collector": 28.8016,
+        "t_tank_top": 27.5424,
+        "t_tank_bottom": 26.9152,
+        "t_collector": 28.7162,
         "t_greenhouse": 16.996,
         "t_outdoor": 14.4651
       },
@@ -5816,9 +5816,9 @@
     {
       "time": 31680,
       "values": {
-        "t_tank_top": 27.6465,
-        "t_tank_bottom": 27.0244,
-        "t_collector": 28.8118,
+        "t_tank_top": 27.5594,
+        "t_tank_bottom": 26.9359,
+        "t_collector": 28.7264,
         "t_greenhouse": 16.9828,
         "t_outdoor": 14.4552
       },
@@ -5827,9 +5827,9 @@
     {
       "time": 31740,
       "values": {
-        "t_tank_top": 27.6633,
-        "t_tank_bottom": 27.0449,
-        "t_collector": 28.8218,
+        "t_tank_top": 27.5763,
+        "t_tank_bottom": 26.9564,
+        "t_collector": 28.7365,
         "t_greenhouse": 16.9694,
         "t_outdoor": 14.4453
       },
@@ -5838,9 +5838,9 @@
     {
       "time": 31800,
       "values": {
-        "t_tank_top": 27.6799,
-        "t_tank_bottom": 27.0652,
-        "t_collector": 28.8316,
+        "t_tank_top": 27.593,
+        "t_tank_bottom": 26.9769,
+        "t_collector": 28.7464,
         "t_greenhouse": 16.9559,
         "t_outdoor": 14.4352
       },
@@ -5849,9 +5849,9 @@
     {
       "time": 31860,
       "values": {
-        "t_tank_top": 27.6964,
-        "t_tank_bottom": 27.0855,
-        "t_collector": 28.8413,
+        "t_tank_top": 27.6095,
+        "t_tank_bottom": 26.9972,
+        "t_collector": 28.7561,
         "t_greenhouse": 16.9423,
         "t_outdoor": 14.4251
       },
@@ -5860,9 +5860,9 @@
     {
       "time": 31920,
       "values": {
-        "t_tank_top": 27.7127,
-        "t_tank_bottom": 27.1056,
-        "t_collector": 28.8508,
+        "t_tank_top": 27.6259,
+        "t_tank_bottom": 27.0173,
+        "t_collector": 28.7656,
         "t_greenhouse": 16.9286,
         "t_outdoor": 14.4149
       },
@@ -5871,9 +5871,9 @@
     {
       "time": 31980,
       "values": {
-        "t_tank_top": 27.7289,
-        "t_tank_bottom": 27.1255,
-        "t_collector": 28.8601,
+        "t_tank_top": 27.6422,
+        "t_tank_bottom": 27.0373,
+        "t_collector": 28.775,
         "t_greenhouse": 16.9148,
         "t_outdoor": 14.4046
       },
@@ -5882,9 +5882,9 @@
     {
       "time": 32040,
       "values": {
-        "t_tank_top": 27.745,
-        "t_tank_bottom": 27.1453,
-        "t_collector": 28.8692,
+        "t_tank_top": 27.6582,
+        "t_tank_bottom": 27.0572,
+        "t_collector": 28.7842,
         "t_greenhouse": 16.9008,
         "t_outdoor": 14.3943
       },
@@ -5893,9 +5893,9 @@
     {
       "time": 32100,
       "values": {
-        "t_tank_top": 27.7608,
-        "t_tank_bottom": 27.165,
-        "t_collector": 28.8782,
+        "t_tank_top": 27.6742,
+        "t_tank_bottom": 27.0769,
+        "t_collector": 28.7933,
         "t_greenhouse": 16.8867,
         "t_outdoor": 14.3838
       },
@@ -5904,9 +5904,9 @@
     {
       "time": 32160,
       "values": {
-        "t_tank_top": 27.7766,
-        "t_tank_bottom": 27.1845,
-        "t_collector": 28.887,
+        "t_tank_top": 27.69,
+        "t_tank_bottom": 27.0965,
+        "t_collector": 28.8022,
         "t_greenhouse": 16.8725,
         "t_outdoor": 14.3733
       },
@@ -5915,9 +5915,9 @@
     {
       "time": 32220,
       "values": {
-        "t_tank_top": 27.7922,
-        "t_tank_bottom": 27.2039,
-        "t_collector": 28.8957,
+        "t_tank_top": 27.7056,
+        "t_tank_bottom": 27.116,
+        "t_collector": 28.8109,
         "t_greenhouse": 16.8582,
         "t_outdoor": 14.3627
       },
@@ -5926,9 +5926,9 @@
     {
       "time": 32280,
       "values": {
-        "t_tank_top": 27.8076,
-        "t_tank_bottom": 27.2232,
-        "t_collector": 28.9042,
+        "t_tank_top": 27.7211,
+        "t_tank_bottom": 27.1353,
+        "t_collector": 28.8194,
         "t_greenhouse": 16.8438,
         "t_outdoor": 14.352
       },
@@ -5937,9 +5937,9 @@
     {
       "time": 32340,
       "values": {
-        "t_tank_top": 27.8229,
-        "t_tank_bottom": 27.2423,
-        "t_collector": 28.9125,
+        "t_tank_top": 27.7365,
+        "t_tank_bottom": 27.1545,
+        "t_collector": 28.8278,
         "t_greenhouse": 16.8292,
         "t_outdoor": 14.3412
       },
@@ -5948,9 +5948,9 @@
     {
       "time": 32400,
       "values": {
-        "t_tank_top": 27.838,
-        "t_tank_bottom": 27.2612,
-        "t_collector": 28.9206,
+        "t_tank_top": 27.7516,
+        "t_tank_bottom": 27.1735,
+        "t_collector": 28.836,
         "t_greenhouse": 16.8146,
         "t_outdoor": 14.3303
       },
@@ -5959,9 +5959,9 @@
     {
       "time": 32460,
       "values": {
-        "t_tank_top": 27.853,
-        "t_tank_bottom": 27.2801,
-        "t_collector": 28.9286,
+        "t_tank_top": 27.7667,
+        "t_tank_bottom": 27.1924,
+        "t_collector": 28.844,
         "t_greenhouse": 16.7998,
         "t_outdoor": 14.3194
       },
@@ -5970,9 +5970,9 @@
     {
       "time": 32520,
       "values": {
-        "t_tank_top": 27.8678,
-        "t_tank_bottom": 27.2987,
-        "t_collector": 28.9364,
+        "t_tank_top": 27.7816,
+        "t_tank_bottom": 27.2111,
+        "t_collector": 28.8518,
         "t_greenhouse": 16.7849,
         "t_outdoor": 14.3083
       },
@@ -5981,9 +5981,9 @@
     {
       "time": 32580,
       "values": {
-        "t_tank_top": 27.8824,
-        "t_tank_bottom": 27.3173,
-        "t_collector": 28.944,
+        "t_tank_top": 27.7963,
+        "t_tank_bottom": 27.2297,
+        "t_collector": 28.8595,
         "t_greenhouse": 16.7698,
         "t_outdoor": 14.2972
       },
@@ -5992,9 +5992,9 @@
     {
       "time": 32640,
       "values": {
-        "t_tank_top": 27.897,
-        "t_tank_bottom": 27.3357,
-        "t_collector": 28.9514,
+        "t_tank_top": 27.8109,
+        "t_tank_bottom": 27.2482,
+        "t_collector": 28.867,
         "t_greenhouse": 16.7547,
         "t_outdoor": 14.286
       },
@@ -6003,9 +6003,9 @@
     {
       "time": 32700,
       "values": {
-        "t_tank_top": 27.9113,
-        "t_tank_bottom": 27.3539,
-        "t_collector": 28.9587,
+        "t_tank_top": 27.8253,
+        "t_tank_bottom": 27.2665,
+        "t_collector": 28.8744,
         "t_greenhouse": 16.7394,
         "t_outdoor": 14.2747
       },
@@ -6014,9 +6014,9 @@
     {
       "time": 32760,
       "values": {
-        "t_tank_top": 27.9255,
-        "t_tank_bottom": 27.372,
-        "t_collector": 28.9658,
+        "t_tank_top": 27.8396,
+        "t_tank_bottom": 27.2846,
+        "t_collector": 28.8816,
         "t_greenhouse": 16.724,
         "t_outdoor": 14.2634
       },
@@ -6025,9 +6025,9 @@
     {
       "time": 32820,
       "values": {
-        "t_tank_top": 27.9396,
-        "t_tank_bottom": 27.39,
-        "t_collector": 28.9728,
+        "t_tank_top": 27.8537,
+        "t_tank_bottom": 27.3027,
+        "t_collector": 28.8886,
         "t_greenhouse": 16.7085,
         "t_outdoor": 14.252
       },
@@ -6036,9 +6036,9 @@
     {
       "time": 32880,
       "values": {
-        "t_tank_top": 27.9535,
-        "t_tank_bottom": 27.4078,
-        "t_collector": 28.9796,
+        "t_tank_top": 27.8676,
+        "t_tank_bottom": 27.3205,
+        "t_collector": 28.8954,
         "t_greenhouse": 16.6929,
         "t_outdoor": 14.2404
       },
@@ -6047,9 +6047,9 @@
     {
       "time": 32940,
       "values": {
-        "t_tank_top": 27.9672,
-        "t_tank_bottom": 27.4254,
-        "t_collector": 28.9862,
+        "t_tank_top": 27.8814,
+        "t_tank_bottom": 27.3383,
+        "t_collector": 28.9021,
         "t_greenhouse": 16.6772,
         "t_outdoor": 14.2288
       },
@@ -6058,9 +6058,9 @@
     {
       "time": 33000,
       "values": {
-        "t_tank_top": 27.9808,
-        "t_tank_bottom": 27.443,
-        "t_collector": 28.9926,
+        "t_tank_top": 27.8951,
+        "t_tank_bottom": 27.3559,
+        "t_collector": 28.9085,
         "t_greenhouse": 16.6613,
         "t_outdoor": 14.2172
       },
@@ -6069,9 +6069,9 @@
     {
       "time": 33060,
       "values": {
-        "t_tank_top": 27.9942,
-        "t_tank_bottom": 27.4603,
-        "t_collector": 28.9988,
+        "t_tank_top": 27.9086,
+        "t_tank_bottom": 27.3733,
+        "t_collector": 28.9149,
         "t_greenhouse": 16.6454,
         "t_outdoor": 14.2054
       },
@@ -6080,9 +6080,9 @@
     {
       "time": 33120,
       "values": {
-        "t_tank_top": 28.0075,
-        "t_tank_bottom": 27.4776,
-        "t_collector": 29.0049,
+        "t_tank_top": 27.9219,
+        "t_tank_bottom": 27.3906,
+        "t_collector": 28.921,
         "t_greenhouse": 16.6293,
         "t_outdoor": 14.1936
       },
@@ -6091,9 +6091,9 @@
     {
       "time": 33180,
       "values": {
-        "t_tank_top": 28.0206,
-        "t_tank_bottom": 27.4947,
-        "t_collector": 29.0108,
+        "t_tank_top": 27.9351,
+        "t_tank_bottom": 27.4077,
+        "t_collector": 28.927,
         "t_greenhouse": 16.6131,
         "t_outdoor": 14.1816
       },
@@ -6102,9 +6102,9 @@
     {
       "time": 33240,
       "values": {
-        "t_tank_top": 28.0336,
-        "t_tank_bottom": 27.5116,
-        "t_collector": 29.0166,
+        "t_tank_top": 27.9481,
+        "t_tank_bottom": 27.4247,
+        "t_collector": 28.9328,
         "t_greenhouse": 16.5968,
         "t_outdoor": 14.1696
       },
@@ -6113,9 +6113,9 @@
     {
       "time": 33300,
       "values": {
-        "t_tank_top": 28.0464,
-        "t_tank_bottom": 27.5284,
-        "t_collector": 29.0221,
+        "t_tank_top": 27.961,
+        "t_tank_bottom": 27.4416,
+        "t_collector": 28.9384,
         "t_greenhouse": 16.5803,
         "t_outdoor": 14.1576
       },
@@ -6124,9 +6124,9 @@
     {
       "time": 33360,
       "values": {
-        "t_tank_top": 28.059,
-        "t_tank_bottom": 27.545,
-        "t_collector": 29.0275,
+        "t_tank_top": 27.9737,
+        "t_tank_bottom": 27.4583,
+        "t_collector": 28.9439,
         "t_greenhouse": 16.5638,
         "t_outdoor": 14.1454
       },
@@ -6135,9 +6135,9 @@
     {
       "time": 33420,
       "values": {
-        "t_tank_top": 28.0715,
-        "t_tank_bottom": 27.5615,
-        "t_collector": 29.0328,
+        "t_tank_top": 27.9862,
+        "t_tank_bottom": 27.4748,
+        "t_collector": 28.9491,
         "t_greenhouse": 16.5471,
         "t_outdoor": 14.1332
       },
@@ -6146,9 +6146,9 @@
     {
       "time": 33480,
       "values": {
-        "t_tank_top": 28.0839,
-        "t_tank_bottom": 27.5779,
-        "t_collector": 29.0378,
+        "t_tank_top": 27.9986,
+        "t_tank_bottom": 27.4913,
+        "t_collector": 28.9543,
         "t_greenhouse": 16.5304,
         "t_outdoor": 14.1208
       },
@@ -6157,9 +6157,9 @@
     {
       "time": 33540,
       "values": {
-        "t_tank_top": 28.096,
-        "t_tank_bottom": 27.5941,
-        "t_collector": 29.0427,
+        "t_tank_top": 28.0109,
+        "t_tank_bottom": 27.5075,
+        "t_collector": 28.9592,
         "t_greenhouse": 16.5135,
         "t_outdoor": 14.1084
       },
@@ -6168,9 +6168,9 @@
     {
       "time": 33600,
       "values": {
-        "t_tank_top": 28.1081,
-        "t_tank_bottom": 27.6101,
-        "t_collector": 29.0474,
+        "t_tank_top": 28.023,
+        "t_tank_bottom": 27.5236,
+        "t_collector": 28.964,
         "t_greenhouse": 16.4965,
         "t_outdoor": 14.096
       },
@@ -6179,9 +6179,9 @@
     {
       "time": 33660,
       "values": {
-        "t_tank_top": 28.1199,
-        "t_tank_bottom": 27.626,
-        "t_collector": 29.0519,
+        "t_tank_top": 28.0349,
+        "t_tank_bottom": 27.5396,
+        "t_collector": 28.9685,
         "t_greenhouse": 16.4794,
         "t_outdoor": 14.0834
       },
@@ -6190,9 +6190,9 @@
     {
       "time": 33720,
       "values": {
-        "t_tank_top": 28.1316,
-        "t_tank_bottom": 27.6418,
-        "t_collector": 29.0563,
+        "t_tank_top": 28.0466,
+        "t_tank_bottom": 27.5554,
+        "t_collector": 28.973,
         "t_greenhouse": 16.4621,
         "t_outdoor": 14.0708
       },
@@ -6201,9 +6201,9 @@
     {
       "time": 33780,
       "values": {
-        "t_tank_top": 28.1432,
-        "t_tank_bottom": 27.6574,
-        "t_collector": 29.0604,
+        "t_tank_top": 28.0583,
+        "t_tank_bottom": 27.5711,
+        "t_collector": 28.9772,
         "t_greenhouse": 16.4448,
         "t_outdoor": 14.0581
       },
@@ -6212,9 +6212,9 @@
     {
       "time": 33840,
       "values": {
-        "t_tank_top": 28.1546,
-        "t_tank_bottom": 27.6728,
-        "t_collector": 29.0645,
+        "t_tank_top": 28.0697,
+        "t_tank_bottom": 27.5866,
+        "t_collector": 28.9813,
         "t_greenhouse": 16.4273,
         "t_outdoor": 14.0453
       },
@@ -6223,9 +6223,9 @@
     {
       "time": 33900,
       "values": {
-        "t_tank_top": 28.1658,
-        "t_tank_bottom": 27.6881,
-        "t_collector": 29.0683,
+        "t_tank_top": 28.081,
+        "t_tank_bottom": 27.6019,
+        "t_collector": 28.9852,
         "t_greenhouse": 16.4098,
         "t_outdoor": 14.0324
       },
@@ -6234,9 +6234,9 @@
     {
       "time": 33960,
       "values": {
-        "t_tank_top": 28.1769,
-        "t_tank_bottom": 27.7033,
-        "t_collector": 29.0719,
+        "t_tank_top": 28.0921,
+        "t_tank_bottom": 27.6171,
+        "t_collector": 28.9889,
         "t_greenhouse": 16.3921,
         "t_outdoor": 14.0195
       },
@@ -6245,9 +6245,9 @@
     {
       "time": 34020,
       "values": {
-        "t_tank_top": 28.1878,
-        "t_tank_bottom": 27.7183,
-        "t_collector": 29.0754,
+        "t_tank_top": 28.1031,
+        "t_tank_bottom": 27.6322,
+        "t_collector": 28.9924,
         "t_greenhouse": 16.3743,
         "t_outdoor": 14.0065
       },
@@ -6256,9 +6256,9 @@
     {
       "time": 34080,
       "values": {
-        "t_tank_top": 28.1985,
-        "t_tank_bottom": 27.7331,
-        "t_collector": 29.0787,
+        "t_tank_top": 28.1139,
+        "t_tank_bottom": 27.6471,
+        "t_collector": 28.9958,
         "t_greenhouse": 16.3564,
         "t_outdoor": 13.9934
       },
@@ -6267,9 +6267,9 @@
     {
       "time": 34140,
       "values": {
-        "t_tank_top": 28.2091,
-        "t_tank_bottom": 27.7478,
-        "t_collector": 29.0819,
+        "t_tank_top": 28.1245,
+        "t_tank_bottom": 27.6619,
+        "t_collector": 28.999,
         "t_greenhouse": 16.3384,
         "t_outdoor": 13.9802
       },
@@ -6278,9 +6278,9 @@
     {
       "time": 34200,
       "values": {
-        "t_tank_top": 28.2195,
-        "t_tank_bottom": 27.7623,
-        "t_collector": 29.0848,
+        "t_tank_top": 28.135,
+        "t_tank_bottom": 27.6765,
+        "t_collector": 29.002,
         "t_greenhouse": 16.3203,
         "t_outdoor": 13.967
       },
@@ -6289,9 +6289,9 @@
     {
       "time": 34260,
       "values": {
-        "t_tank_top": 28.2298,
-        "t_tank_bottom": 27.7767,
-        "t_collector": 29.0876,
+        "t_tank_top": 28.1454,
+        "t_tank_bottom": 27.6909,
+        "t_collector": 29.0049,
         "t_greenhouse": 16.302,
         "t_outdoor": 13.9537
       },
@@ -6300,9 +6300,9 @@
     {
       "time": 34320,
       "values": {
-        "t_tank_top": 28.2399,
-        "t_tank_bottom": 27.791,
-        "t_collector": 29.0902,
+        "t_tank_top": 28.1555,
+        "t_tank_bottom": 27.7052,
+        "t_collector": 29.0075,
         "t_greenhouse": 16.2837,
         "t_outdoor": 13.9403
       },
@@ -6311,9 +6311,9 @@
     {
       "time": 34380,
       "values": {
-        "t_tank_top": 28.2499,
-        "t_tank_bottom": 27.8051,
-        "t_collector": 29.0927,
+        "t_tank_top": 28.1655,
+        "t_tank_bottom": 27.7194,
+        "t_collector": 29.01,
         "t_greenhouse": 16.2653,
         "t_outdoor": 13.9268
       },
@@ -6322,9 +6322,9 @@
     {
       "time": 34440,
       "values": {
-        "t_tank_top": 28.2596,
-        "t_tank_bottom": 27.819,
-        "t_collector": 29.0949,
+        "t_tank_top": 28.1754,
+        "t_tank_bottom": 27.7334,
+        "t_collector": 29.0123,
         "t_greenhouse": 16.2467,
         "t_outdoor": 13.9133
       },
@@ -6333,9 +6333,9 @@
     {
       "time": 34500,
       "values": {
-        "t_tank_top": 28.2693,
-        "t_tank_bottom": 27.8328,
-        "t_collector": 29.097,
+        "t_tank_top": 28.1851,
+        "t_tank_bottom": 27.7472,
+        "t_collector": 29.0145,
         "t_greenhouse": 16.228,
         "t_outdoor": 13.8996
       },
@@ -6344,9 +6344,9 @@
     {
       "time": 34560,
       "values": {
-        "t_tank_top": 28.2787,
-        "t_tank_bottom": 27.8464,
-        "t_collector": 29.0989,
+        "t_tank_top": 28.1946,
+        "t_tank_bottom": 27.7609,
+        "t_collector": 29.0165,
         "t_greenhouse": 16.2092,
         "t_outdoor": 13.886
       },
@@ -6355,9 +6355,9 @@
     {
       "time": 34620,
       "values": {
-        "t_tank_top": 28.288,
-        "t_tank_bottom": 27.8599,
-        "t_collector": 29.1007,
+        "t_tank_top": 28.204,
+        "t_tank_bottom": 27.7744,
+        "t_collector": 29.0183,
         "t_greenhouse": 16.1904,
         "t_outdoor": 13.8722
       },
@@ -6366,9 +6366,9 @@
     {
       "time": 34680,
       "values": {
-        "t_tank_top": 28.2972,
-        "t_tank_bottom": 27.8732,
-        "t_collector": 29.1022,
+        "t_tank_top": 28.2132,
+        "t_tank_bottom": 27.7878,
+        "t_collector": 29.0199,
         "t_greenhouse": 16.1714,
         "t_outdoor": 13.8584
       },
@@ -6377,9 +6377,9 @@
     {
       "time": 34740,
       "values": {
-        "t_tank_top": 28.3061,
-        "t_tank_bottom": 27.8864,
-        "t_collector": 29.1036,
+        "t_tank_top": 28.2222,
+        "t_tank_bottom": 27.801,
+        "t_collector": 29.0213,
         "t_greenhouse": 16.1522,
         "t_outdoor": 13.8444
       },
@@ -6388,9 +6388,9 @@
     {
       "time": 34800,
       "values": {
-        "t_tank_top": 28.315,
-        "t_tank_bottom": 27.8994,
-        "t_collector": 29.1048,
+        "t_tank_top": 28.2311,
+        "t_tank_bottom": 27.8141,
+        "t_collector": 29.0226,
         "t_greenhouse": 16.133,
         "t_outdoor": 13.8305
       },
@@ -6399,9 +6399,9 @@
     {
       "time": 34860,
       "values": {
-        "t_tank_top": 28.3236,
-        "t_tank_bottom": 27.9122,
-        "t_collector": 29.1059,
+        "t_tank_top": 28.2398,
+        "t_tank_bottom": 27.827,
+        "t_collector": 29.0237,
         "t_greenhouse": 16.1137,
         "t_outdoor": 13.8164
       },
@@ -6410,9 +6410,9 @@
     {
       "time": 34920,
       "values": {
-        "t_tank_top": 28.3321,
-        "t_tank_bottom": 27.9249,
-        "t_collector": 29.1067,
+        "t_tank_top": 28.2483,
+        "t_tank_bottom": 27.8398,
+        "t_collector": 29.0246,
         "t_greenhouse": 16.0943,
         "t_outdoor": 13.8023
       },
@@ -6421,9 +6421,9 @@
     {
       "time": 34980,
       "values": {
-        "t_tank_top": 28.3404,
-        "t_tank_bottom": 27.9375,
-        "t_collector": 29.1074,
+        "t_tank_top": 28.2567,
+        "t_tank_bottom": 27.8524,
+        "t_collector": 29.0253,
         "t_greenhouse": 16.0748,
         "t_outdoor": 13.7881
       },
@@ -6432,9 +6432,9 @@
     {
       "time": 35040,
       "values": {
-        "t_tank_top": 28.3486,
-        "t_tank_bottom": 27.9498,
-        "t_collector": 29.1079,
+        "t_tank_top": 28.2649,
+        "t_tank_bottom": 27.8648,
+        "t_collector": 29.0259,
         "t_greenhouse": 16.0551,
         "t_outdoor": 13.7738
       },
@@ -6443,9 +6443,9 @@
     {
       "time": 35100,
       "values": {
-        "t_tank_top": 28.3566,
-        "t_tank_bottom": 27.9621,
-        "t_collector": 29.1082,
+        "t_tank_top": 28.273,
+        "t_tank_bottom": 27.8771,
+        "t_collector": 29.0263,
         "t_greenhouse": 16.0354,
         "t_outdoor": 13.7594
       },
@@ -6454,9 +6454,9 @@
     {
       "time": 35160,
       "values": {
-        "t_tank_top": 28.3644,
-        "t_tank_bottom": 27.9742,
-        "t_collector": 29.1084,
+        "t_tank_top": 28.2809,
+        "t_tank_bottom": 27.8893,
+        "t_collector": 29.0265,
         "t_greenhouse": 16.0155,
         "t_outdoor": 13.745
       },
@@ -6465,9 +6465,9 @@
     {
       "time": 35220,
       "values": {
-        "t_tank_top": 28.3721,
-        "t_tank_bottom": 27.9861,
-        "t_collector": 29.1084,
+        "t_tank_top": 28.2886,
+        "t_tank_bottom": 27.9012,
+        "t_collector": 29.0265,
         "t_greenhouse": 15.9956,
         "t_outdoor": 13.7305
       },
@@ -6476,9 +6476,9 @@
     {
       "time": 35280,
       "values": {
-        "t_tank_top": 28.3796,
-        "t_tank_bottom": 27.9978,
-        "t_collector": 29.1082,
+        "t_tank_top": 28.2962,
+        "t_tank_bottom": 27.9131,
+        "t_collector": 29.0264,
         "t_greenhouse": 15.9755,
         "t_outdoor": 13.716
       },
@@ -6487,9 +6487,9 @@
     {
       "time": 35340,
       "values": {
-        "t_tank_top": 28.387,
-        "t_tank_bottom": 28.0094,
-        "t_collector": 29.1078,
+        "t_tank_top": 28.3036,
+        "t_tank_bottom": 27.9247,
+        "t_collector": 29.0261,
         "t_greenhouse": 15.9553,
         "t_outdoor": 13.7013
       },
@@ -6498,9 +6498,9 @@
     {
       "time": 35400,
       "values": {
-        "t_tank_top": 28.3941,
-        "t_tank_bottom": 28.0209,
-        "t_collector": 29.1072,
+        "t_tank_top": 28.3109,
+        "t_tank_bottom": 27.9363,
+        "t_collector": 29.0256,
         "t_greenhouse": 15.9351,
         "t_outdoor": 13.6866
       },
@@ -6509,9 +6509,9 @@
     {
       "time": 35460,
       "values": {
-        "t_tank_top": 28.4012,
-        "t_tank_bottom": 28.0322,
-        "t_collector": 29.1065,
+        "t_tank_top": 28.3179,
+        "t_tank_bottom": 27.9476,
+        "t_collector": 29.0249,
         "t_greenhouse": 15.9147,
         "t_outdoor": 13.6719
       },
@@ -6520,9 +6520,9 @@
     {
       "time": 35520,
       "values": {
-        "t_tank_top": 28.408,
-        "t_tank_bottom": 28.0433,
-        "t_collector": 29.1056,
+        "t_tank_top": 28.3248,
+        "t_tank_bottom": 27.9588,
+        "t_collector": 29.0241,
         "t_greenhouse": 15.8942,
         "t_outdoor": 13.657
       },
@@ -6531,9 +6531,9 @@
     {
       "time": 35580,
       "values": {
-        "t_tank_top": 28.4147,
-        "t_tank_bottom": 28.0543,
-        "t_collector": 29.1045,
+        "t_tank_top": 28.3316,
+        "t_tank_bottom": 27.9698,
+        "t_collector": 29.023,
         "t_greenhouse": 15.8736,
         "t_outdoor": 13.6421
       },
@@ -6542,9 +6542,9 @@
     {
       "time": 35640,
       "values": {
-        "t_tank_top": 28.4212,
-        "t_tank_bottom": 28.0651,
-        "t_collector": 29.1033,
+        "t_tank_top": 28.3382,
+        "t_tank_bottom": 27.9807,
+        "t_collector": 29.0218,
         "t_greenhouse": 15.8529,
         "t_outdoor": 13.6271
       },
@@ -6553,9 +6553,9 @@
     {
       "time": 35700,
       "values": {
-        "t_tank_top": 28.4276,
-        "t_tank_bottom": 28.0758,
-        "t_collector": 29.1018,
+        "t_tank_top": 28.3446,
+        "t_tank_bottom": 27.9914,
+        "t_collector": 29.0205,
         "t_greenhouse": 15.8321,
         "t_outdoor": 13.6121
       },
@@ -6564,9 +6564,9 @@
     {
       "time": 35760,
       "values": {
-        "t_tank_top": 28.4338,
-        "t_tank_bottom": 28.0863,
-        "t_collector": 29.1002,
+        "t_tank_top": 28.3508,
+        "t_tank_bottom": 28.002,
+        "t_collector": 29.0189,
         "t_greenhouse": 15.8113,
         "t_outdoor": 13.597
       },
@@ -6575,9 +6575,9 @@
     {
       "time": 35820,
       "values": {
-        "t_tank_top": 28.4398,
-        "t_tank_bottom": 28.0966,
-        "t_collector": 29.0984,
+        "t_tank_top": 28.3569,
+        "t_tank_bottom": 28.0124,
+        "t_collector": 29.0172,
         "t_greenhouse": 15.7903,
         "t_outdoor": 13.5818
       },
@@ -6586,9 +6586,9 @@
     {
       "time": 35880,
       "values": {
-        "t_tank_top": 28.4457,
-        "t_tank_bottom": 28.1068,
-        "t_collector": 29.0964,
+        "t_tank_top": 28.3628,
+        "t_tank_bottom": 28.0226,
+        "t_collector": 29.0153,
         "t_greenhouse": 15.7692,
         "t_outdoor": 13.5665
       },
@@ -6597,9 +6597,9 @@
     {
       "time": 35940,
       "values": {
-        "t_tank_top": 28.4514,
-        "t_tank_bottom": 28.1168,
-        "t_collector": 29.0943,
+        "t_tank_top": 28.3686,
+        "t_tank_bottom": 28.0327,
+        "t_collector": 29.0132,
         "t_greenhouse": 15.748,
         "t_outdoor": 13.5512
       },
@@ -6608,9 +6608,9 @@
     {
       "time": 36000,
       "values": {
-        "t_tank_top": 28.4569,
-        "t_tank_bottom": 28.1267,
-        "t_collector": 29.092,
+        "t_tank_top": 28.3742,
+        "t_tank_bottom": 28.0427,
+        "t_collector": 29.0109,
         "t_greenhouse": 15.7267,
         "t_outdoor": 13.5358
       },
@@ -6619,9 +6619,9 @@
     {
       "time": 36060,
       "values": {
-        "t_tank_top": 28.4622,
-        "t_tank_bottom": 28.1364,
-        "t_collector": 29.0895,
+        "t_tank_top": 28.3796,
+        "t_tank_bottom": 28.0524,
+        "t_collector": 29.0085,
         "t_greenhouse": 15.7053,
         "t_outdoor": 13.5203
       },
@@ -6630,9 +6630,9 @@
     {
       "time": 36120,
       "values": {
-        "t_tank_top": 28.4674,
-        "t_tank_bottom": 28.1459,
-        "t_collector": 29.0868,
+        "t_tank_top": 28.3849,
+        "t_tank_bottom": 28.062,
+        "t_collector": 29.0059,
         "t_greenhouse": 15.6838,
         "t_outdoor": 13.5048
       },
@@ -6641,9 +6641,9 @@
     {
       "time": 36180,
       "values": {
-        "t_tank_top": 28.4725,
-        "t_tank_bottom": 28.1553,
-        "t_collector": 29.084,
+        "t_tank_top": 28.39,
+        "t_tank_bottom": 28.0715,
+        "t_collector": 29.0031,
         "t_greenhouse": 15.6622,
         "t_outdoor": 13.4892
       },
@@ -6652,9 +6652,9 @@
     {
       "time": 36240,
       "values": {
-        "t_tank_top": 28.4773,
-        "t_tank_bottom": 28.1645,
-        "t_collector": 29.0809,
+        "t_tank_top": 28.3949,
+        "t_tank_bottom": 28.0808,
+        "t_collector": 29.0001,
         "t_greenhouse": 15.6405,
         "t_outdoor": 13.4736
       },
@@ -6663,9 +6663,9 @@
     {
       "time": 36300,
       "values": {
-        "t_tank_top": 28.482,
-        "t_tank_bottom": 28.1736,
-        "t_collector": 29.0777,
+        "t_tank_top": 28.3996,
+        "t_tank_bottom": 28.0899,
+        "t_collector": 28.9969,
         "t_greenhouse": 15.6187,
         "t_outdoor": 13.4578
       },
@@ -6674,9 +6674,9 @@
     {
       "time": 36360,
       "values": {
-        "t_tank_top": 28.4866,
-        "t_tank_bottom": 28.1825,
-        "t_collector": 29.0743,
+        "t_tank_top": 28.4042,
+        "t_tank_bottom": 28.0988,
+        "t_collector": 28.9936,
         "t_greenhouse": 15.5968,
         "t_outdoor": 13.442
       },
@@ -6685,9 +6685,9 @@
     {
       "time": 36420,
       "values": {
-        "t_tank_top": 28.4909,
-        "t_tank_bottom": 28.1913,
-        "t_collector": 29.0708,
+        "t_tank_top": 28.4086,
+        "t_tank_bottom": 28.1076,
+        "t_collector": 28.9901,
         "t_greenhouse": 15.5748,
         "t_outdoor": 13.4262
       },
@@ -6696,9 +6696,9 @@
     {
       "time": 36480,
       "values": {
-        "t_tank_top": 28.4951,
-        "t_tank_bottom": 28.1998,
-        "t_collector": 29.067,
+        "t_tank_top": 28.4129,
+        "t_tank_bottom": 28.1163,
+        "t_collector": 28.9864,
         "t_greenhouse": 15.5527,
         "t_outdoor": 13.4103
       },
@@ -6707,9 +6707,9 @@
     {
       "time": 36540,
       "values": {
-        "t_tank_top": 28.4991,
-        "t_tank_bottom": 28.2083,
-        "t_collector": 29.0631,
+        "t_tank_top": 28.417,
+        "t_tank_bottom": 28.1248,
+        "t_collector": 28.9826,
         "t_greenhouse": 15.5305,
         "t_outdoor": 13.3943
       },
@@ -6718,9 +6718,9 @@
     {
       "time": 36600,
       "values": {
-        "t_tank_top": 28.503,
-        "t_tank_bottom": 28.2165,
-        "t_collector": 29.059,
+        "t_tank_top": 28.4209,
+        "t_tank_bottom": 28.1331,
+        "t_collector": 28.9785,
         "t_greenhouse": 15.5082,
         "t_outdoor": 13.3782
       },
@@ -6729,9 +6729,9 @@
     {
       "time": 36660,
       "values": {
-        "t_tank_top": 28.5067,
-        "t_tank_bottom": 28.2246,
-        "t_collector": 29.0547,
+        "t_tank_top": 28.4247,
+        "t_tank_bottom": 28.1412,
+        "t_collector": 28.9743,
         "t_greenhouse": 15.4859,
         "t_outdoor": 13.3621
       },
@@ -6740,9 +6740,9 @@
     {
       "time": 36720,
       "values": {
-        "t_tank_top": 28.5102,
-        "t_tank_bottom": 28.2325,
-        "t_collector": 29.0503,
+        "t_tank_top": 28.4282,
+        "t_tank_bottom": 28.1492,
+        "t_collector": 28.9699,
         "t_greenhouse": 15.4634,
         "t_outdoor": 13.3459
       },
@@ -6751,9 +6751,9 @@
     {
       "time": 36780,
       "values": {
-        "t_tank_top": 28.5136,
-        "t_tank_bottom": 28.2403,
-        "t_collector": 29.0457,
+        "t_tank_top": 28.4317,
+        "t_tank_bottom": 28.1571,
+        "t_collector": 28.9654,
         "t_greenhouse": 15.4408,
         "t_outdoor": 13.3297
       },
@@ -6762,9 +6762,9 @@
     {
       "time": 36840,
       "values": {
-        "t_tank_top": 28.5168,
-        "t_tank_bottom": 28.2479,
-        "t_collector": 29.0409,
+        "t_tank_top": 28.4349,
+        "t_tank_bottom": 28.1647,
+        "t_collector": 28.9606,
         "t_greenhouse": 15.4181,
         "t_outdoor": 13.3134
       },
@@ -6773,9 +6773,9 @@
     {
       "time": 36900,
       "values": {
-        "t_tank_top": 28.5198,
-        "t_tank_bottom": 28.2554,
-        "t_collector": 29.0359,
+        "t_tank_top": 28.438,
+        "t_tank_bottom": 28.1722,
+        "t_collector": 28.9557,
         "t_greenhouse": 15.3954,
         "t_outdoor": 13.297
       },
@@ -6784,9 +6784,9 @@
     {
       "time": 36960,
       "values": {
-        "t_tank_top": 28.5227,
-        "t_tank_bottom": 28.2627,
-        "t_collector": 29.0307,
+        "t_tank_top": 28.4409,
+        "t_tank_bottom": 28.1796,
+        "t_collector": 28.9506,
         "t_greenhouse": 15.3725,
         "t_outdoor": 13.2806
       },
@@ -6795,9 +6795,9 @@
     {
       "time": 37020,
       "values": {
-        "t_tank_top": 28.5253,
-        "t_tank_bottom": 28.2698,
-        "t_collector": 29.0254,
+        "t_tank_top": 28.4437,
+        "t_tank_bottom": 28.1868,
+        "t_collector": 28.9453,
         "t_greenhouse": 15.3496,
         "t_outdoor": 13.2641
       },
@@ -6806,9 +6806,9 @@
     {
       "time": 37080,
       "values": {
-        "t_tank_top": 28.5279,
-        "t_tank_bottom": 28.2767,
-        "t_collector": 29.0199,
+        "t_tank_top": 28.4462,
+        "t_tank_bottom": 28.1938,
+        "t_collector": 28.9399,
         "t_greenhouse": 15.3265,
         "t_outdoor": 13.2475
       },
@@ -6817,9 +6817,9 @@
     {
       "time": 37140,
       "values": {
-        "t_tank_top": 28.5302,
-        "t_tank_bottom": 28.2835,
-        "t_collector": 29.0142,
+        "t_tank_top": 28.4486,
+        "t_tank_bottom": 28.2006,
+        "t_collector": 28.9342,
         "t_greenhouse": 15.3034,
         "t_outdoor": 13.2309
       },
@@ -6828,9 +6828,9 @@
     {
       "time": 37200,
       "values": {
-        "t_tank_top": 28.5324,
-        "t_tank_bottom": 28.2902,
-        "t_collector": 29.0083,
+        "t_tank_top": 28.4509,
+        "t_tank_bottom": 28.2073,
+        "t_collector": 28.9284,
         "t_greenhouse": 15.2801,
         "t_outdoor": 13.2142
       },
@@ -6839,9 +6839,9 @@
     {
       "time": 37260,
       "values": {
-        "t_tank_top": 28.5344,
-        "t_tank_bottom": 28.2966,
-        "t_collector": 29.0023,
+        "t_tank_top": 28.4529,
+        "t_tank_bottom": 28.2139,
+        "t_collector": 28.9224,
         "t_greenhouse": 15.2568,
         "t_outdoor": 13.1975
       },
@@ -6850,9 +6850,9 @@
     {
       "time": 37320,
       "values": {
-        "t_tank_top": 28.5362,
-        "t_tank_bottom": 28.3029,
-        "t_collector": 28.996,
+        "t_tank_top": 28.4548,
+        "t_tank_bottom": 28.2202,
+        "t_collector": 28.9163,
         "t_greenhouse": 15.2334,
         "t_outdoor": 13.1807
       },
@@ -6861,9 +6861,9 @@
     {
       "time": 37380,
       "values": {
-        "t_tank_top": 28.5379,
-        "t_tank_bottom": 28.3091,
-        "t_collector": 28.9896,
+        "t_tank_top": 28.4566,
+        "t_tank_bottom": 28.2264,
+        "t_collector": 28.9099,
         "t_greenhouse": 15.2099,
         "t_outdoor": 13.1638
       },
@@ -6872,9 +6872,9 @@
     {
       "time": 37440,
       "values": {
-        "t_tank_top": 28.5394,
-        "t_tank_bottom": 28.3151,
-        "t_collector": 28.9831,
+        "t_tank_top": 28.4581,
+        "t_tank_bottom": 28.2325,
+        "t_collector": 28.9034,
         "t_greenhouse": 15.1862,
         "t_outdoor": 13.1469
       },
@@ -6883,9 +6883,9 @@
     {
       "time": 37500,
       "values": {
-        "t_tank_top": 28.5408,
-        "t_tank_bottom": 28.3209,
-        "t_collector": 28.9763,
+        "t_tank_top": 28.4595,
+        "t_tank_bottom": 28.2383,
+        "t_collector": 28.8967,
         "t_greenhouse": 15.1626,
         "t_outdoor": 13.1299
       },
@@ -6894,9 +6894,9 @@
     {
       "time": 37560,
       "values": {
-        "t_tank_top": 28.5419,
-        "t_tank_bottom": 28.3265,
-        "t_collector": 28.9694,
+        "t_tank_top": 28.4608,
+        "t_tank_bottom": 28.244,
+        "t_collector": 28.8898,
         "t_greenhouse": 15.1388,
         "t_outdoor": 13.1129
       },
@@ -6905,9 +6905,9 @@
     {
       "time": 37620,
       "values": {
-        "t_tank_top": 28.5429,
-        "t_tank_bottom": 28.332,
-        "t_collector": 28.9623,
+        "t_tank_top": 28.4618,
+        "t_tank_bottom": 28.2496,
+        "t_collector": 28.8828,
         "t_greenhouse": 15.1149,
         "t_outdoor": 13.0958
       },
@@ -6916,9 +6916,9 @@
     {
       "time": 37680,
       "values": {
-        "t_tank_top": 28.5437,
-        "t_tank_bottom": 28.3373,
-        "t_collector": 28.955,
+        "t_tank_top": 28.4627,
+        "t_tank_bottom": 28.255,
+        "t_collector": 28.8755,
         "t_greenhouse": 15.0909,
         "t_outdoor": 13.0786
       },
@@ -6927,9 +6927,9 @@
     {
       "time": 37740,
       "values": {
-        "t_tank_top": 28.5444,
-        "t_tank_bottom": 28.3425,
-        "t_collector": 28.9475,
+        "t_tank_top": 28.4634,
+        "t_tank_bottom": 28.2602,
+        "t_collector": 28.8681,
         "t_greenhouse": 15.0669,
         "t_outdoor": 13.0614
       },
@@ -6938,9 +6938,9 @@
     {
       "time": 37800,
       "values": {
-        "t_tank_top": 28.5449,
-        "t_tank_bottom": 28.3475,
-        "t_collector": 28.9399,
+        "t_tank_top": 28.464,
+        "t_tank_bottom": 28.2652,
+        "t_collector": 28.8605,
         "t_greenhouse": 15.0427,
         "t_outdoor": 13.0441
       },
@@ -6949,9 +6949,9 @@
     {
       "time": 37860,
       "values": {
-        "t_tank_top": 28.5452,
-        "t_tank_bottom": 28.3523,
-        "t_collector": 28.932,
+        "t_tank_top": 28.4643,
+        "t_tank_bottom": 28.2701,
+        "t_collector": 28.8528,
         "t_greenhouse": 15.0185,
         "t_outdoor": 13.0268
       },
@@ -6960,9 +6960,9 @@
     {
       "time": 37920,
       "values": {
-        "t_tank_top": 28.5454,
-        "t_tank_bottom": 28.357,
-        "t_collector": 28.924,
+        "t_tank_top": 28.4646,
+        "t_tank_bottom": 28.2748,
+        "t_collector": 28.8448,
         "t_greenhouse": 14.9941,
         "t_outdoor": 13.0094
       },
@@ -6971,9 +6971,9 @@
     {
       "time": 37980,
       "values": {
-        "t_tank_top": 28.5453,
-        "t_tank_bottom": 28.3614,
-        "t_collector": 28.9159,
+        "t_tank_top": 28.4646,
+        "t_tank_bottom": 28.2794,
+        "t_collector": 28.8367,
         "t_greenhouse": 14.9697,
         "t_outdoor": 12.9919
       },
@@ -6982,9 +6982,9 @@
     {
       "time": 38040,
       "values": {
-        "t_tank_top": 28.5451,
-        "t_tank_bottom": 28.3658,
-        "t_collector": 28.9075,
+        "t_tank_top": 28.4645,
+        "t_tank_bottom": 28.2838,
+        "t_collector": 28.8284,
         "t_greenhouse": 14.9452,
         "t_outdoor": 12.9744
       },
@@ -6993,9 +6993,9 @@
     {
       "time": 38100,
       "values": {
-        "t_tank_top": 28.5448,
-        "t_tank_bottom": 28.3699,
-        "t_collector": 28.899,
+        "t_tank_top": 28.4642,
+        "t_tank_bottom": 28.288,
+        "t_collector": 28.8199,
         "t_greenhouse": 14.9206,
         "t_outdoor": 12.9568
       },
@@ -7004,9 +7004,9 @@
     {
       "time": 38160,
       "values": {
-        "t_tank_top": 28.5443,
-        "t_tank_bottom": 28.3739,
-        "t_collector": 28.8903,
+        "t_tank_top": 28.4637,
+        "t_tank_bottom": 28.292,
+        "t_collector": 28.8113,
         "t_greenhouse": 14.896,
         "t_outdoor": 12.9392
       },
@@ -7015,9 +7015,9 @@
     {
       "time": 38220,
       "values": {
-        "t_tank_top": 28.5436,
-        "t_tank_bottom": 28.3778,
-        "t_collector": 28.8814,
+        "t_tank_top": 28.463,
+        "t_tank_bottom": 28.2959,
+        "t_collector": 28.8025,
         "t_greenhouse": 14.8712,
         "t_outdoor": 12.9215
       },
@@ -7026,9 +7026,9 @@
     {
       "time": 38280,
       "values": {
-        "t_tank_top": 28.5383,
-        "t_tank_bottom": 28.3814,
-        "t_collector": 29.0149,
+        "t_tank_top": 28.4602,
+        "t_tank_bottom": 28.2996,
+        "t_collector": 28.8593,
         "t_greenhouse": 14.8464,
         "t_outdoor": 12.9038
       },
@@ -7037,9 +7037,9 @@
     {
       "time": 38340,
       "values": {
-        "t_tank_top": 28.5306,
-        "t_tank_bottom": 28.3846,
-        "t_collector": 29.2287,
+        "t_tank_top": 28.4524,
+        "t_tank_bottom": 28.303,
+        "t_collector": 29.0758,
         "t_greenhouse": 14.8214,
         "t_outdoor": 12.886
       },
@@ -7048,9 +7048,9 @@
     {
       "time": 38400,
       "values": {
-        "t_tank_top": 28.5233,
-        "t_tank_bottom": 28.3874,
-        "t_collector": 29.4324,
+        "t_tank_top": 28.445,
+        "t_tank_bottom": 28.306,
+        "t_collector": 29.2823,
         "t_greenhouse": 14.7964,
         "t_outdoor": 12.8682
       },
@@ -7059,9 +7059,9 @@
     {
       "time": 38460,
       "values": {
-        "t_tank_top": 28.5164,
-        "t_tank_bottom": 28.3899,
-        "t_collector": 29.6262,
+        "t_tank_top": 28.4379,
+        "t_tank_bottom": 28.3086,
+        "t_collector": 29.4788,
         "t_greenhouse": 14.7713,
         "t_outdoor": 12.8503
       },
@@ -7070,9 +7070,9 @@
     {
       "time": 38520,
       "values": {
-        "t_tank_top": 28.5097,
-        "t_tank_bottom": 28.3921,
-        "t_collector": 29.8103,
+        "t_tank_top": 28.4312,
+        "t_tank_bottom": 28.3109,
+        "t_collector": 29.6655,
         "t_greenhouse": 14.7461,
         "t_outdoor": 12.8323
       },
@@ -7081,9 +7081,9 @@
     {
       "time": 38580,
       "values": {
-        "t_tank_top": 28.5034,
-        "t_tank_bottom": 28.3939,
-        "t_collector": 29.9848,
+        "t_tank_top": 28.4248,
+        "t_tank_bottom": 28.3128,
+        "t_collector": 29.8426,
         "t_greenhouse": 14.7208,
         "t_outdoor": 12.8143
       },
@@ -7092,9 +7092,9 @@
     {
       "time": 38640,
       "values": {
-        "t_tank_top": 28.4973,
-        "t_tank_bottom": 28.3955,
-        "t_collector": 30.1499,
+        "t_tank_top": 28.4187,
+        "t_tank_bottom": 28.3145,
+        "t_collector": 30.0102,
         "t_greenhouse": 14.6955,
         "t_outdoor": 12.7963
       },
@@ -7103,9 +7103,9 @@
     {
       "time": 38700,
       "values": {
-        "t_tank_top": 28.4916,
-        "t_tank_bottom": 28.3968,
-        "t_collector": 30.3058,
+        "t_tank_top": 28.4128,
+        "t_tank_bottom": 28.3159,
+        "t_collector": 30.1686,
         "t_greenhouse": 14.67,
         "t_outdoor": 12.7782
       },
@@ -7114,9 +7114,9 @@
     {
       "time": 38760,
       "values": {
-        "t_tank_top": 28.486,
-        "t_tank_bottom": 28.3978,
-        "t_collector": 30.4526,
+        "t_tank_top": 28.4072,
+        "t_tank_bottom": 28.317,
+        "t_collector": 30.3178,
         "t_greenhouse": 14.6445,
         "t_outdoor": 12.76
       },
@@ -7125,9 +7125,9 @@
     {
       "time": 38820,
       "values": {
-        "t_tank_top": 28.4807,
-        "t_tank_bottom": 28.3987,
-        "t_collector": 30.5904,
+        "t_tank_top": 28.4018,
+        "t_tank_bottom": 28.3179,
+        "t_collector": 30.458,
         "t_greenhouse": 14.6189,
         "t_outdoor": 12.7418
       },
@@ -7136,9 +7136,9 @@
     {
       "time": 38880,
       "values": {
-        "t_tank_top": 28.4756,
-        "t_tank_bottom": 28.3993,
-        "t_collector": 30.7195,
+        "t_tank_top": 28.3967,
+        "t_tank_bottom": 28.3186,
+        "t_collector": 30.5894,
         "t_greenhouse": 14.5932,
         "t_outdoor": 12.7235
       },
@@ -7147,9 +7147,9 @@
     {
       "time": 38940,
       "values": {
-        "t_tank_top": 28.4707,
-        "t_tank_bottom": 28.3997,
-        "t_collector": 30.8399,
+        "t_tank_top": 28.3917,
+        "t_tank_bottom": 28.319,
+        "t_collector": 30.7122,
         "t_greenhouse": 14.5675,
         "t_outdoor": 12.7052
       },
@@ -7158,9 +7158,9 @@
     {
       "time": 39000,
       "values": {
-        "t_tank_top": 28.466,
-        "t_tank_bottom": 28.3999,
-        "t_collector": 30.9518,
+        "t_tank_top": 28.387,
+        "t_tank_bottom": 28.3193,
+        "t_collector": 30.8264,
         "t_greenhouse": 14.5416,
         "t_outdoor": 12.6868
       },
@@ -7169,9 +7169,9 @@
     {
       "time": 39060,
       "values": {
-        "t_tank_top": 28.4614,
-        "t_tank_bottom": 28.3999,
-        "t_collector": 31.0554,
+        "t_tank_top": 28.3824,
+        "t_tank_bottom": 28.3194,
+        "t_collector": 30.9322,
         "t_greenhouse": 14.5157,
         "t_outdoor": 12.6684
       },
@@ -7180,9 +7180,9 @@
     {
       "time": 39120,
       "values": {
-        "t_tank_top": 28.457,
-        "t_tank_bottom": 28.3998,
-        "t_collector": 31.1508,
+        "t_tank_top": 28.3779,
+        "t_tank_bottom": 28.3194,
+        "t_collector": 31.0298,
         "t_greenhouse": 14.4897,
         "t_outdoor": 12.6499
       },
@@ -7191,9 +7191,9 @@
     {
       "time": 39180,
       "values": {
-        "t_tank_top": 28.4528,
-        "t_tank_bottom": 28.3995,
-        "t_collector": 31.2381,
+        "t_tank_top": 28.3736,
+        "t_tank_bottom": 28.3191,
+        "t_collector": 31.1192,
         "t_greenhouse": 14.4636,
         "t_outdoor": 12.6314
       },
@@ -7202,9 +7202,9 @@
     {
       "time": 39240,
       "values": {
-        "t_tank_top": 28.4487,
-        "t_tank_bottom": 28.3991,
-        "t_collector": 31.3175,
+        "t_tank_top": 28.3695,
+        "t_tank_bottom": 28.3188,
+        "t_collector": 31.2008,
         "t_greenhouse": 14.4374,
         "t_outdoor": 12.6128
       },
@@ -7213,9 +7213,9 @@
     {
       "time": 39300,
       "values": {
-        "t_tank_top": 28.4447,
-        "t_tank_bottom": 28.3985,
-        "t_collector": 31.3891,
+        "t_tank_top": 28.3655,
+        "t_tank_bottom": 28.3183,
+        "t_collector": 31.2744,
         "t_greenhouse": 14.4112,
         "t_outdoor": 12.5942
       },
@@ -7224,9 +7224,9 @@
     {
       "time": 39360,
       "values": {
-        "t_tank_top": 28.4408,
-        "t_tank_bottom": 28.3979,
-        "t_collector": 31.4531,
+        "t_tank_top": 28.3616,
+        "t_tank_bottom": 28.3177,
+        "t_collector": 31.3404,
         "t_greenhouse": 14.3849,
         "t_outdoor": 12.5755
       },
@@ -7235,9 +7235,9 @@
     {
       "time": 39420,
       "values": {
-        "t_tank_top": 28.437,
-        "t_tank_bottom": 28.3971,
-        "t_collector": 31.5095,
+        "t_tank_top": 28.3578,
+        "t_tank_bottom": 28.3169,
+        "t_collector": 31.3989,
         "t_greenhouse": 14.3585,
         "t_outdoor": 12.5568
       },
@@ -7246,9 +7246,9 @@
     {
       "time": 39480,
       "values": {
-        "t_tank_top": 28.4334,
-        "t_tank_bottom": 28.3962,
-        "t_collector": 31.5585,
+        "t_tank_top": 28.3541,
+        "t_tank_bottom": 28.3161,
+        "t_collector": 31.4498,
         "t_greenhouse": 14.332,
         "t_outdoor": 12.538
       },
@@ -7257,9 +7257,9 @@
     {
       "time": 39540,
       "values": {
-        "t_tank_top": 28.4298,
-        "t_tank_bottom": 28.3952,
-        "t_collector": 31.6003,
+        "t_tank_top": 28.3505,
+        "t_tank_bottom": 28.3151,
+        "t_collector": 31.4935,
         "t_greenhouse": 14.3054,
         "t_outdoor": 12.5192
       },
@@ -7268,9 +7268,9 @@
     {
       "time": 39600,
       "values": {
-        "t_tank_top": 28.4263,
-        "t_tank_bottom": 28.3942,
-        "t_collector": 31.6348,
+        "t_tank_top": 28.347,
+        "t_tank_bottom": 28.3141,
+        "t_collector": 31.53,
         "t_greenhouse": 14.2788,
         "t_outdoor": 12.5003
       },
@@ -7279,9 +7279,9 @@
     {
       "time": 39660,
       "values": {
-        "t_tank_top": 28.4229,
-        "t_tank_bottom": 28.393,
-        "t_collector": 31.6624,
+        "t_tank_top": 28.3436,
+        "t_tank_bottom": 28.313,
+        "t_collector": 31.5594,
         "t_greenhouse": 14.2521,
         "t_outdoor": 12.4814
       },
@@ -7290,9 +7290,9 @@
     {
       "time": 39720,
       "values": {
-        "t_tank_top": 28.4196,
-        "t_tank_bottom": 28.3917,
-        "t_collector": 31.683,
+        "t_tank_top": 28.3403,
+        "t_tank_bottom": 28.3118,
+        "t_collector": 31.5819,
         "t_greenhouse": 14.2253,
         "t_outdoor": 12.4624
       },
@@ -7301,9 +7301,9 @@
     {
       "time": 39780,
       "values": {
-        "t_tank_top": 28.4163,
-        "t_tank_bottom": 28.3904,
-        "t_collector": 31.6969,
+        "t_tank_top": 28.337,
+        "t_tank_bottom": 28.3105,
+        "t_collector": 31.5975,
         "t_greenhouse": 14.1985,
         "t_outdoor": 12.4434
       },
@@ -7312,9 +7312,9 @@
     {
       "time": 39840,
       "values": {
-        "t_tank_top": 28.4131,
-        "t_tank_bottom": 28.389,
-        "t_collector": 31.704,
+        "t_tank_top": 28.3338,
+        "t_tank_bottom": 28.3091,
+        "t_collector": 31.6064,
         "t_greenhouse": 14.1715,
         "t_outdoor": 12.4244
       },
@@ -7323,9 +7323,9 @@
     {
       "time": 39900,
       "values": {
-        "t_tank_top": 28.41,
-        "t_tank_bottom": 28.3876,
-        "t_collector": 31.7046,
+        "t_tank_top": 28.3307,
+        "t_tank_bottom": 28.3077,
+        "t_collector": 31.6088,
         "t_greenhouse": 14.1445,
         "t_outdoor": 12.4053
       },
@@ -7334,9 +7334,9 @@
     {
       "time": 39960,
       "values": {
-        "t_tank_top": 28.4069,
-        "t_tank_bottom": 28.3861,
-        "t_collector": 31.6987,
+        "t_tank_top": 28.3276,
+        "t_tank_bottom": 28.3062,
+        "t_collector": 31.6046,
         "t_greenhouse": 14.1174,
         "t_outdoor": 12.3861
       },
@@ -7345,9 +7345,9 @@
     {
       "time": 40020,
       "values": {
-        "t_tank_top": 28.4039,
-        "t_tank_bottom": 28.3845,
-        "t_collector": 31.6865,
+        "t_tank_top": 28.3246,
+        "t_tank_bottom": 28.3047,
+        "t_collector": 31.5941,
         "t_greenhouse": 14.0903,
         "t_outdoor": 12.3669
       },
@@ -7356,9 +7356,9 @@
     {
       "time": 40080,
       "values": {
-        "t_tank_top": 28.4009,
-        "t_tank_bottom": 28.3829,
-        "t_collector": 31.6681,
+        "t_tank_top": 28.3216,
+        "t_tank_bottom": 28.3031,
+        "t_collector": 31.5772,
         "t_greenhouse": 14.0631,
         "t_outdoor": 12.3477
       },
@@ -7367,9 +7367,9 @@
     {
       "time": 40140,
       "values": {
-        "t_tank_top": 28.398,
-        "t_tank_bottom": 28.3812,
-        "t_collector": 31.6435,
+        "t_tank_top": 28.3186,
+        "t_tank_bottom": 28.3014,
+        "t_collector": 31.5543,
         "t_greenhouse": 14.0358,
         "t_outdoor": 12.3284
       },
@@ -7378,9 +7378,9 @@
     {
       "time": 40200,
       "values": {
-        "t_tank_top": 28.3951,
-        "t_tank_bottom": 28.3795,
-        "t_collector": 31.6129,
+        "t_tank_top": 28.3158,
+        "t_tank_bottom": 28.2997,
+        "t_collector": 31.5252,
         "t_greenhouse": 14.0084,
         "t_outdoor": 12.3091
       },
@@ -7389,9 +7389,9 @@
     {
       "time": 40260,
       "values": {
-        "t_tank_top": 28.3923,
-        "t_tank_bottom": 28.3777,
-        "t_collector": 31.5763,
+        "t_tank_top": 28.3129,
+        "t_tank_bottom": 28.298,
+        "t_collector": 31.4902,
         "t_greenhouse": 13.981,
         "t_outdoor": 12.2897
       },
@@ -7400,9 +7400,9 @@
     {
       "time": 40320,
       "values": {
-        "t_tank_top": 28.3895,
-        "t_tank_bottom": 28.3759,
-        "t_collector": 31.5339,
+        "t_tank_top": 28.3101,
+        "t_tank_bottom": 28.2962,
+        "t_collector": 31.4494,
         "t_greenhouse": 13.9534,
         "t_outdoor": 12.2703
       },
@@ -7411,9 +7411,9 @@
     {
       "time": 40380,
       "values": {
-        "t_tank_top": 28.3867,
-        "t_tank_bottom": 28.3741,
-        "t_collector": 31.4858,
+        "t_tank_top": 28.3073,
+        "t_tank_bottom": 28.2944,
+        "t_collector": 31.4028,
         "t_greenhouse": 13.9259,
         "t_outdoor": 12.2508
       },
@@ -7422,9 +7422,9 @@
     {
       "time": 40440,
       "values": {
-        "t_tank_top": 28.3839,
-        "t_tank_bottom": 28.3722,
-        "t_collector": 31.4321,
+        "t_tank_top": 28.3046,
+        "t_tank_bottom": 28.2926,
+        "t_collector": 31.3505,
         "t_greenhouse": 13.8982,
         "t_outdoor": 12.2313
       },
@@ -7433,9 +7433,9 @@
     {
       "time": 40500,
       "values": {
-        "t_tank_top": 28.3812,
-        "t_tank_bottom": 28.3703,
-        "t_collector": 31.3728,
+        "t_tank_top": 28.3018,
+        "t_tank_bottom": 28.2907,
+        "t_collector": 31.2927,
         "t_greenhouse": 13.8705,
         "t_outdoor": 12.2118
       },
@@ -7444,9 +7444,9 @@
     {
       "time": 40560,
       "values": {
-        "t_tank_top": 28.3785,
-        "t_tank_bottom": 28.3684,
-        "t_collector": 31.3081,
+        "t_tank_top": 28.2991,
+        "t_tank_bottom": 28.2888,
+        "t_collector": 31.2294,
         "t_greenhouse": 13.8427,
         "t_outdoor": 12.1922
       },
@@ -7455,9 +7455,9 @@
     {
       "time": 40620,
       "values": {
-        "t_tank_top": 28.3758,
-        "t_tank_bottom": 28.3664,
-        "t_collector": 31.238,
+        "t_tank_top": 28.2965,
+        "t_tank_bottom": 28.2868,
+        "t_collector": 31.1608,
         "t_greenhouse": 13.8148,
         "t_outdoor": 12.1726
       },
@@ -7466,9 +7466,9 @@
     {
       "time": 40680,
       "values": {
-        "t_tank_top": 28.3732,
-        "t_tank_bottom": 28.3644,
-        "t_collector": 31.1627,
+        "t_tank_top": 28.2938,
+        "t_tank_bottom": 28.2848,
+        "t_collector": 31.0868,
         "t_greenhouse": 13.7869,
         "t_outdoor": 12.1529
       },
@@ -7477,9 +7477,9 @@
     {
       "time": 40740,
       "values": {
-        "t_tank_top": 28.3706,
-        "t_tank_bottom": 28.3624,
-        "t_collector": 31.0822,
+        "t_tank_top": 28.2912,
+        "t_tank_bottom": 28.2828,
+        "t_collector": 31.0076,
         "t_greenhouse": 13.7589,
         "t_outdoor": 12.1332
       },
@@ -7488,9 +7488,9 @@
     {
       "time": 40800,
       "values": {
-        "t_tank_top": 28.3679,
-        "t_tank_bottom": 28.3603,
-        "t_collector": 30.9966,
+        "t_tank_top": 28.2886,
+        "t_tank_bottom": 28.2808,
+        "t_collector": 30.9234,
         "t_greenhouse": 13.7309,
         "t_outdoor": 12.1134
       },
@@ -7499,9 +7499,9 @@
     {
       "time": 40860,
       "values": {
-        "t_tank_top": 28.3654,
-        "t_tank_bottom": 28.3583,
-        "t_collector": 30.906,
+        "t_tank_top": 28.286,
+        "t_tank_bottom": 28.2788,
+        "t_collector": 30.8341,
         "t_greenhouse": 13.7027,
         "t_outdoor": 12.0936
       },
@@ -7510,9 +7510,9 @@
     {
       "time": 40920,
       "values": {
-        "t_tank_top": 28.3628,
-        "t_tank_bottom": 28.3562,
-        "t_collector": 30.8105,
+        "t_tank_top": 28.2834,
+        "t_tank_bottom": 28.2767,
+        "t_collector": 30.7399,
         "t_greenhouse": 13.6745,
         "t_outdoor": 12.0738
       },
@@ -7521,9 +7521,9 @@
     {
       "time": 40980,
       "values": {
-        "t_tank_top": 28.3602,
-        "t_tank_bottom": 28.3541,
-        "t_collector": 30.7102,
+        "t_tank_top": 28.2809,
+        "t_tank_bottom": 28.2746,
+        "t_collector": 30.6408,
         "t_greenhouse": 13.6463,
         "t_outdoor": 12.0539
       },
@@ -7532,9 +7532,9 @@
     {
       "time": 41040,
       "values": {
-        "t_tank_top": 28.3577,
-        "t_tank_bottom": 28.3519,
-        "t_collector": 30.6051,
+        "t_tank_top": 28.2783,
+        "t_tank_bottom": 28.2725,
+        "t_collector": 30.537,
         "t_greenhouse": 13.6179,
         "t_outdoor": 12.034
       },
@@ -7543,9 +7543,9 @@
     {
       "time": 41100,
       "values": {
-        "t_tank_top": 28.3551,
-        "t_tank_bottom": 28.3498,
-        "t_collector": 30.4954,
+        "t_tank_top": 28.2758,
+        "t_tank_bottom": 28.2704,
+        "t_collector": 30.4285,
         "t_greenhouse": 13.5896,
         "t_outdoor": 12.0141
       },
@@ -7554,9 +7554,9 @@
     {
       "time": 41160,
       "values": {
-        "t_tank_top": 28.3526,
-        "t_tank_bottom": 28.3476,
-        "t_collector": 30.3811,
+        "t_tank_top": 28.2733,
+        "t_tank_bottom": 28.2682,
+        "t_collector": 30.3153,
         "t_greenhouse": 13.5611,
         "t_outdoor": 11.9941
       },
@@ -7565,9 +7565,9 @@
     {
       "time": 41220,
       "values": {
-        "t_tank_top": 28.3501,
-        "t_tank_bottom": 28.3455,
-        "t_collector": 30.2622,
+        "t_tank_top": 28.2708,
+        "t_tank_bottom": 28.2661,
+        "t_collector": 30.1977,
         "t_greenhouse": 13.5326,
         "t_outdoor": 11.9741
       },
@@ -7576,9 +7576,9 @@
     {
       "time": 41280,
       "values": {
-        "t_tank_top": 28.3476,
-        "t_tank_bottom": 28.3433,
-        "t_collector": 30.139,
+        "t_tank_top": 28.2683,
+        "t_tank_bottom": 28.2639,
+        "t_collector": 30.0756,
         "t_greenhouse": 13.504,
         "t_outdoor": 11.954
       },
@@ -7587,9 +7587,9 @@
     {
       "time": 41340,
       "values": {
-        "t_tank_top": 28.3451,
-        "t_tank_bottom": 28.3411,
-        "t_collector": 30.0114,
+        "t_tank_top": 28.2658,
+        "t_tank_bottom": 28.2617,
+        "t_collector": 29.9491,
         "t_greenhouse": 13.4754,
         "t_outdoor": 11.9339
       },
@@ -7598,9 +7598,9 @@
     {
       "time": 41400,
       "values": {
-        "t_tank_top": 28.3426,
-        "t_tank_bottom": 28.3389,
-        "t_collector": 29.8794,
+        "t_tank_top": 28.2633,
+        "t_tank_bottom": 28.2595,
+        "t_collector": 29.8183,
         "t_greenhouse": 13.4467,
         "t_outdoor": 11.9138
       },
@@ -7609,9 +7609,9 @@
     {
       "time": 41460,
       "values": {
-        "t_tank_top": 28.3401,
-        "t_tank_bottom": 28.3366,
-        "t_collector": 29.7433,
+        "t_tank_top": 28.2608,
+        "t_tank_bottom": 28.2573,
+        "t_collector": 29.6832,
         "t_greenhouse": 13.4179,
         "t_outdoor": 11.8936
       },
@@ -7620,9 +7620,9 @@
     {
       "time": 41520,
       "values": {
-        "t_tank_top": 28.3376,
-        "t_tank_bottom": 28.3344,
-        "t_collector": 29.6031,
+        "t_tank_top": 28.2583,
+        "t_tank_bottom": 28.2551,
+        "t_collector": 29.544,
         "t_greenhouse": 13.3891,
         "t_outdoor": 11.8734
       },
@@ -7631,9 +7631,9 @@
     {
       "time": 41580,
       "values": {
-        "t_tank_top": 28.3351,
-        "t_tank_bottom": 28.3322,
-        "t_collector": 29.4588,
+        "t_tank_top": 28.2559,
+        "t_tank_bottom": 28.2528,
+        "t_collector": 29.4008,
         "t_greenhouse": 13.3602,
         "t_outdoor": 11.8531
       },
@@ -7642,9 +7642,9 @@
     {
       "time": 41640,
       "values": {
-        "t_tank_top": 28.3327,
-        "t_tank_bottom": 28.3299,
-        "t_collector": 29.3104,
+        "t_tank_top": 28.2534,
+        "t_tank_bottom": 28.2506,
+        "t_collector": 29.2535,
         "t_greenhouse": 13.3312,
         "t_outdoor": 11.8328
       },
@@ -7653,9 +7653,9 @@
     {
       "time": 41700,
       "values": {
-        "t_tank_top": 28.3302,
-        "t_tank_bottom": 28.3276,
-        "t_collector": 29.1582,
+        "t_tank_top": 28.251,
+        "t_tank_bottom": 28.2483,
+        "t_collector": 29.1022,
         "t_greenhouse": 13.3022,
         "t_outdoor": 11.8125
       },
@@ -7664,9 +7664,9 @@
     {
       "time": 41760,
       "values": {
-        "t_tank_top": 28.3277,
-        "t_tank_bottom": 28.3253,
-        "t_collector": 29.0021,
+        "t_tank_top": 28.2485,
+        "t_tank_bottom": 28.2461,
+        "t_collector": 28.9471,
         "t_greenhouse": 13.2732,
         "t_outdoor": 11.7922
       },
@@ -7675,9 +7675,9 @@
     {
       "time": 41820,
       "values": {
-        "t_tank_top": 28.3253,
-        "t_tank_bottom": 28.3231,
-        "t_collector": 28.8421,
+        "t_tank_top": 28.2461,
+        "t_tank_bottom": 28.2438,
+        "t_collector": 28.7882,
         "t_greenhouse": 13.244,
         "t_outdoor": 11.7718
       },
@@ -7686,9 +7686,9 @@
     {
       "time": 41880,
       "values": {
-        "t_tank_top": 28.3228,
-        "t_tank_bottom": 28.3208,
-        "t_collector": 28.6785,
+        "t_tank_top": 28.2436,
+        "t_tank_bottom": 28.2415,
+        "t_collector": 28.6255,
         "t_greenhouse": 13.2148,
         "t_outdoor": 11.7514
       },
@@ -7697,9 +7697,9 @@
     {
       "time": 41940,
       "values": {
-        "t_tank_top": 28.3204,
-        "t_tank_bottom": 28.3185,
-        "t_collector": 28.5112,
+        "t_tank_top": 28.2412,
+        "t_tank_bottom": 28.2392,
+        "t_collector": 28.4591,
         "t_greenhouse": 13.1856,
         "t_outdoor": 11.7309
       },
@@ -7708,9 +7708,9 @@
     {
       "time": 42000,
       "values": {
-        "t_tank_top": 28.3179,
-        "t_tank_bottom": 28.3161,
-        "t_collector": 28.3403,
+        "t_tank_top": 28.2388,
+        "t_tank_bottom": 28.2369,
+        "t_collector": 28.2891,
         "t_greenhouse": 13.1563,
         "t_outdoor": 11.7104
       },
@@ -7719,9 +7719,9 @@
     {
       "time": 42060,
       "values": {
-        "t_tank_top": 28.3155,
-        "t_tank_bottom": 28.3138,
-        "t_collector": 28.1658,
+        "t_tank_top": 28.2363,
+        "t_tank_bottom": 28.2346,
+        "t_collector": 28.1156,
         "t_greenhouse": 13.1269,
         "t_outdoor": 11.6899
       },
@@ -7730,9 +7730,9 @@
     {
       "time": 42120,
       "values": {
-        "t_tank_top": 28.3131,
-        "t_tank_bottom": 28.3115,
-        "t_collector": 27.9878,
+        "t_tank_top": 28.2339,
+        "t_tank_bottom": 28.2323,
+        "t_collector": 27.9385,
         "t_greenhouse": 13.0975,
         "t_outdoor": 11.6694
       },
@@ -7741,9 +7741,9 @@
     {
       "time": 42180,
       "values": {
-        "t_tank_top": 28.3106,
-        "t_tank_bottom": 28.3092,
-        "t_collector": 27.8065,
+        "t_tank_top": 28.2315,
+        "t_tank_bottom": 28.23,
+        "t_collector": 27.758,
         "t_greenhouse": 13.0681,
         "t_outdoor": 11.6488
       },
@@ -7752,9 +7752,9 @@
     {
       "time": 42240,
       "values": {
-        "t_tank_top": 28.3082,
-        "t_tank_bottom": 28.3068,
-        "t_collector": 27.6217,
+        "t_tank_top": 28.229,
+        "t_tank_bottom": 28.2276,
+        "t_collector": 27.5741,
         "t_greenhouse": 13.0385,
         "t_outdoor": 11.6282
       },
@@ -7763,9 +7763,9 @@
     {
       "time": 42300,
       "values": {
-        "t_tank_top": 28.3057,
-        "t_tank_bottom": 28.3045,
-        "t_collector": 27.4337,
+        "t_tank_top": 28.2266,
+        "t_tank_bottom": 28.2253,
+        "t_collector": 27.3869,
         "t_greenhouse": 13.009,
         "t_outdoor": 11.6075
       },
@@ -7774,9 +7774,9 @@
     {
       "time": 42360,
       "values": {
-        "t_tank_top": 28.3033,
-        "t_tank_bottom": 28.3021,
-        "t_collector": 27.2424,
+        "t_tank_top": 28.2242,
+        "t_tank_bottom": 28.223,
+        "t_collector": 27.1965,
         "t_greenhouse": 12.9793,
         "t_outdoor": 11.5869
       },
@@ -7785,9 +7785,9 @@
     {
       "time": 42420,
       "values": {
-        "t_tank_top": 28.3009,
-        "t_tank_bottom": 28.2998,
-        "t_collector": 27.0479,
+        "t_tank_top": 28.2217,
+        "t_tank_bottom": 28.2206,
+        "t_collector": 27.0028,
         "t_greenhouse": 12.9496,
         "t_outdoor": 11.5662
       },
@@ -7796,9 +7796,9 @@
     {
       "time": 42480,
       "values": {
-        "t_tank_top": 28.2984,
-        "t_tank_bottom": 28.2974,
-        "t_collector": 26.8503,
+        "t_tank_top": 28.2193,
+        "t_tank_bottom": 28.2183,
+        "t_collector": 26.806,
         "t_greenhouse": 12.9199,
         "t_outdoor": 11.5454
       },
@@ -7807,9 +7807,9 @@
     {
       "time": 42540,
       "values": {
-        "t_tank_top": 28.296,
-        "t_tank_bottom": 28.295,
-        "t_collector": 26.6495,
+        "t_tank_top": 28.2169,
+        "t_tank_bottom": 28.2159,
+        "t_collector": 26.606,
         "t_greenhouse": 12.8901,
         "t_outdoor": 11.5247
       },
@@ -7818,9 +7818,9 @@
     {
       "time": 42600,
       "values": {
-        "t_tank_top": 28.2935,
-        "t_tank_bottom": 28.2927,
-        "t_collector": 26.4458,
+        "t_tank_top": 28.2145,
+        "t_tank_bottom": 28.2136,
+        "t_collector": 26.4031,
         "t_greenhouse": 12.8603,
         "t_outdoor": 11.5039
       },
@@ -7829,9 +7829,9 @@
     {
       "time": 42660,
       "values": {
-        "t_tank_top": 28.2911,
-        "t_tank_bottom": 28.2903,
-        "t_collector": 26.2391,
+        "t_tank_top": 28.212,
+        "t_tank_bottom": 28.2112,
+        "t_collector": 26.1971,
         "t_greenhouse": 12.8304,
         "t_outdoor": 11.4831
       },
@@ -7840,9 +7840,9 @@
     {
       "time": 42720,
       "values": {
-        "t_tank_top": 28.2887,
-        "t_tank_bottom": 28.2879,
-        "t_collector": 26.0294,
+        "t_tank_top": 28.2096,
+        "t_tank_bottom": 28.2088,
+        "t_collector": 25.9882,
         "t_greenhouse": 12.8004,
         "t_outdoor": 11.4622
       },
@@ -7851,9 +7851,9 @@
     {
       "time": 42780,
       "values": {
-        "t_tank_top": 28.2862,
-        "t_tank_bottom": 28.2855,
-        "t_collector": 25.8169,
+        "t_tank_top": 28.2072,
+        "t_tank_bottom": 28.2065,
+        "t_collector": 25.7764,
         "t_greenhouse": 12.7704,
         "t_outdoor": 11.4413
       },
@@ -7862,9 +7862,9 @@
     {
       "time": 42840,
       "values": {
-        "t_tank_top": 28.2838,
-        "t_tank_bottom": 28.2831,
-        "t_collector": 25.6015,
+        "t_tank_top": 28.2047,
+        "t_tank_bottom": 28.2041,
+        "t_collector": 25.5618,
         "t_greenhouse": 12.7404,
         "t_outdoor": 11.4204
       },
@@ -7873,9 +7873,9 @@
     {
       "time": 42900,
       "values": {
-        "t_tank_top": 28.2814,
-        "t_tank_bottom": 28.2807,
-        "t_collector": 25.3834,
+        "t_tank_top": 28.2023,
+        "t_tank_bottom": 28.2017,
+        "t_collector": 25.3443,
         "t_greenhouse": 12.7103,
         "t_outdoor": 11.3995
       },
@@ -7884,9 +7884,9 @@
     {
       "time": 42960,
       "values": {
-        "t_tank_top": 28.2789,
-        "t_tank_bottom": 28.2783,
-        "t_collector": 25.1626,
+        "t_tank_top": 28.1999,
+        "t_tank_bottom": 28.1993,
+        "t_collector": 25.1242,
         "t_greenhouse": 12.6801,
         "t_outdoor": 11.3785
       },
@@ -7895,9 +7895,9 @@
     {
       "time": 43020,
       "values": {
-        "t_tank_top": 28.2765,
-        "t_tank_bottom": 28.2759,
-        "t_collector": 24.939,
+        "t_tank_top": 28.1975,
+        "t_tank_bottom": 28.1969,
+        "t_collector": 24.9013,
         "t_greenhouse": 12.65,
         "t_outdoor": 11.3576
       },
@@ -7906,9 +7906,9 @@
     {
       "time": 43080,
       "values": {
-        "t_tank_top": 28.274,
-        "t_tank_bottom": 28.2735,
-        "t_collector": 24.7128,
+        "t_tank_top": 28.195,
+        "t_tank_bottom": 28.1945,
+        "t_collector": 24.6758,
         "t_greenhouse": 12.6197,
         "t_outdoor": 11.3365
       },
@@ -7917,9 +7917,9 @@
     {
       "time": 43140,
       "values": {
-        "t_tank_top": 28.2716,
-        "t_tank_bottom": 28.2711,
-        "t_collector": 24.4841,
+        "t_tank_top": 28.1926,
+        "t_tank_bottom": 28.1921,
+        "t_collector": 24.4477,
         "t_greenhouse": 12.5894,
         "t_outdoor": 11.3155
       },
@@ -7928,9 +7928,9 @@
     {
       "time": 43200,
       "values": {
-        "t_tank_top": 28.2691,
-        "t_tank_bottom": 28.2687,
-        "t_collector": 24.2528,
+        "t_tank_top": 28.1901,
+        "t_tank_bottom": 28.1897,
+        "t_collector": 24.2171,
         "t_greenhouse": 12.5591,
         "t_outdoor": 11.2944
       },
@@ -7940,33 +7940,33 @@
   "log_entries": [
     {
       "kind": "sim",
-      "time": 908,
-      "text": "idle → solar_charging | delta=10.0°C > 10°C threshold | T_coll=20.0 T_top=11.0 T_bot=10.0 T_gh=10.8 T_out=9.0",
+      "time": 401,
+      "text": "idle → solar_charging | delta=5.0°C > 10°C threshold | T_coll=14.6 T_top=11.4 T_bot=9.6 T_gh=10.9 T_out=8.8",
       "mode": "solar_charging"
     },
     {
       "kind": "sim",
-      "time": 1489,
-      "text": "solar_charging → idle | tank stopped rising (peak T_top=11.5°C, now 11.4°C, drop 0.1°C) | T_coll=12.1 T_top=11.4 T_bot=10.4 T_gh=10.7 T_out=9.2",
+      "time": 769,
+      "text": "solar_charging → idle | tank stopped rising (peak T_top=11.5°C, now 11.3°C, drop 0.2°C) | T_coll=11.6 T_top=11.3 T_bot=9.9 T_gh=10.8 T_out=9.0",
       "mode": "idle"
     },
     {
       "kind": "sim",
-      "time": 2157,
-      "text": "idle → solar_charging | delta=10.0°C > 10°C threshold | T_coll=20.7 T_top=11.1 T_bot=10.7 T_gh=10.8 T_out=9.5",
+      "time": 1058,
+      "text": "idle → solar_charging | delta=5.0°C > 10°C threshold | T_coll=15.1 T_top=11.1 T_bot=10.1 T_gh=10.8 T_out=9.1",
       "mode": "solar_charging"
     },
     {
       "kind": "sim",
-      "time": 38243,
-      "text": "solar_charging → idle | tank stopped rising (peak T_top=28.5°C, now 28.5°C, drop 0.0°C) | T_coll=28.9 T_top=28.5 T_bot=28.4 T_gh=14.9 T_out=12.9",
+      "time": 38263,
+      "text": "solar_charging → idle | tank stopped rising (peak T_top=28.5°C, now 28.5°C, drop 0.0°C) | T_coll=28.8 T_top=28.5 T_bot=28.3 T_gh=14.9 T_out=12.9",
       "mode": "idle"
     }
   ],
   "final_model_state": {
-    "t_tank_top": 28.2691,
-    "t_tank_bottom": 28.2687,
-    "t_collector": 24.2528,
+    "t_tank_top": 28.1901,
+    "t_tank_bottom": 28.1897,
+    "t_collector": 24.2171,
     "t_greenhouse": 12.5591,
     "t_outdoor": 11.2944,
     "irradiance": 0.0312,
@@ -7974,7 +7974,7 @@
   },
   "final_controller_state": {
     "currentMode": "idle",
-    "modeStartTime": 38243,
+    "modeStartTime": 38263,
     "collectorsDrained": false,
     "lastRefillAttempt": 0,
     "emergencyHeatingActive": false,

--- a/playground/js/main.js
+++ b/playground/js/main.js
@@ -1019,7 +1019,10 @@ function fetchLiveEvents(before) {
           text: formatLiveTransitionText(e.from, e.to),
           // cause/sensors may be null for pre-2026-04-20 rows or for
           // firmware that doesn't yet carry the transition cause.
+          // reason (added 2026-04-21) is the evaluator's decision code;
+          // null when the transition did not come from evaluate().
           cause: e.cause || null,
+          reason: e.reason || null,
           sensors: e.sensors || null,
         });
       }
@@ -1059,10 +1062,11 @@ function detectLiveTransition(result) {
     mode: mode,
     from: lastLiveMode,
     text: formatLiveTransitionText(lastLiveMode, mode),
-    // Carry cause + temps through from the state payload so the log
-    // can show them immediately, without waiting for a /api/events
+    // Carry cause + reason + temps through from the state payload so the
+    // log can show them immediately, without waiting for a /api/events
     // round-trip.
     cause: (result && result.cause) || null,
+    reason: (result && result.reason) || null,
     sensors: (result && result.temps) ? Object.assign({}, result.temps) : null,
   });
   lastLiveMode = mode;
@@ -1099,12 +1103,18 @@ function renderLogsList() {
       : t.mode === 'emergency_heating' ? 'log-dot-emergency' : 'log-dot-muted';
     const timeLabel = t.kind === 'live' ? formatClockTime(t.ts) : formatTimeOfDay(t.time);
     const causeChip = t.cause ? ' <span class="log-cause">' + escapeHtml(formatCauseLabel(t.cause)) + '</span>' : '';
+    // reason sits on its own line so operators can skim the cause chip
+    // row and dive into the decision code only when needed.
+    const reasonLine = t.reason
+      ? '<div class="log-reason">' + escapeHtml(formatReasonLabel(t.reason)) + '</div>'
+      : '';
     const sensorsLine = t.sensors ? '<div class="log-sensors">' + formatSensorsLine(t.sensors) + '</div>' : '';
     html += '<div class="log-item">' +
       '<div class="log-dot ' + dotClass + '"></div>' +
       '<div class="log-content">' +
         '<div class="log-title">' + escapeHtml(mi.label) + causeChip + '</div>' +
         '<div class="log-desc">' + escapeHtml(t.text || '') + '</div>' +
+        reasonLine +
         sensorsLine +
       '</div>' +
       '<div class="log-time">' + timeLabel + '</div>' +
@@ -1151,6 +1161,36 @@ const CAUSE_LABELS = {
 };
 function formatCauseLabel(c) {
   return CAUSE_LABELS[c] || c;
+}
+
+// Finer-grained decision codes from the evaluator (shelly/control-logic.js).
+// Paired with CAUSE_LABELS in the System Logs UI to turn a bare
+// "automation" tag into "Automation — solar stall". Keep the keys in
+// sync with the `reason` string set at each return path inside
+// evaluate().
+const REASON_LABELS = {
+  solar_enter: 'collector hot enough to charge',
+  solar_refill: 'refilling drained collectors',
+  solar_active: 'tank still gaining heat',
+  solar_stall: 'tank stopped gaining heat',
+  solar_drop_from_peak: 'tank cooling below peak',
+  overheat_circulate: 'collector overheat — circulating to cool',
+  overheat_drain: 'collector overheat — draining',
+  freeze_drain: 'freeze risk — draining',
+  drain_running: 'drain in progress',
+  drain_timeout: 'drain timeout fallback',
+  greenhouse_enter: 'greenhouse cold — heating',
+  greenhouse_active: 'greenhouse still cold',
+  greenhouse_warm: 'greenhouse warm enough',
+  greenhouse_tank_depleted: 'tank too cool to heat greenhouse',
+  emergency_enter: 'greenhouse critical — emergency heat',
+  sensor_stale: 'sensor reading stale',
+  watchdog_ban: 'mode blocked by watchdog',
+  min_duration: 'holding minimum run time',
+  idle: 'no trigger active',
+};
+function formatReasonLabel(r) {
+  return REASON_LABELS[r] || r;
 }
 
 // Render the temp snapshot as "coll 62.3° · tank 41/29° · gh 12° · out 8°"
@@ -1305,8 +1345,17 @@ function buildLogsClipboardText() {
       const timeLabel = t.kind === 'live'
         ? formatFullTimeHelsinki(t.ts)
         : formatTimeOfDay(t.time);
-      const causeSuffix = t.cause ? '  [' + t.cause + ']' : '';
+      // Header row carries cause and, when present, the evaluator's
+      // decision code in the form `[cause: reason]` so `grep` on a
+      // single bracketed pair still matches the cause.
+      let causeSuffix = '';
+      if (t.cause && t.reason) causeSuffix = '  [' + t.cause + ': ' + t.reason + ']';
+      else if (t.cause) causeSuffix = '  [' + t.cause + ']';
+      else if (t.reason) causeSuffix = '  [' + t.reason + ']';
       lines.push(timeLabel + '  ' + mi.label + '  ' + (t.text || '') + causeSuffix);
+      if (t.reason) {
+        lines.push('    reason: ' + formatReasonLabel(t.reason));
+      }
       if (t.sensors) {
         const s = t.sensors;
         const fmt = (v) => (typeof v === 'number' ? v.toFixed(1) + '°C' : '—');

--- a/playground/public/style.css
+++ b/playground/public/style.css
@@ -813,6 +813,15 @@ select, input, textarea { max-width: 100%; }
   font-variant-numeric: tabular-nums;
 }
 
+/* Evaluator decision reason (plain-English label from REASON_LABELS) */
+.log-reason {
+  font-size: 11px;
+  color: var(--on-surface-variant);
+  line-height: 1.4;
+  margin-top: 2px;
+  font-style: italic;
+}
+
 /* ── Critical Components ── */
 .components-grid {
   display: grid;

--- a/server/lib/db.js
+++ b/server/lib/db.js
@@ -118,6 +118,11 @@ var SCHEMA_SQL = [
   // stay NULL; the API maps NULL to null.
   "ALTER TABLE state_events ADD COLUMN IF NOT EXISTS cause TEXT",
   "ALTER TABLE state_events ADD COLUMN IF NOT EXISTS sensors JSONB",
+  // 2026-04-21: reason carries the evaluator's finer-grained decision
+  // code (solar_stall, freeze_drain, greenhouse_enter, ...) paired with
+  // cause. Null for non-evaluator transitions (user_shutdown, forced,
+  // drain_complete, failed) and for pre-2026-04-21 rows.
+  "ALTER TABLE state_events ADD COLUMN IF NOT EXISTS reason TEXT",
 
   // Shelly control-script crash log. Written by server/lib/script-monitor.js
   // when the 30-second Script.GetStatus poll first observes running:false
@@ -257,11 +262,12 @@ function insertSensorReadings(ts, temps, callback) {
   });
 }
 
-// Signature accepts an optional opts object {cause, sensors} so mode
-// rows can carry transition context (what triggered the change + sensor
-// snapshot at transition time). Valve/actuator writes omit opts and
-// store NULL in those columns. Positional signature preserved for
-// callers that don't need the extension.
+// Signature accepts an optional opts object {cause, reason, sensors} so
+// mode rows can carry transition context (what triggered the change,
+// the evaluator's decision code, and the sensor snapshot at transition
+// time). Valve/actuator writes omit opts and store NULL in those
+// columns. Positional signature preserved for callers that don't need
+// the extension.
 function insertStateEvent(ts, entityType, entityId, oldValue, newValue, optsOrCallback, maybeCallback) {
   var p = getPool();
   var opts, callback;
@@ -273,10 +279,11 @@ function insertStateEvent(ts, entityType, entityId, oldValue, newValue, optsOrCa
     callback = maybeCallback;
   }
   var cause = opts && opts.cause !== undefined ? opts.cause : null;
+  var reason = opts && opts.reason !== undefined ? opts.reason : null;
   var sensors = opts && opts.sensors !== undefined ? opts.sensors : null;
-  var sql = 'INSERT INTO state_events (ts, entity_type, entity_id, old_value, new_value, cause, sensors) ' +
-            'VALUES ($1, $2, $3, $4, $5, $6, $7)';
-  p.query(sql, [ts, entityType, entityId, oldValue, newValue, cause, sensors], function (err) {
+  var sql = 'INSERT INTO state_events (ts, entity_type, entity_id, old_value, new_value, cause, reason, sensors) ' +
+            'VALUES ($1, $2, $3, $4, $5, $6, $7, $8)';
+  p.query(sql, [ts, entityType, entityId, oldValue, newValue, cause, reason, sensors], function (err) {
     if (callback) callback(err || null);
   });
 }
@@ -396,7 +403,7 @@ function getEventsPaginated(entityType, limit, before, callback) {
   var fetchLimit = effLimit + 1;
 
   var params = [entityType];
-  var sql = 'SELECT ts, entity_type, entity_id, old_value, new_value, cause, sensors FROM state_events WHERE entity_type = $1';
+  var sql = 'SELECT ts, entity_type, entity_id, old_value, new_value, cause, reason, sensors FROM state_events WHERE entity_type = $1';
   if (before !== null && before !== undefined) {
     params.push(new Date(before));
     sql += ' AND ts < $' + params.length;
@@ -417,8 +424,10 @@ function getEventsPaginated(entityType, limit, before, callback) {
         from: row.old_value,
         to: row.new_value,
         // cause / sensors populated only for mode rows written after
-        // 2026-04-20. Older rows and valve/actuator rows carry null.
+        // 2026-04-20; reason added 2026-04-21. Older rows and
+        // valve/actuator rows carry null.
         cause: row.cause,
+        reason: row.reason,
         sensors: row.sensors,
       };
     });

--- a/server/lib/mqtt-bridge.js
+++ b/server/lib/mqtt-bridge.js
@@ -168,6 +168,10 @@ function detectStateChanges(ts, prev, curr, _db) {
   if (prev.mode !== curr.mode) {
     var modeOpts = {
       cause: (typeof curr.cause === 'string' && curr.cause) || null,
+      // reason is the evaluator's decision code (e.g. "solar_stall").
+      // Only meaningful when cause is "automation" or "safety_override";
+      // older payloads without the field store null.
+      reason: (typeof curr.reason === 'string' && curr.reason) || null,
       sensors: (curr.temps && typeof curr.temps === 'object') ? curr.temps : null,
     };
     d.insertStateEvent(ts, 'mode', 'mode', prev.mode, curr.mode, modeOpts, function (err) {

--- a/shelly/control-logic.js
+++ b/shelly/control-logic.js
@@ -83,7 +83,13 @@ var VALVE_TIMING = {
 };
 
 var DEFAULT_CONFIG = {
-  solarEnterDelta: 10,
+  // Collector must exceed tank_bottom by this many K to start a solar
+  // charging session. Raised from 5 → 10 in early testing to avoid
+  // short-cycle entries on marginal irradiance; lowered back to 5 on
+  // 2026-04-21 after logs showed the controller bypassing obvious
+  // charging opportunities (e.g. 40 °C collector vs 32 °C bottom was
+  // still below the 10 K bar).
+  solarEnterDelta: 5,
   // Solar charging exits when the tank has stopped accepting heat:
   //   - tank_top has not risen for solarExitStallSeconds, OR
   //   - tank_top has dropped solarExitTankDrop °C from the session peak
@@ -170,7 +176,7 @@ function shortCodeOf(mode) {
   return null;
 }
 
-function makeResult(mode, flags, deviceConfig, safetyOverride) {
+function makeResult(mode, flags, deviceConfig, safetyOverride, reason) {
   var valves = {};
   var actuators = {};
   var key;
@@ -188,7 +194,12 @@ function makeResult(mode, flags, deviceConfig, safetyOverride) {
     actuators: actuators,
     flags: flags,
     suppressed: false,
-    safetyOverride: !!safetyOverride
+    safetyOverride: !!safetyOverride,
+    // Reason code explaining which decision path the evaluator took this
+    // tick. The server copies it alongside state_events.cause so the
+    // System Logs UI can show "automation: solar_stall" instead of a
+    // bare "automation" tag. Null only for legacy/missing paths.
+    reason: reason || null
   };
   // Safety overrides (freeze drain, overheat drain) bypass all device config
   // suppression — they MUST actuate even when controls are disabled.
@@ -263,16 +274,16 @@ function evaluate(state, config, deviceConfig) {
     flags.emergencyHeatingActive = false;
     flags.solarChargePeakTankTop = null;
     flags.solarChargePeakTankTopAt = 0;
-    return makeResult(MODES.IDLE, flags, dc);
+    return makeResult(MODES.IDLE, flags, dc, false, "sensor_stale");
   }
 
   // Already draining — stay until shell completes or timeout
   if (state.currentMode === MODES.ACTIVE_DRAIN) {
     if (elapsed > cfg.drainTimeout) {
       flags.collectorsDrained = true;
-      return makeResult(MODES.IDLE, flags, dc);
+      return makeResult(MODES.IDLE, flags, dc, false, "drain_timeout");
     }
-    return makeResult(MODES.ACTIVE_DRAIN, flags, dc);
+    return makeResult(MODES.ACTIVE_DRAIN, flags, dc, false, "drain_running");
   }
 
   // Freeze protection — preempts immediately, ignores min duration
@@ -292,7 +303,7 @@ function evaluate(state, config, deviceConfig) {
       !state.collectorsDrained) {
     flags.solarChargePeakTankTop = null;
     flags.solarChargePeakTankTopAt = 0;
-    return makeResult(MODES.ACTIVE_DRAIN, flags, dc, true);
+    return makeResult(MODES.ACTIVE_DRAIN, flags, dc, true, "freeze_drain");
   }
 
   // Collector overheat protection — drain only as a last resort.
@@ -303,14 +314,14 @@ function evaluate(state, config, deviceConfig) {
       state.currentMode === MODES.SOLAR_CHARGING && !state.collectorsDrained) {
     flags.solarChargePeakTankTop = null;
     flags.solarChargePeakTankTopAt = 0;
-    return makeResult(MODES.ACTIVE_DRAIN, flags, dc, true);
+    return makeResult(MODES.ACTIVE_DRAIN, flags, dc, true, "overheat_drain");
   }
 
   // Minimum mode duration (not for IDLE or EMERGENCY_HEATING, not for drain above)
   if (state.currentMode !== MODES.IDLE &&
       state.currentMode !== MODES.EMERGENCY_HEATING &&
       elapsed < getMinDuration(state, cfg)) {
-    var result = makeResult(state.currentMode, flags, dc);
+    var result = makeResult(state.currentMode, flags, dc, false, "min_duration");
     // Emergency overlay still applies during min-duration hold
     if (t.greenhouse !== null && flags.emergencyHeatingActive) {
       result.actuators.space_heater = true;
@@ -335,6 +346,11 @@ function evaluate(state, config, deviceConfig) {
   // Solar charging has priority: free energy, time-limited (daylight only).
   // Greenhouse heating uses stored energy and can run any time.
   var pumpMode = MODES.IDLE;
+  // Decision reason for this tick. Updated as the evaluator progresses
+  // through the branches below; the final value is attached to the result
+  // and published with every state snapshot. See CAUSE_LABELS /
+  // REASON_LABELS for the stable, UI-mapped codes.
+  var reason = "idle";
 
   // Solar charging — capture free energy first
   if (t.collector !== null && t.tank_bottom !== null) {
@@ -358,12 +374,20 @@ function evaluate(state, config, deviceConfig) {
       }
       if (!stalled && !droppedFromPeak) {
         pumpMode = MODES.SOLAR_CHARGING;
+        reason = "solar_active";
+      } else if (droppedFromPeak) {
+        // droppedFromPeak wins over stalled when both are true — it's the
+        // more decisive signal (tank is actively cooling).
+        reason = "solar_drop_from_peak";
+      } else {
+        reason = "solar_stall";
       }
       // Otherwise fall through to IDLE / other modes
     } else if (!state.collectorsDrained) {
       // Normal solar entry — collector clearly hotter than tank bottom
       if (t.collector > t.tank_bottom + cfg.solarEnterDelta) {
         pumpMode = MODES.SOLAR_CHARGING;
+        reason = "solar_enter";
         if (t.tank_top !== null) {
           flags.solarChargePeakTankTop = t.tank_top;
           flags.solarChargePeakTankTopAt = state.now;
@@ -383,6 +407,7 @@ function evaluate(state, config, deviceConfig) {
           flags.collectorsDrained = false;
           flags.lastRefillAttempt = state.now;
           pumpMode = MODES.SOLAR_CHARGING;
+          reason = "solar_refill";
           if (t.tank_top !== null) {
             flags.solarChargePeakTankTop = t.tank_top;
             flags.solarChargePeakTankTopAt = state.now;
@@ -399,11 +424,19 @@ function evaluate(state, config, deviceConfig) {
       if (t.greenhouse <= cfg.greenhouseExitTemp &&
           t.tank_top >= t.greenhouse + cfg.greenhouseExitTankDelta) {
         pumpMode = MODES.GREENHOUSE_HEATING;
+        reason = "greenhouse_active";
+      } else if (t.greenhouse > cfg.greenhouseExitTemp) {
+        // Greenhouse crossed the warm-enough threshold — stop heating.
+        reason = "greenhouse_warm";
+      } else {
+        // Tank dropped below greenhouse + exit delta — no longer useful
+        // energy available (further pumping would cool via radiator).
+        reason = "greenhouse_tank_depleted";
       }
-      // Above exit temp or tank too close to greenhouse, fall through
     } else if (t.greenhouse < cfg.greenhouseEnterTemp &&
                t.tank_top > t.greenhouse + cfg.greenhouseMinTankDelta) {
       pumpMode = MODES.GREENHOUSE_HEATING;
+      reason = "greenhouse_enter";
     }
   }
 
@@ -413,6 +446,7 @@ function evaluate(state, config, deviceConfig) {
   if (t.collector !== null && t.collector > cfg.overheatDrainTemp &&
       !state.collectorsDrained && pumpMode !== MODES.SOLAR_CHARGING) {
     pumpMode = MODES.SOLAR_CHARGING;
+    reason = "overheat_circulate";
     if (t.tank_top !== null && flags.solarChargePeakTankTop === null) {
       flags.solarChargePeakTankTop = t.tank_top;
       flags.solarChargePeakTankTopAt = state.now;
@@ -430,12 +464,12 @@ function evaluate(state, config, deviceConfig) {
     // Emergency heating is also subject to wb
     if (dc && dc.wb && dc.wb.EH && dc.wb.EH > state.now) {
       flags.emergencyHeatingActive = false;
-      return makeResult(MODES.IDLE, flags, dc);
+      return makeResult(MODES.IDLE, flags, dc, false, "watchdog_ban");
     }
-    return makeResult(MODES.EMERGENCY_HEATING, flags, dc);
+    return makeResult(MODES.EMERGENCY_HEATING, flags, dc, false, "emergency_enter");
   }
 
-  var result = makeResult(pumpMode, flags, dc);
+  var result = makeResult(pumpMode, flags, dc, false, reason);
   if (flags.emergencyHeatingActive) {
     result.actuators.space_heater = true;
   }
@@ -448,7 +482,7 @@ function evaluate(state, config, deviceConfig) {
     if (natCode && dc.wb[natCode] && dc.wb[natCode] > state.now) {
       flags.solarChargePeakTankTop = null;
       flags.solarChargePeakTankTopAt = 0;
-      return makeResult(MODES.IDLE, flags, dc);
+      return makeResult(MODES.IDLE, flags, dc, false, "watchdog_ban");
     }
   }
 
@@ -750,7 +784,13 @@ function buildSnapshotFromState(st, dc, now) {
     // state_events.cause. One of: boot | automation | forced |
     // safety_override | watchdog_auto | user_shutdown | drain_complete
     // | failed.
-    cause: st.lastTransitionCause || "boot"
+    cause: st.lastTransitionCause || "boot",
+    // Finer-grained decision code from the evaluator (solar_enter,
+    // solar_stall, freeze_drain, greenhouse_enter, ...). Null when the
+    // transition was not produced by evaluate() — e.g. user_shutdown,
+    // drain_complete, failed. Written to state_events.reason on mode
+    // change. See REASON_LABELS in playground/js/main.js for UI mapping.
+    reason: st.lastTransitionReason || null
   };
 }
 

--- a/shelly/control.js
+++ b/shelly/control.js
@@ -115,6 +115,12 @@ var state = {
   //   records it alongside the mode-change row so the UI can show
   //   operators why the system changed state.
   lastTransitionCause: "boot",
+  // Finer-grained decision code from control-logic.evaluate() for the
+  // most recent automation/safety transition (e.g. "solar_stall",
+  // "freeze_drain", "greenhouse_enter"). Null when the transition was
+  // driven by a non-evaluator code path (user_shutdown, drain_complete,
+  // failed, boot). Published alongside lastTransitionCause.
+  lastTransitionReason: null,
 };
 
 // ── Actuator commands with config guards ──
@@ -599,6 +605,7 @@ function finalizeTransitionFail() {
   state.mode = MODES.IDLE;
   state.mode_start = Date.now();
   state.lastTransitionCause = "failed";
+  state.lastTransitionReason = null;
   captureWatchdogBaseline();
   state.transitioning = false;
   state.transition_step = null;
@@ -758,6 +765,12 @@ function transitionTo(result, cause) {
   // "drain_complete", "failed"). Default is "automation" for legacy
   // call sites that don't yet annotate themselves.
   if (cause) state.lastTransitionCause = cause;
+  // Pair the cause with the evaluator's finer-grained reason code when
+  // the transition came from evaluate(). Manual paths (drain_complete,
+  // user_shutdown, forced mode from the UI) pass results without a
+  // reason; clear the stored reason in that case so the published
+  // snapshot doesn't misattribute the transition.
+  state.lastTransitionReason = (result && result.reason) ? result.reason : null;
 
   if (state.transitioning) {
     // Allow in-place target change during an in-flight staged transition.

--- a/tests/control-logic.test.js
+++ b/tests/control-logic.test.js
@@ -25,11 +25,14 @@ describe('mode evaluation', () => {
     assert.strictEqual(result.nextMode, MODES.IDLE);
   });
 
-  it('enters SOLAR_CHARGING when collector > tank_bottom + 10', () => {
+  it('enters SOLAR_CHARGING when collector > tank_bottom + solarEnterDelta', () => {
+    // DEFAULT_CONFIG.solarEnterDelta = 5 K. collector 36 vs tank_bottom
+    // 30 gives a 6 K delta — above the new entry bar.
     const result = evaluate(makeState({
-      temps: { collector: 41, tank_top: 40, tank_bottom: 30, greenhouse: 15, outdoor: 10 }
+      temps: { collector: 36, tank_top: 40, tank_bottom: 30, greenhouse: 15, outdoor: 10 }
     }), null);
     assert.strictEqual(result.nextMode, MODES.SOLAR_CHARGING);
+    assert.strictEqual(result.reason, 'solar_enter');
   });
 
   it('enters GREENHOUSE_HEATING when greenhouse < 10 and tank has delta > 5', () => {
@@ -100,16 +103,18 @@ describe('mode evaluation', () => {
 });
 
 describe('hysteresis', () => {
-  it('enters solar charging at collector > tank_bottom + 10', () => {
+  it('enters solar charging at collector > tank_bottom + solarEnterDelta', () => {
     const result = evaluate(makeState({
-      temps: { collector: 41, tank_top: 40, tank_bottom: 30, greenhouse: 15, outdoor: 10 }
+      temps: { collector: 36, tank_top: 40, tank_bottom: 30, greenhouse: 15, outdoor: 10 }
     }), null);
     assert.strictEqual(result.nextMode, MODES.SOLAR_CHARGING);
+    assert.strictEqual(result.reason, 'solar_enter');
   });
 
-  it('does not enter solar at collector = tank_bottom + 10 (needs strictly greater)', () => {
+  it('does not enter solar at collector = tank_bottom + solarEnterDelta (needs strictly greater)', () => {
+    // delta exactly at threshold (5 K): 35 - 30 = 5. Must not enter.
     const result = evaluate(makeState({
-      temps: { collector: 40, tank_top: 40, tank_bottom: 30, greenhouse: 15, outdoor: 10 }
+      temps: { collector: 35, tank_top: 40, tank_bottom: 30, greenhouse: 15, outdoor: 10 }
     }), null);
     assert.strictEqual(result.nextMode, MODES.IDLE);
   });
@@ -1861,6 +1866,204 @@ describe('buildSnapshotFromState — US5 staged-transition fields', () => {
     assert.strictEqual(snap.valves.vo_coll, true);
     assert.strictEqual(snap.valves.vi_top, false);
     assert.strictEqual(snap.actuators.pump, true);
+  });
+});
+
+describe('evaluate() emits a decision reason for each path', () => {
+  function evalWith(overrides) {
+    return evaluate(makeState(overrides), null);
+  }
+
+  it('solar_enter when collector crosses tank_bottom + solarEnterDelta', () => {
+    const r = evalWith({
+      temps: { collector: 36, tank_top: 40, tank_bottom: 30, greenhouse: 15, outdoor: 10 }
+    });
+    assert.strictEqual(r.nextMode, MODES.SOLAR_CHARGING);
+    assert.strictEqual(r.reason, 'solar_enter');
+  });
+
+  it('solar_active while tank_top is still gaining heat', () => {
+    const r = evalWith({
+      temps: { collector: 50, tank_top: 42, tank_bottom: 30, greenhouse: 15, outdoor: 10 },
+      currentMode: MODES.SOLAR_CHARGING,
+      solarChargePeakTankTop: 40, solarChargePeakTankTopAt: 1500, now: 2000
+    });
+    assert.strictEqual(r.nextMode, MODES.SOLAR_CHARGING);
+    assert.strictEqual(r.reason, 'solar_active');
+  });
+
+  it('solar_stall when tank_top has not risen for solarExitStallSeconds', () => {
+    const r = evalWith({
+      temps: { collector: 50, tank_top: 40, tank_bottom: 30, greenhouse: 15, outdoor: 10 },
+      currentMode: MODES.SOLAR_CHARGING,
+      solarChargePeakTankTop: 40, solarChargePeakTankTopAt: 1700, now: 2000
+    });
+    assert.strictEqual(r.nextMode, MODES.IDLE);
+    assert.strictEqual(r.reason, 'solar_stall');
+  });
+
+  it('solar_drop_from_peak when tank_top falls solarExitTankDrop below peak', () => {
+    const r = evalWith({
+      temps: { collector: 50, tank_top: 38, tank_bottom: 30, greenhouse: 15, outdoor: 10 },
+      currentMode: MODES.SOLAR_CHARGING,
+      solarChargePeakTankTop: 40, solarChargePeakTankTopAt: 1900, now: 2000
+    });
+    assert.strictEqual(r.nextMode, MODES.IDLE);
+    assert.strictEqual(r.reason, 'solar_drop_from_peak');
+  });
+
+  it('freeze_drain when coldest sensor drops below freezeDrainTemp', () => {
+    const r = evalWith({
+      temps: { collector: -1, tank_top: 40, tank_bottom: 30, greenhouse: 15, outdoor: 5 }
+    });
+    assert.strictEqual(r.nextMode, MODES.ACTIVE_DRAIN);
+    assert.strictEqual(r.reason, 'freeze_drain');
+    assert.strictEqual(r.safetyOverride, true);
+  });
+
+  it('overheat_drain when collector > overheatDrainTemp during SOLAR_CHARGING', () => {
+    const r = evalWith({
+      temps: { collector: 96, tank_top: 90, tank_bottom: 80, greenhouse: 15, outdoor: 10 },
+      currentMode: MODES.SOLAR_CHARGING,
+      modeEnteredAt: 0, now: 100000
+    });
+    assert.strictEqual(r.nextMode, MODES.ACTIVE_DRAIN);
+    assert.strictEqual(r.reason, 'overheat_drain');
+  });
+
+  it('overheat_circulate forces SOLAR_CHARGING when collector is dangerously hot but solar entry did not fire', () => {
+    // tank_bottom already near boiling leaves the entry delta unsatisfied
+    // (96 is not > 95 + 5). The overheat_circulate override still fires so
+    // the pump dumps heat rather than letting the collector boil.
+    const r = evalWith({
+      temps: { collector: 96, tank_top: 90, tank_bottom: 95, greenhouse: 15, outdoor: 10 }
+    });
+    assert.strictEqual(r.nextMode, MODES.SOLAR_CHARGING);
+    assert.strictEqual(r.reason, 'overheat_circulate');
+  });
+
+  it('greenhouse_enter when greenhouse is cold and tank has delta', () => {
+    const r = evalWith({
+      temps: { collector: 20, tank_top: 40, tank_bottom: 30, greenhouse: 9, outdoor: 10 }
+    });
+    assert.strictEqual(r.nextMode, MODES.GREENHOUSE_HEATING);
+    assert.strictEqual(r.reason, 'greenhouse_enter');
+  });
+
+  it('greenhouse_active while in GH and not yet at exit', () => {
+    const r = evalWith({
+      temps: { collector: 20, tank_top: 40, tank_bottom: 30, greenhouse: 11, outdoor: 10 },
+      currentMode: MODES.GREENHOUSE_HEATING,
+      modeEnteredAt: 0, now: 2000
+    });
+    assert.strictEqual(r.nextMode, MODES.GREENHOUSE_HEATING);
+    assert.strictEqual(r.reason, 'greenhouse_active');
+  });
+
+  it('greenhouse_warm when greenhouse crosses exit temp', () => {
+    const r = evalWith({
+      temps: { collector: 20, tank_top: 40, tank_bottom: 30, greenhouse: 13, outdoor: 10 },
+      currentMode: MODES.GREENHOUSE_HEATING,
+      modeEnteredAt: 0, now: 2000
+    });
+    assert.strictEqual(r.nextMode, MODES.IDLE);
+    assert.strictEqual(r.reason, 'greenhouse_warm');
+  });
+
+  it('greenhouse_tank_depleted when tank drops below greenhouse + exit delta', () => {
+    const r = evalWith({
+      temps: { collector: 5, tank_top: 12, tank_bottom: 10, greenhouse: 11, outdoor: 10 },
+      currentMode: MODES.GREENHOUSE_HEATING,
+      modeEnteredAt: 0, now: 2000,
+      collectorsDrained: true
+    });
+    assert.strictEqual(r.nextMode, MODES.IDLE);
+    assert.strictEqual(r.reason, 'greenhouse_tank_depleted');
+  });
+
+  it('emergency_enter when greenhouse is critically cold and pump mode is IDLE', () => {
+    const r = evalWith({
+      temps: { collector: 5, tank_top: 12, tank_bottom: 10, greenhouse: 8, outdoor: -5 },
+      collectorsDrained: true
+    });
+    assert.strictEqual(r.nextMode, MODES.EMERGENCY_HEATING);
+    assert.strictEqual(r.reason, 'emergency_enter');
+  });
+
+  it('sensor_stale forces IDLE with reason sensor_stale', () => {
+    const r = evaluate(makeState({
+      temps: { collector: 41, tank_top: 40, tank_bottom: 30, greenhouse: 15, outdoor: 10 },
+      sensorAge: { collector: 999, tank_top: 0, tank_bottom: 0, greenhouse: 0, outdoor: 0 }
+    }), null);
+    assert.strictEqual(r.nextMode, MODES.IDLE);
+    assert.strictEqual(r.reason, 'sensor_stale');
+  });
+
+  it('min_duration when a non-IDLE mode is within its hold window', () => {
+    // 30s into a SOLAR_CHARGING session, min duration is 300s → hold.
+    const r = evalWith({
+      temps: { collector: 50, tank_top: 40, tank_bottom: 30, greenhouse: 15, outdoor: 10 },
+      currentMode: MODES.SOLAR_CHARGING,
+      modeEnteredAt: 1970, now: 2000,
+      solarChargePeakTankTop: 40, solarChargePeakTankTopAt: 1970
+    });
+    assert.strictEqual(r.nextMode, MODES.SOLAR_CHARGING);
+    assert.strictEqual(r.reason, 'min_duration');
+  });
+
+  it('drain_running while still inside an ACTIVE_DRAIN', () => {
+    const r = evalWith({
+      temps: { collector: 5, tank_top: 40, tank_bottom: 30, greenhouse: 15, outdoor: 5 },
+      currentMode: MODES.ACTIVE_DRAIN,
+      modeEnteredAt: 1900, now: 2000
+    });
+    assert.strictEqual(r.nextMode, MODES.ACTIVE_DRAIN);
+    assert.strictEqual(r.reason, 'drain_running');
+  });
+
+  it('watchdog_ban when evaluator chose a mode that is banned', () => {
+    const dc = { ce: true, wb: { SC: 9999999999 } };
+    const r = evaluate(makeState({
+      temps: { collector: 50, tank_top: 40, tank_bottom: 30, greenhouse: 15, outdoor: 10 }
+    }), null, dc);
+    assert.strictEqual(r.nextMode, MODES.IDLE);
+    assert.strictEqual(r.reason, 'watchdog_ban');
+  });
+
+  it('idle when no trigger is active', () => {
+    const r = evalWith({});
+    assert.strictEqual(r.nextMode, MODES.IDLE);
+    assert.strictEqual(r.reason, 'idle');
+  });
+});
+
+describe('buildSnapshotFromState exposes reason alongside cause', () => {
+  function baseState() {
+    return {
+      mode: MODES.IDLE, mode_start: 0, transitioning: false, transition_step: null,
+      temps: { collector: 20, tank_top: 40, tank_bottom: 30, greenhouse: 15, outdoor: 10 },
+      valve_states: {}, pump_on: false, fan_on: false, space_heater_on: false, immersion_heater_on: false,
+      collectors_drained: false, emergency_heating_active: false,
+      valveOpening: {}, valveOpenSince: {}, valvePendingOpen: [], valvePendingClose: [],
+    };
+  }
+  const dc = { ce: true, mo: null };
+
+  it('publishes null reason when lastTransitionReason is unset', () => {
+    const st = baseState();
+    st.lastTransitionCause = 'boot';
+    const snap = buildSnapshotFromState(st, dc, 123);
+    assert.strictEqual(snap.cause, 'boot');
+    assert.strictEqual(snap.reason, null);
+  });
+
+  it('publishes the stashed reason', () => {
+    const st = baseState();
+    st.lastTransitionCause = 'automation';
+    st.lastTransitionReason = 'solar_stall';
+    const snap = buildSnapshotFromState(st, dc, 123);
+    assert.strictEqual(snap.cause, 'automation');
+    assert.strictEqual(snap.reason, 'solar_stall');
   });
 });
 

--- a/tests/db.test.js
+++ b/tests/db.test.js
@@ -109,14 +109,14 @@ describe('db module', () => {
       assert.ifError(err);
       const insertQ = capturedQueries.find(q => q.sql && q.sql.includes('INSERT INTO state_events'));
       assert.ok(insertQ);
-      // cause + sensors default to null when not supplied (e.g. valve/
-      // actuator rows, or mode rows from pre-2026-04-20 firmware).
-      assert.deepStrictEqual(insertQ.params, [ts, 'mode', 'mode', 'idle', 'solar_charging', null, null]);
+      // cause + reason + sensors default to null when not supplied
+      // (valve/actuator rows, or mode rows from pre-2026-04-21 firmware).
+      assert.deepStrictEqual(insertQ.params, [ts, 'mode', 'mode', 'idle', 'solar_charging', null, null, null]);
       done();
     });
   });
 
-  it('insertStateEvent persists cause and sensors from opts', (t, done) => {
+  it('insertStateEvent persists cause, reason, and sensors from opts', (t, done) => {
     process.env.DATABASE_URL = 'postgres://test:test@localhost/test';
     db._reset();
     delete require.cache[require.resolve('../server/lib/db.js')];
@@ -125,11 +125,12 @@ describe('db module', () => {
     const ts = new Date();
     const sensors = { collector: 62.3, tank_top: 41, tank_bottom: 29, greenhouse: 12, outdoor: 8 };
     db.insertStateEvent(ts, 'mode', 'mode', 'idle', 'solar_charging',
-      { cause: 'automation', sensors }, function (err) {
+      { cause: 'automation', reason: 'solar_enter', sensors }, function (err) {
         assert.ifError(err);
         const insertQ = capturedQueries.find(q => q.sql && q.sql.includes('INSERT INTO state_events'));
         assert.ok(insertQ);
-        assert.deepStrictEqual(insertQ.params, [ts, 'mode', 'mode', 'idle', 'solar_charging', 'automation', sensors]);
+        assert.deepStrictEqual(insertQ.params,
+          [ts, 'mode', 'mode', 'idle', 'solar_charging', 'automation', 'solar_enter', sensors]);
         done();
       });
   });

--- a/tests/e2e/sensor-errors.spec.js
+++ b/tests/e2e/sensor-errors.spec.js
@@ -54,6 +54,12 @@ test.describe('Sensor view does not auto-scan', () => {
   });
 
   test('no periodic polling happens while view is open', async ({ page }) => {
+    // Explicit 10s budget: the assertion needs 4 s of real waits (1 s post-
+    // click + 3 s to prove no interval polling fires) on top of the page
+    // load. The 5 s global timeout in playwright.config.js left this test
+    // routinely sitting ~200 ms below the limit on developer machines and
+    // tipping over under CI worker contention.
+    test.setTimeout(10000);
     let discoveryCallCount = 0;
     await page.route('**/api/sensor-config', async (route) => {
       await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(sensorConfigResponse) });

--- a/tests/mqtt-bridge.test.js
+++ b/tests/mqtt-bridge.test.js
@@ -39,7 +39,7 @@ describe('mqtt-bridge', () => {
       assert.strictEqual(events[0].newVal, 'solar_charging');
     });
 
-    it('records cause and sensor snapshot for mode changes', () => {
+    it('records cause, reason, and sensor snapshot for mode changes', () => {
       const events = [];
       const mockDb = {
         insertStateEvent: function (ts, type, id, oldVal, newVal, optsOrCb, maybeCb) {
@@ -54,6 +54,7 @@ describe('mqtt-bridge', () => {
       const curr = {
         mode: 'solar_charging',
         cause: 'automation',
+        reason: 'solar_enter',
         temps: { collector: 62.3, tank_top: 41, tank_bottom: 29, greenhouse: 12, outdoor: 8 },
         valves: {}, actuators: {},
       };
@@ -62,11 +63,12 @@ describe('mqtt-bridge', () => {
       const modeEvt = events.find(e => e.type === 'mode');
       assert.ok(modeEvt);
       assert.strictEqual(modeEvt.opts.cause, 'automation');
+      assert.strictEqual(modeEvt.opts.reason, 'solar_enter');
       assert.deepStrictEqual(modeEvt.opts.sensors,
         { collector: 62.3, tank_top: 41, tank_bottom: 29, greenhouse: 12, outdoor: 8 });
     });
 
-    it('null-fills cause and sensors when the state payload lacks them (old firmware)', () => {
+    it('null-fills cause, reason, and sensors when the state payload lacks them (old firmware)', () => {
       const events = [];
       const mockDb = {
         insertStateEvent: function (ts, type, id, oldVal, newVal, optsOrCb, maybeCb) {
@@ -82,6 +84,7 @@ describe('mqtt-bridge', () => {
       bridge.detectStateChanges(new Date(), prev, curr, mockDb);
       const modeEvt = events.find(e => e.type === 'mode');
       assert.strictEqual(modeEvt.opts.cause, null);
+      assert.strictEqual(modeEvt.opts.reason, null);
       assert.strictEqual(modeEvt.opts.sensors, null);
     });
 


### PR DESCRIPTION
## Summary

Two coupled changes driven by logs showing the controller bypassing a clear charging opportunity (collector 40 °C vs tank_bottom 32 °C) at 12:01:58 on 2026-04-20.

**1. Per-transition reason code.** `evaluate()` now tags every return path with a stable machine-readable code (`solar_enter`, `solar_stall`, `solar_drop_from_peak`, `overheat_circulate`, `overheat_drain`, `freeze_drain`, `greenhouse_enter`, `greenhouse_active`, `greenhouse_warm`, `greenhouse_tank_depleted`, `emergency_enter`, `drain_running`, `drain_timeout`, `min_duration`, `sensor_stale`, `watchdog_ban`, `idle`). It rides through:

- `shelly/control.js` stashes `result.reason` on `state.lastTransitionReason`
- `buildSnapshotFromState` publishes it in every MQTT state snapshot alongside `cause`
- `server/lib/mqtt-bridge.js` extracts it on mode change and passes `opts.reason` through
- `server/lib/db.js` adds a `reason TEXT` column to `state_events` (backfills null) and the `/api/events` feed returns it
- `playground/js/main.js` stores it on each log entry, renders a plain-English line under the cause chip, and includes it in the clipboard export as `[automation: solar_stall]` + `reason: tank stopped gaining heat`

`REASON_LABELS` in `playground/js/main.js` owns the code → label mapping.

**2. `solarEnterDelta` 10 K → 5 K.** The 12:01:58 sample above never cleared the old 10 K bar even though the tank was still gaining heat. 5 K lets those marginal mid-morning sessions start.

## Test plan

- [x] `npm run test:unit` — 738 / 738 pass. Added 16 reason-path assertions + boundary-value update in `control-logic.test.js`, extended `db.test.js` and `mqtt-bridge.test.js` for the new column.
- [x] `npx playwright test tests/e2e/live-logs.spec.js tests/e2e/copy-logs.spec.js` — 15 / 15 pass.
- [x] Regenerated `playground/assets/bootstrap-history.json` so the snapshot-drift guard stays green.
- [x] Extended the tight-budget `sensor-errors.spec.js::no periodic polling happens while view is open` test to 10 s — the test hard-sleeps for 4 s inside a 5 s global timeout and was ~200 ms below the line; the slightly larger playground bundle tipped it over on CI workers (see commit `51bd820`).

https://claude.ai/code/session_01EgzeQiHb9A4WLXBgMvn2PL