### PR TITLE
Sync Shelly Cloud app device names with role mapping

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -19,6 +19,9 @@ COPY system.yaml ./
 # Copy Shelly scripts (for simulation support and device deployment)
 COPY shelly/ ./shelly/
 
+# Copy repo scripts (deploy.sh and sensor-apply invoke rename-cloud-devices.mjs from here)
+COPY scripts/ ./scripts/
+
 # Make app directory owned by node user
 RUN chown -R node:node /app
 

--- a/deploy/terraform/main.tf
+++ b/deploy/terraform/main.tf
@@ -289,6 +289,8 @@ resource "kubernetes_secret" "app_secrets" {
     S3_SECRET_ACCESS_KEY = upcloud_managed_object_storage_user_access_key.app.secret_access_key
     S3_REGION            = var.objsto_region
     NEW_RELIC_LICENSE_KEY = var.new_relic_license_key
+    SHELLY_CLOUD_REFRESH_TOKEN = var.shelly_cloud_refresh_token
+    SHELLY_CLOUD_API_URL       = var.shelly_cloud_api_url
   }
 
   depends_on = [upcloud_kubernetes_node_group.default]

--- a/deploy/terraform/terraform.tfvars.example
+++ b/deploy/terraform/terraform.tfvars.example
@@ -10,6 +10,13 @@ github_repo = "Wnt/greenhouse-solar-heater"
 # Session secret for signed cookies (generate with: openssl rand -hex 32)
 session_secret = "REPLACE_ME"
 
+# Shelly Cloud refresh token (60-day) for device-name automation.
+# Obtain via the DevTools console one-liner in scripts/rename-cloud-devices.mjs.
+# Leave empty to disable cloud renaming; deploy + sensor remap will log a warning
+# with instructions.
+# shelly_cloud_refresh_token = ""
+# shelly_cloud_api_url       = "https://shelly-249-eu.shelly.cloud"
+
 # UpCloud zone (default: fi-hel1 = Helsinki)
 # upcloud_zone = "fi-hel1"
 

--- a/deploy/terraform/variables.tf
+++ b/deploy/terraform/variables.tf
@@ -39,6 +39,19 @@ variable "new_relic_license_key" {
   default     = ""
 }
 
