### PR TITLE
deploy: name Shelly devices + switches on deploy, temp sensors on role apply

### DIFF
--- a/server/lib/sensor-apply.js
+++ b/server/lib/sensor-apply.js
@@ -93,16 +93,24 @@ async function waitForHubReady(host, timeoutMs) {
   return false;
 }
 
-function buildTargetMap(hosts, assignments) {
-  // Returns { hostIp: { cid: { addr, role }, ... }, ... }.
+function buildTargetMap(hosts, assignments, roleLabels) {
+  // Returns { hostIp: { cid: { addr, role, label }, ... }, ... }.
+  // `label` is the human-readable role label (e.g. "Tank Top") that the
+  // Shelly app shows as the Temperature component name. Falls back to the
+  // role key if no label is supplied.
   const byHost = {};
+  const labels = roleLabels || {};
   for (const role in assignments) {
     const a = assignments[role];
     if (!a || !a.addr) continue;
     const h = hosts[a.hostIndex];
     if (!h || !h.ip) continue;
     if (!byHost[h.ip]) byHost[h.ip] = {};
-    byHost[h.ip][String(a.componentId)] = { addr: a.addr, role: role };
+    byHost[h.ip][String(a.componentId)] = {
+      addr: a.addr,
+      role: role,
+      label: labels[role] || role,
+    };
   }
   return byHost;
 }
@@ -162,7 +170,12 @@ async function applyHost(hostIp, target) {
     }
   }
 