+variable "shelly_cloud_refresh_token" {
+  description = "60-day refresh token for the Shelly Cloud REST API. Used by deploy + sensor-remap to keep the mobile/web app's device names in sync with the hardware role mapping. See scripts/rename-cloud-devices.mjs for how to obtain. Leave empty to skip cloud naming."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "shelly_cloud_api_url" {
+  description = "Regional Shelly Cloud API shard URL, embedded in the access-token JWT's user_api_url claim but absent from the refresh token, so it must be stored alongside."
+  type        = string
+  default     = "https://shelly-249-eu.shelly.cloud"
+}
+
 # ── Kubernetes variables ──
 
 variable "k8s_version" {

--- a/playground/js/sensors.js
+++ b/playground/js/sensors.js
@@ -377,18 +377,29 @@ function showStatus(msg, isError) {
   }
 }
 
+function escapeHtml(s) {
+  return String(s).replace(/[&<>"']/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+}
+
 function showApplyResults(data) {
   const el = document.getElementById('apply-results');
   if (!el || !data || !data.results) return;
+
   let html = '<div class="apply-results-grid">';
   for (const target in data.results) {
     const r = data.results[target];
     const isOk = r.status === 'success';
     html += '<div class="apply-result ' + (isOk ? 'success' : 'error') + '">';
-    html += '<strong>' + target + '</strong>: ' + r.message;
+    html += '<strong>' + escapeHtml(target) + '</strong>: ' + escapeHtml(r.message);
     if (!isOk) {
-      html += ' <button class="retry-btn" data-target="' + target + '">Retry</button>';
+      html += ' <button class="retry-btn" data-target="' + escapeHtml(target) + '">Retry</button>';
     }
+    html += '</div>';
+  }
+  if (data.warning) {
+    html += '<div class="apply-warning">';
+    html += '<span class="apply-warning-text">' + escapeHtml(data.warning.message) + '</span>';
+    html += '<button class="apply-warning-dismiss" title="Dismiss this warning" aria-label="Dismiss">×</button>';
     html += '</div>';
   }
   html += '</div>';
@@ -401,12 +412,24 @@ function showApplyResults(data) {
       btn.textContent = 'Retrying...';
       try {
         const result = await applyTarget(btn.dataset.target);
-        showApplyResults({ results: Object.assign({}, data.results, result.results) });
+        showApplyResults({
+          results: Object.assign({}, data.results, result.results),
+          warning: data.warning,
+        });
       } catch (e) {
         showStatus('Retry failed: ' + e.message, true);
       }
     });
   });
+
+  // Dismiss just removes the card; next apply re-surfaces it if still present.
+  const dismissBtn = el.querySelector('.apply-warning-dismiss');
+  if (dismissBtn) {
+    dismissBtn.addEventListener('click', () => {
+      const card = dismissBtn.closest('.apply-warning');
+      if (card) card.remove();
+    });
+  }
 }
 
 // ── Event handlers ──

--- a/playground/public/style.css
+++ b/playground/public/style.css
@@ -1871,6 +1871,25 @@ button.scanning { opacity: 0.7; cursor: wait; }
 .apply-result { padding: 6px 10px; border-radius: 6px; font-size: 13px; }
 .apply-result.success { background: rgba(118, 255, 3, 0.1); color: #76ff03; }
 .apply-result.error { background: rgba(239, 83, 80, 0.1); color: var(--error); }
+.apply-warning {
+  display: flex; align-items: flex-start; gap: 8px;
+  padding: 8px 10px; border-radius: 6px; font-size: 13px;
+  background: rgba(255, 193, 7, 0.12); color: #ffc107;
+}
+.apply-warning-text {
+  flex: 1;
+  white-space: pre-wrap;
+  font-family: inherit;
+  line-height: 1.5;
+  overflow-wrap: anywhere;
+}
+.apply-warning-dismiss {
+  background: transparent; color: inherit;
+  border: 1px solid currentColor; border-radius: 4px;
+  padding: 0 8px; font-size: 16px; line-height: 1.4;
+  cursor: pointer; flex-shrink: 0; opacity: 0.7;
+}
+.apply-warning-dismiss:hover { opacity: 1; }
 .retry-btn {
   background: var(--surface-container); color: var(--on-surface);
   border: 1px solid var(--outline-variant); border-radius: 4px;

--- a/scripts/rename-cloud-devices.mjs
+++ b/scripts/rename-cloud-devices.mjs
@@ -1,0 +1,179 @@
+/**
+ * Rename Shelly Cloud device/channel entries to match the canonical role
+ * mapping in shelly/deploy.sh.
+ *
+ * Why it exists:
+ *   The Shelly Cloud app keeps its own name store per channel. Cloud sync is
+ *   one-way (cloud → device), so the names set by `deploy.sh` via
+ *   Sys.SetConfig / Switch.SetConfig never appear in the mobile / web app.
+ *   This script closes that gap by calling the same Cloud REST API that the
+ *   web app uses when you save a "Device name" in the UI.
+ *
+ * Usage:
+ *   # One-shot with a 24 h access token (copy from DevTools):
+ *   SHELLY_CLOUD_TOKEN=<jwt> node scripts/rename-cloud-devices.mjs [--dry-run]
+ *
+ *   # Long-lived: use a 60 d refresh token. The script will exchange it for a
+ *   # fresh access token on each run. The refresh token ROTATES — the new one
+ *   # is printed to stderr; store it to keep unattended runs working.
+ *   SHELLY_CLOUD_REFRESH_TOKEN=<jwt> \
+ *   SHELLY_CLOUD_API_URL=https://shelly-249-eu.shelly.cloud \
+ *   node scripts/rename-cloud-devices.mjs
+ *
+ *   # Just refresh and print the new tokens (no renames):
+ *   SHELLY_CLOUD_REFRESH_TOKEN=<jwt> SHELLY_CLOUD_API_URL=https://... \
+ *   node scripts/rename-cloud-devices.mjs --refresh-only
+ *
+ * Getting the initial tokens:
+ *   1. Log in to https://control.shelly.cloud/
+ *   2. DevTools → Application → Local Storage → key `user_data`
+ *   3. Copy `token` (access, 24 h) and/or `refresh_token` (60 d) and
+ *      `user_api_url` (regional shard).
+ *
+ * The access-token JWT payload embeds `user_api_url`; the refresh-token JWT
+ * does not, so when refreshing you MUST also supply SHELLY_CLOUD_API_URL.
+ *
+ * Name map is duplicated with deploy.sh:apply_device_names for now. If this
+ * grows, extract a shared JSON data file and have deploy.sh read it via jq.
+ */
+
+// IP → per-channel cloud names. `null` means "leave whatever the cloud has".
+// Channel index is 0-based and maps to the Shelly Cloud `channel` field.
+const IP_TO_CHANNEL_NAMES = {
+  // Pro 4PM — main controller. Channels match control.js setActuators mapping.
+  '192.168.30.50': ['Pump', 'Fan', 'Heater (immersion)', 'Heater (space)'],
+  // Pro 2PM valve controllers. Channels match VALVES in control.js.
+  '192.168.30.51': ['VI-btm', 'VI-top'],
+  '192.168.30.52': ['VI-coll', 'VO-coll'],
+  '192.168.30.53': ['VO-rad', 'VO-tank'],
+  '192.168.30.54': ['V-air', null], // ch 1 = reserved spare (spec 024)
+  '192.168.30.55': [null, null],    // PRO2PM_5 = spare
+  // Shelly Plus 1 sensor hubs (relay output is the only channel).
+  '192.168.30.20': ['GH Sensors 1'],
+  '192.168.30.21': ['GH Sensors 2'],
+};
+
+const DRY_RUN = process.argv.includes('--dry-run');
+const REFRESH_ONLY = process.argv.includes('--refresh-only');
+
+function die(msg) {
+  console.error(`Error: ${msg}`);
+  process.exit(1);
+}
+
+function decodeJwt(jwt) {
+  try {
+    return JSON.parse(Buffer.from(jwt.split('.')[1], 'base64url').toString('utf8'));
+  } catch {
+    die('Invalid JWT.');
+  }
+}
+
+async function refreshAccessToken(apiUrl, refreshToken) {
+  const res = await fetch(`${apiUrl}/v2/users/auth/refresh`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ refreshToken }),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    die(`refresh → ${res.status} ${res.statusText}\n${text}`);
+  }
+  const body = await res.json();
+  if (!body.accessToken || !body.refreshToken) {
+    die(`refresh response missing tokens: ${JSON.stringify(body)}`);
+  }
+  return body;
+}
+
+async function resolveAuth() {
+  const accessEnv = process.env.SHELLY_CLOUD_TOKEN;
+  const refreshEnv = process.env.SHELLY_CLOUD_REFRESH_TOKEN;
+
+  if (accessEnv && !REFRESH_ONLY) {
+    const payload = decodeJwt(accessEnv);
+    if (!payload.user_api_url) die('SHELLY_CLOUD_TOKEN JWT missing user_api_url claim.');
+    if (payload.exp * 1000 < Date.now()) {
+      // Fall through to refresh if available; otherwise fail.
+      if (!refreshEnv) die(`Access token expired at ${new Date(payload.exp * 1000).toISOString()}.`);
+    } else {
+      return { token: accessEnv, apiUrl: payload.user_api_url };
+    }
+  }
+
+  if (!refreshEnv) {
+    die(
+      'No valid auth. Set SHELLY_CLOUD_TOKEN (24 h access) or\n' +
+      'SHELLY_CLOUD_REFRESH_TOKEN + SHELLY_CLOUD_API_URL (60 d refresh).\n' +
+      'See the header comment for how to obtain them.',
+    );
+  }
+  const apiUrl = process.env.SHELLY_CLOUD_API_URL;
+  if (!apiUrl) die('SHELLY_CLOUD_API_URL required when using SHELLY_CLOUD_REFRESH_TOKEN (e.g. https://shelly-249-eu.shelly.cloud).');
+
+  const rt = decodeJwt(refreshEnv);
+  if (rt.exp * 1000 < Date.now()) die(`Refresh token expired at ${new Date(rt.exp * 1000).toISOString()}. Log in again to obtain a new one.`);
+
+  const body = await refreshAccessToken(apiUrl, refreshEnv);
+  const newRt = decodeJwt(body.refreshToken);
+  process.stderr.write(
+    `\n⚠️  Refresh token rotated. The old one may stop working soon — save this new one:\n` +
+    `    SHELLY_CLOUD_REFRESH_TOKEN=${body.refreshToken}\n` +
+    `    (valid until ${new Date(newRt.exp * 1000).toISOString()})\n\n`,
+  );
+  if (REFRESH_ONLY) {
+    // Emit parseable output on stdout so callers can `eval`.
+    process.stdout.write(`SHELLY_CLOUD_TOKEN=${body.accessToken}\n`);
+    process.stdout.write(`SHELLY_CLOUD_REFRESH_TOKEN=${body.refreshToken}\n`);
+    process.stdout.write(`SHELLY_CLOUD_API_URL=${apiUrl}\n`);
+    process.exit(0);
+  }
+  return { token: body.accessToken, apiUrl };
+}
+
+const { token, apiUrl } = await resolveAuth();
+
+async function api(path, { method = 'POST', body, headers = {} } = {}) {
+  const res = await fetch(`${apiUrl}${path}`, {
+    method,
+    headers: { Authorization: `Bearer ${token}`, ...headers },
+    body,
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`${method} ${path} → ${res.status} ${res.statusText}\n${text}`);
+  }
+  return res.json();
+}
+
+const list = await api('/interface/device/get_all_lists');
+if (!list.isok) die(`get_all_lists returned isok=false: ${JSON.stringify(list)}`);
+const rows = Object.values(list.data.devices);
+
+let renamed = 0, skipped = 0, untouched = 0;
+for (const row of rows) {
+  const targets = IP_TO_CHANNEL_NAMES[row.ip];
+  if (!targets) { untouched++; continue; }
+  const target = targets[row.channel];
+  if (target == null) { untouched++; continue; }
+  if (row.name === target) { skipped++; continue; }
+
+  const prefix = DRY_RUN ? '[dry-run] ' : '';
+  console.log(`${prefix}${row.id} (${row.ip} ch ${row.channel}): "${row.name}" → "${target}"`);
+
+  if (!DRY_RUN) {
+    const body = new URLSearchParams({
+      id: row.id,
+      data: JSON.stringify({ ...row, name: target }),
+    });
+    const save = await api('/interface/device/save', {
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body,
+    });
+    if (!save.isok) die(`save returned isok=false for ${row.id}: ${JSON.stringify(save)}`);
+  }
+  renamed++;
+}
+
+console.log(`\nSummary: renamed=${renamed} already-matching=${skipped} no-mapping=${untouched}`);
+if (DRY_RUN && renamed > 0) console.log('(dry run — no changes applied)');

--- a/server/lib/sensor-config.js
+++ b/server/lib/sensor-config.js
@@ -275,6 +275,7 @@ function toCompactFormat(config) {
 // controller can drive its polling loop.
 
 var sensorApply = require('./sensor-apply');
+var shellyCloud = require('./shelly-cloud');
 
 // Role → human-readable label map, used by sensor-apply to name each
 // Temperature component in the Shelly app when roles are applied.
@@ -324,7 +325,13 @@ function applyConfig(mqttBridge, callback) {
     } else {
       results.control = { status: 'error', message: 'MQTT bridge not available' };
     }
-    callback(null, results);
+    // Keep the Shelly Cloud app's channel names in sync with the role
+    // mapping. Non-fatal; any problem is surfaced as a dismissible UI
+    // warning (not a hub-level error) because it's cosmetic and the user
+    // may not care about the cloud app.
+    shellyCloud.renameCloudDevices(log).then(function (warning) {
+      callback(null, { results: results, warning: warning || null });
+    });
   }).catch(function (err) {
     callback(err);
   });
@@ -410,16 +417,16 @@ function handlePut(req, res, body, onUpdate) {
 }
 
 function handleApply(req, res, mqttBridge) {
-  applyConfig(mqttBridge, function (err, results) {
+  applyConfig(mqttBridge, function (err, out) {
     if (err) {
       var statusCode = err.message === 'Request timed out' ? 504 : 500;
       res.writeHead(statusCode, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ error: err.message === 'Request timed out' ? 'Config apply timed out' : err.message }));
       return;
     }
-    log.info('sensor config applied', { results: results });
+    log.info('sensor config applied', { results: out.results, warning: out.warning });
     res.writeHead(200, { 'Content-Type': 'application/json' });
-    res.end(JSON.stringify({ results: results }));
+    res.end(JSON.stringify({ results: out.results, warning: out.warning }));
   });
 }
 

--- a/server/lib/shelly-cloud.js
+++ b/server/lib/shelly-cloud.js
@@ -1,0 +1,121 @@
+/**
+ * Thin wrapper around scripts/rename-cloud-devices.mjs for server-side use.
+ *
+ * Lets sensor-remap (and anything else that changes naming state) trigger a
+ * Shelly Cloud rename without duplicating the script's logic. Spawns the
+ * script as a child process so both the CLI and this module stay in sync.
+ *
+ * Non-fatal by design: a broken cloud-side rename should never block the
+ * primary operation. The caller gets back either `null` (success) or a
+ * `{ id, message }` warning object suitable for surfacing to the UI as a
+ * dismissible banner.
+ *
+ * Rotation caveat: Shelly's /v2/users/auth/refresh rotates the refresh
+ * token on every call. After a successful run the script prints the new
+ * refresh token to stderr — we forward that to the log so an operator can
+ * update the stored secret. Until the stored token is updated, subsequent
+ * runs will fail with a clear auth error (still non-fatal).
+ */
+
+const { spawn } = require('child_process');
+const path = require('path');
+
+const SCRIPT_PATH = path.resolve(__dirname, '..', '..', 'scripts', 'rename-cloud-devices.mjs');
+
+const WARNING_ID = 'cloud-rename';
+
+// The DevTools-console one-liner that grabs a fresh 60-day refresh token
+// out of the Shelly Cloud app's localStorage and copies it to the clipboard.
+// Kept as a single line so it pastes cleanly into the browser console.
+var TOKEN_ONELINER =
+  "(u=>{const {refresh_token:t,user_api_url:a}=u;console.log({refresh_token:t,user_api_url:a," +
+  "exp:new Date(JSON.parse(atob(t.split('.')[1].replace(/-/g,'+').replace(/_/g,'/'))).exp*1e3).toISOString()});" +
+  "copy(`SHELLY_CLOUD_REFRESH_TOKEN=${t}\\nSHELLY_CLOUD_API_URL=${a}`)})(JSON.parse(localStorage.user_data))";
+
+function buildFixInstructions(lead) {
+  return [
+    lead,
+    '',
+    'To fix:',
+    '  1. Log in at https://control.shelly.cloud/',
+    '  2. Open DevTools (F12) → Console, paste this one-liner — it copies the',
+    '     refresh token and API URL to your clipboard:',
+    '',
+    '       ' + TOKEN_ONELINER,
+    '',
+    '  3. In deploy/terraform/, set (or update) the two variables with the',
+    '     copied values:',
+    '',
+    '       shelly_cloud_refresh_token = "eyJ…"',
+    '       shelly_cloud_api_url       = "https://shelly-XXX-eu.shelly.cloud"',
+    '',
+    '  4. Run: cd deploy/terraform && terraform apply',
+    '',
+    'The token is valid for 60 days and rotates on every successful use — you',
+    'will see this warning again after each rotation until the stored value',
+    'is refreshed.',
+  ].join('\n');
+}
+
+const MISSING_CREDS_MSG = buildFixInstructions(
+  "Device names in the Shelly Cloud app aren't being kept in sync — " +
+  'SHELLY_CLOUD_REFRESH_TOKEN is not set on the server.',
+);
+
+const SCRIPT_FAILED_LEAD = "Couldn't update device names in the Shelly Cloud app. " +
+  'The stored SHELLY_CLOUD_REFRESH_TOKEN was likely consumed by an earlier run ' +
+  '(refresh tokens rotate on every use) or has expired.';
+
+function renameCloudDevices(log) {
+  return new Promise(function (resolve) {
+    if (!process.env.SHELLY_CLOUD_TOKEN && !process.env.SHELLY_CLOUD_REFRESH_TOKEN) {
+      log.warn(MISSING_CREDS_MSG);
+      resolve({ id: WARNING_ID, message: MISSING_CREDS_MSG, reason: 'missing-credentials' });
+      return;
+    }
+
+    var stdout = '';
+    var stderr = '';
+    var child;
+    try {
+      child = spawn('node', [SCRIPT_PATH], { env: process.env });
+    } catch (e) {
+      var msg = 'Failed to spawn Shelly Cloud rename script: ' + e.message;
+      log.warn({ err: e.message }, msg);
+      resolve({ id: WARNING_ID, message: msg, reason: 'spawn-error' });
+      return;
+    }
+
+    child.stdout.on('data', function (d) { stdout += d.toString(); });
+    child.stderr.on('data', function (d) { stderr += d.toString(); });
+
+    child.on('error', function (e) {
+      var msg = 'Shelly Cloud rename script error: ' + e.message;
+      log.warn({ err: e.message }, msg);
+      resolve({ id: WARNING_ID, message: msg, reason: 'script-error' });
+    });
+
+    child.on('close', function (code) {
+      var trimmedOut = stdout.trim();
+      var trimmedErr = stderr.trim();
+      if (code === 0) {
+        if (trimmedOut) log.info({ output: trimmedOut }, 'Shelly Cloud rename complete');
+        if (trimmedErr) {
+          // Rotation warning lives on stderr — always surface so operator
+          // can update the stored secret before it becomes invalid.
+          log.warn({ notice: trimmedErr }, 'Shelly Cloud refresh token rotated — update stored secret');
+        }
+        resolve(null);
+      } else {
+        var errMsg = buildFixInstructions(SCRIPT_FAILED_LEAD + ' (exit ' + code + ')');
+        log.warn({ code: code, stdout: trimmedOut, stderr: trimmedErr }, 'Shelly Cloud rename failed');
+        resolve({ id: WARNING_ID, message: errMsg, reason: 'script-failed' });
+      }
+    });
+  });
+}
+
+module.exports = {
+  renameCloudDevices: renameCloudDevices,
+  WARNING_ID: WARNING_ID,
+};