-  // Phase 2 — add all target peripherals with explicit cid + addr.
+  // Phase 2 — add all target peripherals with explicit cid + addr, and
+  // immediately name each Temperature component after its role (e.g.
+  // "Tank Top"). SetConfig persists even before the Temperature.GetStatus
+  // handlers register, so the label survives the phase-3 reboot.
+  // Naming failures are non-fatal: the peripheral is bound, the routing
+  // works, only the app-side label is missing.
   for (const cid of Object.keys(target)) {
     const t = target[cid];
     try {
@@ -173,6 +186,17 @@ async function applyHost(hostIp, target) {
       added++;
     } catch (e) {
       errors.push('add ' + t.role + ' (cid ' + cid + ', addr ' + t.addr + '): ' + e.message);
+      continue;
+    }
+    try {
+      await httpRpc(hostIp, 'Temperature.SetConfig', {
+        id: parseInt(cid, 10),
+        config: { name: t.label },
+      });
+    } catch (e) {
+      log.warn('failed to label temperature component', {
+        host: hostIp, cid: cid, role: t.role, error: e.message,
+      });
     }
   }
 
@@ -191,8 +215,8 @@ async function applyHost(hostIp, target) {
   return out;
 }
 
-async function applyAll(hosts, assignments) {
-  const targetByHost = buildTargetMap(hosts, assignments);
+async function applyAll(hosts, assignments, roleLabels) {
+  const targetByHost = buildTargetMap(hosts, assignments, roleLabels);
   const ips = hosts.map(function (h) { return h.ip; });
   const results = await Promise.all(ips.map(function (ip) {
     return applyHost(ip, targetByHost[ip] || {}).catch(function (e) {
@@ -206,8 +230,8 @@ async function applyAll(hosts, assignments) {
   };
 }
 
-async function applyOne(hosts, assignments, hostIp) {
-  const targetByHost = buildTargetMap(hosts, assignments);
+async function applyOne(hosts, assignments, hostIp, roleLabels) {
+  const targetByHost = buildTargetMap(hosts, assignments, roleLabels);
   const result = await applyHost(hostIp, targetByHost[hostIp] || {});
   return { id: 'apply-' + Date.now(), success: result.ok, results: [result] };
 }

--- a/server/lib/sensor-config.js
+++ b/server/lib/sensor-config.js
@@ -276,6 +276,16 @@ function toCompactFormat(config) {
 
 var sensorApply = require('./sensor-apply');
 
+// Role → human-readable label map, used by sensor-apply to name each
+// Temperature component in the Shelly app when roles are applied.
+function buildRoleLabels() {
+  var labels = {};
+  for (var i = 0; i < SENSOR_ROLES.length; i++) {
+    labels[SENSOR_ROLES[i].name] = SENSOR_ROLES[i].label;
+  }
+  return labels;
+}
+
 function formatHostResult(config, r) {
   var hostInfo = config.hosts.find(function (h) { return h.ip === r.host; });
   var hostId = hostInfo ? hostInfo.id : r.host;
@@ -293,7 +303,7 @@ function applyConfig(mqttBridge, callback) {
   var config = getConfig();
   var compact = toCompactFormat(config);
 
-  sensorApply.applyAll(config.hosts, config.assignments).then(function (result) {
+  sensorApply.applyAll(config.hosts, config.assignments, buildRoleLabels()).then(function (result) {
     var results = {};
     for (var i = 0; i < result.results.length; i++) {
       var f = formatHostResult(config, result.results[i]);
@@ -348,7 +358,7 @@ function applySingleTarget(targetId, mqttBridge, callback) {
     return;
   }
 
-  sensorApply.applyOne(config.hosts, config.assignments, host.ip).then(function (result) {
+  sensorApply.applyOne(config.hosts, config.assignments, host.ip, buildRoleLabels()).then(function (result) {
     var results = {};
     if (result.results && result.results[0]) {
       var f = formatHostResult(config, result.results[0]);

--- a/shelly/deploy.sh
+++ b/shelly/deploy.sh
@@ -9,6 +9,11 @@ CONF="$SCRIPT_DIR/devices.conf"
 LOGIC_JS="$SCRIPT_DIR/control-logic.js"
 CONTROL_JS="$SCRIPT_DIR/control.js"
 
+# Track whether deploy was called with an explicit device IP. When the user
+# targets a single device (e.g. for testing), we skip the multi-device naming
+# phase — it would touch unrelated devices they didn't ask about.
+USER_TARGET="${1:-}"
+
 if [ ! -f "$CONF" ]; then
   echo "Error: $CONF not found" >&2
   exit 1
@@ -186,6 +191,98 @@ if [ -n "${MQTT_BROKER_HOST:-}" ]; then
     -H "Content-Type: application/json" \
     -d "{\"config\":{\"enable\":true,\"server\":\"$MQTT_BROKER_HOST:${MQTT_BROKER_PORT:-1883}\"}}" > /dev/null
   echo "MQTT configured — device may reboot to apply"
+fi
+
+# ── Device + channel naming ──
+# Sets the device-level name (shown in Shelly app under "All Devices") and
+# per-relay labels, all derived from the hardware layout in system.yaml.
+# Cosmetic only: failures are logged but never abort deployment. Skipped when
+# the user targets a specific device (USER_TARGET set), since naming iterates
+# across devices they may not have intended to touch.
+#
+# Temperature sensor (DS18B20) naming happens in server/lib/sensor-apply.js
+# at role-assignment time, not here — the role→sensor mapping changes at
+# runtime and has no meaning at deploy time.
+set_device_name() {
+  local device_ip="$1" device_name="$2"
+  if curl -sf -m 5 -X POST "http://$device_ip/rpc/Sys.SetConfig" \
+      -H "Content-Type: application/json" \
+      -d "{\"config\":{\"device\":{\"name\":\"$device_name\"}}}" > /dev/null 2>&1; then
+    echo "  device name: $device_name"
+  else
+    echo "  WARN: could not set device name on $device_ip (skipping)" >&2
+  fi
+}
+
+set_switch_name() {
+  local device_ip="$1" switch_id="$2" switch_name="$3"
+  if curl -sf -m 5 -X POST "http://$device_ip/rpc/Switch.SetConfig" \
+      -H "Content-Type: application/json" \
+      -d "{\"id\":$switch_id,\"config\":{\"name\":\"$switch_name\"}}" > /dev/null 2>&1; then
+    echo "  switch:$switch_id: $switch_name"
+  else
+    echo "  WARN: could not set switch:$switch_id name on $device_ip" >&2
+  fi
+}
+
+apply_device_names() {
+  # Pro 4PM — main controller. Switch IDs match control.js setActuators mapping.
+  if [ -n "${PRO4PM:-}" ]; then
+    echo "Pro 4PM @ $PRO4PM:"
+    set_device_name  "$PRO4PM" "GH Controller"
+    set_switch_name  "$PRO4PM" 0 "Pump"
+    set_switch_name  "$PRO4PM" 1 "Fan"
+    set_switch_name  "$PRO4PM" 2 "Heater (immersion)"
+    set_switch_name  "$PRO4PM" 3 "Heater (space)"
+  fi
+
+  # Pro 2PM units — valve controllers. Switch IDs match VALVES in control.js.
+  if [ -n "${PRO2PM_1:-}" ]; then
+    echo "Pro 2PM #1 @ $PRO2PM_1:"
+    set_device_name  "$PRO2PM_1" "GH Valves 1 (input low)"
+    set_switch_name  "$PRO2PM_1" 0 "VI-btm"
+    set_switch_name  "$PRO2PM_1" 1 "VI-top"
+  fi
+  if [ -n "${PRO2PM_2:-}" ]; then
+    echo "Pro 2PM #2 @ $PRO2PM_2:"
+    set_device_name  "$PRO2PM_2" "GH Valves 2 (input/coll)"
+    set_switch_name  "$PRO2PM_2" 0 "VI-coll"
+    set_switch_name  "$PRO2PM_2" 1 "VO-coll"
+  fi
+  if [ -n "${PRO2PM_3:-}" ]; then
+    echo "Pro 2PM #3 @ $PRO2PM_3:"
+    set_device_name  "$PRO2PM_3" "GH Valves 3 (output)"
+    set_switch_name  "$PRO2PM_3" 0 "VO-rad"
+    set_switch_name  "$PRO2PM_3" 1 "VO-tank"
+  fi
+  if [ -n "${PRO2PM_4:-}" ]; then
+    echo "Pro 2PM #4 @ $PRO2PM_4:"
+    set_device_name  "$PRO2PM_4" "GH Valves 4 (collector top)"
+    set_switch_name  "$PRO2PM_4" 0 "V-air"
+    # switch 1 = reserved spare (spec 024 removed the collector-top return valve).
+    # Left unnamed so any future manual label in the Shelly app survives deploys.
+  fi
+  if [ -n "${PRO2PM_5:-}" ]; then
+    echo "Pro 2PM #5 @ $PRO2PM_5:"
+    set_device_name  "$PRO2PM_5" "GH Valves 5 (spare)"
+  fi
+
+  # Sensor hubs (Plus 1 + Add-on). Device-level name only; temperature
+  # components are named by sensor-apply when roles are assigned.
+  if [ -n "${SENSOR_1:-}" ]; then
+    echo "Sensor hub 1 @ $SENSOR_1:"
+    set_device_name  "$SENSOR_1" "GH Sensors 1"
+  fi
+  if [ -n "${SENSOR_2:-}" ]; then
+    echo "Sensor hub 2 @ $SENSOR_2:"
+    set_device_name  "$SENSOR_2" "GH Sensors 2"
+  fi
+}
+
+if [ "${DEPLOY_SET_NAMES:-true}" = "true" ] && [ -z "$USER_TARGET" ]; then
+  echo ""
+  echo "Applying device names..."
+  apply_device_names
 fi
 
 echo ""

--- a/tests/deploy.test.js
+++ b/tests/deploy.test.js
@@ -30,9 +30,9 @@ process.on('exit', () => {
   try { fs.writeFileSync(CONF_PATH, ORIGINAL_CONF); } catch (_) {}
 });
 
-function runDeploy(ip, scriptId) {
+function spawnDeploy(args) {
   return new Promise((resolve, reject) => {
-    const child = spawn('bash', [DEPLOY_SH, ip, String(scriptId)], {
+    const child = spawn('bash', [DEPLOY_SH, ...args], {
       cwd: SCRIPTS_DIR,
       env: { ...process.env, DEPLOY_STOP_DELAY: '0' },
       stdio: ['pipe', 'pipe', 'pipe'],
@@ -50,6 +50,18 @@ function runDeploy(ip, scriptId) {
       resolve({ code, stdout, stderr });
     });
   });
+}
+
+// Run deploy.sh with no argument so it takes the full default path
+// (USER_TARGET=""), which includes the multi-device naming phase.
+function runDeployNoArg() {
+  return spawnDeploy([]);
+}
+
+// Run deploy.sh with an explicit target IP. This path skips the naming
+// phase — matching the real-world behavior of "rename only on full deploys."
+function runDeploy(ip) {
+  return spawnDeploy([ip]);
 }
 
 function createMockServer(handler) {
@@ -82,6 +94,9 @@ function createMockServer(handler) {
     } else if (url.includes('Script.Start')) {
       res.writeHead(200, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ was_running: false }));
+    } else if (url.includes('Sys.SetConfig') || url.includes('Switch.SetConfig')) {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ restart_required: false }));
     } else {
       res.writeHead(404);
       res.end('Not found');
@@ -118,10 +133,24 @@ describe('deploy.sh', () => {
         resolve();
       });
     });
-    fs.writeFileSync(CONF_PATH,
-      `PRO4PM=127.0.0.1:${port}\nPRO2PM_1=127.0.0.1\nSENSOR=127.0.0.1\nPRO4PM_VPN=127.0.0.1:${port}\n`
-    );
-    deployResult = await runDeploy(`127.0.0.1:${port}`, 1);
+    // Point every device at the mock so the naming phase exercises real
+    // RPC calls against it. deploy.sh skips naming when a specific device
+    // IP is passed as $1, so the main "deployResult" run (below) passes no
+    // argument and targets PRO4PM implicitly — exercising the full path.
+    const addr = `127.0.0.1:${port}`;
+    fs.writeFileSync(CONF_PATH, [
+      `PRO4PM=${addr}`,
+      `PRO2PM_1=${addr}`,
+      `PRO2PM_2=${addr}`,
+      `PRO2PM_3=${addr}`,
+      `PRO2PM_4=${addr}`,
+      `PRO2PM_5=${addr}`,
+      `SENSOR_1=${addr}`,
+      `SENSOR_2=${addr}`,
+      `PRO4PM_VPN=${addr}`,
+      '',
+    ].join('\n'));
+    deployResult = await runDeployNoArg();
   });
 
   after(async () => {
@@ -231,6 +260,120 @@ describe('deploy.sh', () => {
     assert.strictEqual(putCalls.length, 0,
       'No id=2 PutCode should occur after the telemetry merge');
   });
+
+  // Device + channel naming phase. The deploy run in before() was launched
+  // with no arg so naming executes against every device in devices.conf
+  // (all pointed at the mock). Naming ordering is not asserted — it runs
+  // after MQTT config, which runs after script upload.
+  it('names the Pro 4PM and its four switches with meaningful labels', () => {
+    const sysCalls = mock.calls.filter(c => c.url.includes('Sys.SetConfig'));
+    assert.ok(sysCalls.length >= 1, 'should call Sys.SetConfig at least once');
+    const deviceNames = sysCalls
+      .map(c => { try { return JSON.parse(c.body).config.device.name; } catch (_) { return null; } })
+      .filter(Boolean);
+    assert.ok(deviceNames.includes('GH Controller'),
+      'Pro 4PM should be named "GH Controller", got: ' + deviceNames.join(', '));
+
+    const switchCalls = mock.calls.filter(c => c.url.includes('Switch.SetConfig'));
+    const switchNames = {};
+    for (const c of switchCalls) {
+      try {
+        const p = JSON.parse(c.body);
+        switchNames[p.id] = (switchNames[p.id] || []).concat(p.config.name);
+      } catch (_) { /* ignore */ }
+    }
+    assert.ok((switchNames[0] || []).includes('Pump'), 'switch 0 should include "Pump"');
+    assert.ok((switchNames[1] || []).includes('Fan'), 'switch 1 should include "Fan"');
+    assert.ok((switchNames[2] || []).includes('Heater (immersion)'),
+      'switch 2 should include "Heater (immersion)"');
+    assert.ok((switchNames[3] || []).includes('Heater (space)'),
+      'switch 3 should include "Heater (space)"');
+  });
+
+  it('names every Pro 2PM valve controller with role-specific labels', () => {
+    const sysCalls = mock.calls.filter(c => c.url.includes('Sys.SetConfig'));
+    const deviceNames = sysCalls
+      .map(c => { try { return JSON.parse(c.body).config.device.name; } catch (_) { return null; } })
+      .filter(Boolean);
+    for (const expected of [
+      'GH Valves 1 (input low)',
+      'GH Valves 2 (input/coll)',
+      'GH Valves 3 (output)',
+      'GH Valves 4 (collector top)',
+      'GH Valves 5 (spare)',
+    ]) {
+      assert.ok(deviceNames.includes(expected),
+        `expected device name "${expected}", got: ${deviceNames.join(', ')}`);
+    }
+
+    const switchCalls = mock.calls.filter(c => c.url.includes('Switch.SetConfig'));
+    const switchNamesSeen = new Set();
+    for (const c of switchCalls) {
+      try { switchNamesSeen.add(JSON.parse(c.body).config.name); } catch (_) { /* ignore */ }
+    }
+    for (const expected of ['VI-btm', 'VI-top', 'VI-coll', 'VO-coll', 'VO-rad', 'VO-tank', 'V-air']) {
+      assert.ok(switchNamesSeen.has(expected),
+        `expected valve label "${expected}" in switch names, got: ${[...switchNamesSeen].join(', ')}`);
+    }
+  });
+
+  it('names both sensor hubs at the device level only (no switch rename)', () => {
+    const sysCalls = mock.calls.filter(c => c.url.includes('Sys.SetConfig'));
+    const deviceNames = sysCalls
+      .map(c => { try { return JSON.parse(c.body).config.device.name; } catch (_) { return null; } })
+      .filter(Boolean);
+    assert.ok(deviceNames.includes('GH Sensors 1'), 'sensor hub 1 should be named');
+    assert.ok(deviceNames.includes('GH Sensors 2'), 'sensor hub 2 should be named');
+  });
+});
+
+describe('deploy.sh naming opt-out', () => {
+  let mock;
+  let port;
+
+  before(async () => {
+    mock = createMockServer();
+    await new Promise((resolve) => {
+      mock.server.listen(0, '127.0.0.1', () => {
+        port = mock.server.address().port;
+        resolve();
+      });
+    });
+    const addr = `127.0.0.1:${port}`;
+    fs.writeFileSync(CONF_PATH, [
+      `PRO4PM=${addr}`,
+      `PRO2PM_1=${addr}`,
+      `PRO4PM_VPN=${addr}`,
+      '',
+    ].join('\n'));
+  });
+
+  after(async () => {
+    fs.writeFileSync(CONF_PATH, ORIGINAL_CONF);
+    await new Promise((resolve) => mock.server.close(resolve));
+  });
+
+  it('skips naming when DEPLOY_SET_NAMES=false', async () => {
+    mock.calls.length = 0;
+    const child = spawn('bash', [DEPLOY_SH], {
+      cwd: SCRIPTS_DIR,
+      env: { ...process.env, DEPLOY_STOP_DELAY: '0', DEPLOY_SET_NAMES: 'false' },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    await new Promise((resolve) => child.on('close', resolve));
+    const sysCalls = mock.calls.filter(c => c.url.includes('Sys.SetConfig'));
+    const switchSetConfigCalls = mock.calls.filter(c => c.url.includes('Switch.SetConfig'));
+    assert.strictEqual(sysCalls.length, 0, 'no Sys.SetConfig calls when naming disabled');
+    assert.strictEqual(switchSetConfigCalls.length, 0, 'no Switch.SetConfig calls when naming disabled');
+  });
+
+  it('skips naming when a specific device IP is passed', async () => {
+    mock.calls.length = 0;
+    await runDeploy(`127.0.0.1:${port}`);
+    const sysCalls = mock.calls.filter(c => c.url.includes('Sys.SetConfig'));
+    assert.strictEqual(sysCalls.length, 0,
+      'targeting a single IP should skip the multi-device naming phase');
+  });
 });
 
 // Separate deploy run for error handling
@@ -271,7 +414,7 @@ describe('deploy.sh error handling', () => {
   });
 
   it('fails on PutCode HTTP error', async () => {
-    const result = await runDeploy(`127.0.0.1:${port}`, 1);
+    const result = await runDeploy(`127.0.0.1:${port}`);
     assert.ok(result.code !== 0, 'should exit with non-zero status');
     assert.ok(result.stdout.includes('ERROR'), 'should print error message');
   });

--- a/tests/sensor-apply.test.js
+++ b/tests/sensor-apply.test.js
@@ -64,6 +64,11 @@ function makeFakeHub({ existing = {}, simulateStaleCache = false } = {}) {
 
     if (method === 'Shelly.GetDeviceInfo') return reply({ id: 'fake', ver: '1.7.4' });
     if (method === 'SensorAddon.GetPeripherals') return reply({ ds18b20: state });
+    if (method === 'Temperature.SetConfig') {
+      // Name persistence is verified via the request log, not the peripheral
+      // state, so deepEqual(state, ...) in legacy assertions still holds.
+      return reply({ restart_required: false });
+    }
     if (method === 'SensorAddon.RemovePeripheral') {
       const comp = params.component;
       if (!state[comp]) return replyErr(-105, `Argument '${comp}' not found!`);
@@ -130,7 +135,8 @@ describe('sensor-apply (direct HTTP)', () => {
         {
           collector: { addr: 'aa:01', hostIndex: 0, componentId: 100 },
           tank_top: { addr: 'aa:02', hostIndex: 0, componentId: 101 },
-        }
+        },
+        { collector: 'Collector Outlet', tank_top: 'Tank Top' }
       );
       assert.strictEqual(result.success, true);
       assert.strictEqual(result.results[0].ok, true);
@@ -140,6 +146,48 @@ describe('sensor-apply (direct HTTP)', () => {
         'temperature:100': { addr: 'aa:01' },
         'temperature:101': { addr: 'aa:02' },
       });
+
+      // Each AddPeripheral is followed by a Temperature.SetConfig naming the
+      // new component so the Shelly app shows "Tank Top" instead of
+      // "Temperature 101".
+      const tempSetConfigs = fake.log().filter((m) => m.method === 'Temperature.SetConfig');
+      assert.strictEqual(tempSetConfigs.length, 2,
+        'expected one Temperature.SetConfig per added peripheral');
+      const byId = {};
+      for (const m of tempSetConfigs) byId[m.params.id] = m.params.config.name;
+      assert.strictEqual(byId[100], 'Collector Outlet');
+      assert.strictEqual(byId[101], 'Tank Top');
+    });
+
+  });
+
+  describe('naming fallback — no roleLabels provided', () => {
+    let fake, loaded, port;
+
+    before(async () => {
+      fake = makeFakeHub();
+      port = await listen(fake.server);
+      loaded = loadWithRedirect({ '127.0.0.1': port });
+    });
+
+    after(async () => {
+      loaded.restore();
+      await new Promise((r) => fake.server.close(r));
+    });
+
+    it('uses the role key as the label when no roleLabels are given', async () => {
+      // Simulate a caller that forgot to pass roleLabels. The peripheral
+      // should still be named — using the role key as the label — so the
+      // app never shows the raw "Temperature 100" default.
+      const result = await loaded.mod.applyAll(
+        [{ ip: '127.0.0.1' }],
+        { outdoor: { addr: 'aa:03', hostIndex: 0, componentId: 102 } }
+        // no roleLabels arg
+      );
+      assert.strictEqual(result.success, true);
+      const tempSetConfigs = fake.log().filter((m) => m.method === 'Temperature.SetConfig');
+      assert.strictEqual(tempSetConfigs.length, 1);
+      assert.strictEqual(tempSetConfigs[0].params.config.name, 'outdoor');
     });
   });
 


### PR DESCRIPTION
## Summary

- `shelly/deploy.sh` now names every device in `devices.conf` (Pro 4PM, 5× Pro 2PM, 2× sensor hub) and every relay channel whose role is known from `system.yaml`. The Shelly app reads `Sys.SetConfig` `device.name` and `Switch.SetConfig` `name`, so this removes the factory-default `2)`/`3)` duplicate-marker prefixes and lets one Room group everything cleanly.
- Temperature components on the sensor hubs are named in `server/lib/sensor-apply.js` when roles are assigned — not at deploy time. The role→sensor mapping is runtime-mutable via the Sensor Roles flow, so it has no useful value at deploy time.
- Naming is gated by `DEPLOY_SET_NAMES` (default `true`) and skipped when `deploy.sh` is invoked with an explicit device IP — matching the real-world contract of "rename on full deploy only."

## Naming scheme (derived from `system.yaml`)

| Device | Name | Channels |
|---|---|---|
| Pro 4PM | `GH Controller` | 0 `Pump`, 1 `Fan`, 2 `Heater (immersion)`, 3 `Heater (space)` |
| Pro 2PM #1 | `GH Valves 1 (input low)` | 0 `VI-btm`, 1 `VI-top` |
| Pro 2PM #2 | `GH Valves 2 (input/coll)` | 0 `VI-coll`, 1 `VO-coll` |
| Pro 2PM #3 | `GH Valves 3 (output)` | 0 `VO-rad`, 1 `VO-tank` |
| Pro 2PM #4 | `GH Valves 4 (collector top)` | 0 `V-air` (1 left unnamed — reserved spare) |
| Pro 2PM #5 | `GH Valves 5 (spare)` | (unnamed) |
| Sensor hub 1/2 | `GH Sensors 1/2` | — |
| Temperature:N on hub | role label (e.g. `Tank Top`, `Collector Outlet`) | driven by `server/lib/sensor-config.js` `SENSOR_ROLES[*].label` |

## Test plan

- [x] `node --test tests/deploy.test.js` (15/15 pass — new cases cover naming calls, opt-out via env var, and opt-out via explicit IP arg)
- [x] `node --test tests/sensor-apply.test.js` (6/6 pass — new case asserts `Temperature.SetConfig` is called with the role label, fallback case asserts role-key fallback when labels are omitted)
- [x] `npm run test:unit` (744/744 pass)
- [ ] CD deploy job output shows each device and switch being named

https://claude.ai/code/session_01P87foa2Xhh8WGykvbz8szk