--- a/shelly/deploy.sh
+++ b/shelly/deploy.sh
@@ -285,5 +285,22 @@ if [ "${DEPLOY_SET_NAMES:-true}" = "true" ] && [ -z "$USER_TARGET" ]; then
   apply_device_names
 fi
 
+# ── Shelly Cloud app rename ──
+# Syncs cloud/mobile-app device names with the role mapping. Non-fatal:
+# the Cloud API is separate infra and a failure here shouldn't abort deploy.
+# Skipped when the user targets a single device (USER_TARGET set).
+if [ "${DEPLOY_SET_NAMES:-true}" = "true" ] && [ -z "$USER_TARGET" ]; then
+  echo ""
+  if [ -n "${SHELLY_CLOUD_TOKEN:-}${SHELLY_CLOUD_REFRESH_TOKEN:-}" ]; then
+    echo "Renaming Shelly Cloud entries..."
+    node "$SCRIPT_DIR/../scripts/rename-cloud-devices.mjs" || \
+      echo "WARN: cloud rename failed (non-fatal) — check SHELLY_CLOUD_REFRESH_TOKEN validity" >&2
+  else
+    echo "Skipping Shelly Cloud rename — no SHELLY_CLOUD_TOKEN / SHELLY_CLOUD_REFRESH_TOKEN set."
+    echo "To enable: obtain a 60-day refresh token (see scripts/rename-cloud-devices.mjs header)"
+    echo "and store via Terraform (shelly_cloud_refresh_token variable in deploy/terraform/)."
+  fi
+fi
+
 echo ""
 echo "Deployment complete"

--- a/tests/sensor-config.test.js
+++ b/tests/sensor-config.test.js
@@ -254,15 +254,20 @@ describe('sensor-config', () => {
 
   describe('Direct-HTTP apply (via sensor-apply module)', () => {
     const sensorApply = require('../server/lib/sensor-apply');
-    let origApplyAll, origApplyOne;
+    const shellyCloud = require('../server/lib/shelly-cloud');
+    let origApplyAll, origApplyOne, origRename;
 
     beforeEach(() => {
       origApplyAll = sensorApply.applyAll;
       origApplyOne = sensorApply.applyOne;
+      origRename = shellyCloud.renameCloudDevices;
+      // Stub so tests don't spawn the real script. Default: no warning.
+      shellyCloud.renameCloudDevices = function () { return Promise.resolve(null); };
     });
     afterEach(() => {
       sensorApply.applyAll = origApplyAll;
       sensorApply.applyOne = origApplyOne;
+      shellyCloud.renameCloudDevices = origRename;
     });
 
     it('applyConfig calls sensor-apply.applyAll with hosts + assignments and publishes routing to MQTT', (t, done) => {
@@ -292,13 +297,14 @@ describe('sensor-config', () => {
             return true;
           },
         };
-        sensorConfig.applyConfig(mockBridge, function (err, results) {
+        sensorConfig.applyConfig(mockBridge, function (err, out) {
           assert.ifError(err);
           assert.ok(applyCalled, 'sensor-apply.applyAll must be invoked');
           assert.ok(mqttRoutingPublished, 'MQTT routing config must be published');
-          assert.equal(results.sensor_1.status, 'success');
-          assert.equal(results.sensor_2.status, 'success');
-          assert.equal(results.control.status, 'success');
+          assert.equal(out.results.sensor_1.status, 'success');
+          assert.equal(out.results.sensor_2.status, 'success');
+          assert.equal(out.results.control.status, 'success');
+          assert.equal(out.warning, null);
           done();
         });
       });
@@ -318,10 +324,10 @@ describe('sensor-config', () => {
           });
         };
         const mockBridge = { publishSensorConfig: function () { return true; } };
-        sensorConfig.applyConfig(mockBridge, function (err, results) {
+        sensorConfig.applyConfig(mockBridge, function (err, out) {
           assert.ifError(err);
-          assert.match(results.sensor_1.message, /rebooted/);
-          assert.doesNotMatch(results.sensor_2.message, /rebooted/);
+          assert.match(out.results.sensor_1.message, /rebooted/);
+          assert.doesNotMatch(out.results.sensor_2.message, /rebooted/);
           done();
         });
       });
@@ -341,11 +347,11 @@ describe('sensor-config', () => {
           });
         };
         const mockBridge = { publishSensorConfig: function () { return true; } };
-        sensorConfig.applyConfig(mockBridge, function (err, results) {
+        sensorConfig.applyConfig(mockBridge, function (err, out) {
           assert.ifError(err);
-          assert.equal(results.sensor_1.status, 'success');
-          assert.equal(results.sensor_2.status, 'error');
-          assert.match(results.sensor_2.message, /ECONNREFUSED/);
+          assert.equal(out.results.sensor_1.status, 'success');
+          assert.equal(out.results.sensor_2.status, 'error');
+          assert.match(out.results.sensor_2.message, /ECONNREFUSED/);
           done();
         });
       });
@@ -361,11 +367,35 @@ describe('sensor-config', () => {
             results: [{ host: '192.168.30.20', ok: true, peripherals: 2 }],
           });
         };
-        sensorConfig.applyConfig(null, function (err, results) {
+        sensorConfig.applyConfig(null, function (err, out) {
           assert.ifError(err);
-          assert.equal(results.sensor_1.status, 'success');
-          assert.equal(results.control.status, 'error');
-          assert.match(results.control.message, /MQTT bridge not available/);
+          assert.equal(out.results.sensor_1.status, 'success');
+          assert.equal(out.results.control.status, 'error');
+          assert.match(out.results.control.message, /MQTT bridge not available/);
+          done();
+        });
+      });
+    });
+
+    it('applyConfig surfaces a cloud-rename warning when shelly-cloud returns one', (t, done) => {
+      sensorConfig.load(function (err) {
+        assert.ifError(err);
+        sensorApply.applyAll = function () {
+          return Promise.resolve({
+            id: 'apply-1',
+            success: true,
+            results: [{ host: '192.168.30.20', ok: true, peripherals: 2 }],
+          });
+        };
+        shellyCloud.renameCloudDevices = function () {
+          return Promise.resolve({ id: 'cloud-rename', message: 'creds missing', reason: 'missing-credentials' });
+        };
+        const mockBridge = { publishSensorConfig: function () { return true; } };
+        sensorConfig.applyConfig(mockBridge, function (err, out) {
+          assert.ifError(err);
+          assert.equal(out.warning.id, 'cloud-rename');
+          assert.match(out.warning.message, /creds missing/);
+          assert.equal(out.warning.reason, 'missing-credentials');
           done();
         });
       });


### PR DESCRIPTION
## Summary

- Script + server integration that calls the same Shelly Cloud REST API the web app uses when you save a "Device name", driven by the canonical role mapping (VI-btm, VO-tank, Pump, Fan, GH Sensors N, …). Closes the deploy.sh / cloud-app gap caused by Shelly's one-way cloud→device sync.
- Integrates with both the deploy pipeline (`shelly/deploy.sh`) and the sensor-remap action (`server/lib/sensor-config.js`). Non-fatal: a missing or expired token surfaces as a single amber, × -dismissible warning in the sensor-config UI, with the full fix instructions (DevTools one-liner + Terraform vars + apply command) inline.
- New Terraform variables `shelly_cloud_refresh_token` (sensitive) and `shelly_cloud_api_url` piped into `app-secrets`, matching the pattern used for `NEW_RELIC_LICENSE_KEY`.

## Base

Based on `debt/dead-code-and-file-size`, not `main`.

## Rotation caveat

Shelly's `/v2/users/auth/refresh` rotates the refresh token on every use. The script prints the new token to stderr after a successful run; `shelly-cloud.js` forwards it as a prominent log warning so the stored secret can be updated. Until it is, the next run fails the refresh (still non-fatal — surfaces as the same UI warning).

## Test plan

- [x] Unit tests pass (787 ✓, +1 new test for warning propagation)
- [x] Dry-run against live cloud account — correctly identifies 12 renames, 1 already-matching, 3 no-mapping (spares)
- [x] Live run — all 12 channels renamed; verified in the Cloud web app
- [x] Refresh flow tested end-to-end via the script's `--refresh-only` mode
- [ ] E2E: UI warning render path (manually inspected via `/tmp/warning-preview.html`; no e2e spec added — sensors.spec.js mocks the apply response without `warning` which still works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)