### PR TITLE
tests: frontend V8 coverage report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 tests/output/
 test-results/
 node_modules/
+coverage/
 
 # ── Runtime-generated secrets — NEVER commit ───────────────────────
 # Files in these patterns are created on first run with freshly

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,7 @@ npm test                           # unit + frontend + e2e
 npm run test:unit                  # fast, no browser
 npm run test:frontend              # Playwright against static serve — frontend with mocked APIs
 npm run test:e2e                   # Playwright against real server + pg-mem + aedes MQTT
+npm run coverage:frontend          # V8 JS coverage for playground/js/** driven by the frontend suite — HTML + lcov in coverage/
 npm run screenshots                # regenerate screenshots (runs 24 h sim, ~1–2 min)
 npm run diagram                    # regenerate system-topology.drawio (dark theme)
 npm run topology-pdf               # printable light-theme PDF of the topology

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,10 +29,14 @@
         "@playwright/test": "1.56.0",
         "acorn": "^8.16.0",
         "aedes": "^1.0.2",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
         "js-yaml": "^4.1.1",
         "knip": "^6.6.1",
         "pg-mem": "^3.0.14",
-        "serve": "^14.2.6"
+        "serve": "^14.2.6",
+        "v8-to-istanbul": "^9.3.0"
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -897,31 +901,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -969,6 +948,34 @@
       "resolved": "https://registry.npmjs.org/@hexagon/base64/-/base64-1.1.28.tgz",
       "integrity": "sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw==",
       "license": "MIT"
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
     },
     "node_modules/@js-sdsl/ordered-map": {
       "version": "4.4.2",
@@ -5620,6 +5627,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/memcached": {
       "version": "2.2.10",
       "resolved": "https://registry.npmjs.org/@types/memcached/-/memcached-2.2.10.tgz",
@@ -6574,6 +6588,13 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -7187,6 +7208,13 @@
       "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
       "license": "MIT"
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/http_ece": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http_ece/-/http_ece-1.2.0.tgz",
@@ -7383,6 +7411,45 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/jiti": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
@@ -7540,6 +7607,22 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "license": "ISC"
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -8582,6 +8665,19 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/serve": {
       "version": "14.2.6",
       "resolved": "https://registry.npmjs.org/serve/-/serve-14.2.6.tgz",
@@ -8932,6 +9028,21 @@
       "integrity": "sha512-OdmXxA8rDsQ7YpNVbKSJkNzTw2I+S5WsbMDnCtIWSQaosNAcWtFuI/YK1TjzUI6nbkgiqEyh8gWngfcv8Asd9A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
     },
     "node_modules/vary": {
       "version": "1.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -242,32 +242,32 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.1034.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1034.0.tgz",
-      "integrity": "sha512-r91IZKPKuRlpCBsEmz9qnWrYxuHD0jsQv1p9UGNasFpcuPo1OnfwIB2ClXtqdXKYUvubXCwn7KBObTVnnvYvAA==",
+      "version": "3.1035.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1035.0.tgz",
+      "integrity": "sha512-Bh1h96CjHMpxg6Rn2G4EE30YiiBh9w/7WmSZIfwLB0X/6lblaJcHggcryrq2uNN2Bx1/CNErMjTpGQzqhA7Rhg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.3",
-        "@aws-sdk/credential-provider-node": "^3.972.34",
+        "@aws-sdk/core": "^3.974.4",
+        "@aws-sdk/credential-provider-node": "^3.972.35",
         "@aws-sdk/middleware-bucket-endpoint": "^3.972.10",
         "@aws-sdk/middleware-expect-continue": "^3.972.10",
-        "@aws-sdk/middleware-flexible-checksums": "^3.974.11",
+        "@aws-sdk/middleware-flexible-checksums": "^3.974.12",
         "@aws-sdk/middleware-host-header": "^3.972.10",
         "@aws-sdk/middleware-location-constraint": "^3.972.10",
         "@aws-sdk/middleware-logger": "^3.972.10",
         "@aws-sdk/middleware-recursion-detection": "^3.972.11",
-        "@aws-sdk/middleware-sdk-s3": "^3.972.32",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.33",
         "@aws-sdk/middleware-ssec": "^3.972.10",
-        "@aws-sdk/middleware-user-agent": "^3.972.33",
+        "@aws-sdk/middleware-user-agent": "^3.972.34",
         "@aws-sdk/region-config-resolver": "^3.972.13",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.20",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.21",
         "@aws-sdk/types": "^3.973.8",
         "@aws-sdk/util-endpoints": "^3.996.8",
         "@aws-sdk/util-user-agent-browser": "^3.972.10",
-        "@aws-sdk/util-user-agent-node": "^3.973.19",
+        "@aws-sdk/util-user-agent-node": "^3.973.20",
         "@smithy/config-resolver": "^4.4.17",
         "@smithy/core": "^3.23.16",
         "@smithy/eventstream-serde-browser": "^4.2.14",
@@ -308,9 +308,9 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.974.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.3.tgz",
-      "integrity": "sha512-W3aJJm2clu8OmsrwMOMnfof13O6LGnbknnZIQeSRbxjqKah2nVvkjbUBBZVhWrt08KC69H7WsINTdrxC/2SXQw==",
+      "version": "3.974.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.4.tgz",
+      "integrity": "sha512-EbVgyzQ83/Lf6oh1O4vYY47tuYw3Aosthh865LNU77KyotKz+uvEBNmsl/bSVS/vG+IU39mCqcOHrnhmhF4lug==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
@@ -346,12 +346,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.29",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.29.tgz",
-      "integrity": "sha512-rf+AlUxgTeSzQ/4zoS0D+Bt7XvgpY48PnWG8Yg/N9fdMgyK2Jaqa+6tLZp4MYMIMHkGrfAxnbSeb2YLMGFMg6g==",
+      "version": "3.972.30",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.30.tgz",
+      "integrity": "sha512-dHpeqa29a0cBYq/h59IC2EK3AphLY96nKy4F35kBtiz9GuKDc32UYRTgjZaF8uuJCnqgw9omUZKR+9myyDHC2A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.3",
+        "@aws-sdk/core": "^3.974.4",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/types": "^4.14.1",
@@ -362,12 +362,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.31",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.31.tgz",
-      "integrity": "sha512-TR2/lQ3qKFj2EOrsiASzemsNEz2uzZ/SUBf48+U4Cr9a/FZlHfH/hwAeBJNBp1gMyJNxROJZhT3dn1cO+jnYfQ==",
+      "version": "3.972.32",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.32.tgz",
+      "integrity": "sha512-A+ZTT//Mswkf9DFEM6XlngwOtYdD8X4CUcoZ2wdpgI8cCs9mcGeuhgTwbGJvealub/MeONOaUr3FbRPMKmTDjg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.3",
+        "@aws-sdk/core": "^3.974.4",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/fetch-http-handler": "^5.3.17",
         "@smithy/node-http-handler": "^4.6.0",
@@ -383,19 +383,19 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.33",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.33.tgz",
-      "integrity": "sha512-UwdbJbOrgnOxZbshaNZ4DzX35h5wQd33MNYTGzWhN3ORG9lG9KQbDX6l6tDJSAdaGTktJoZPSritmUoW1rYkRA==",
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.34.tgz",
+      "integrity": "sha512-MoRc7tLnx3JpFkV2R826enEfBUVN8o9Cc7y3hnbMwiWzL/VJhgfxRQzHkEL9vWorMWP7tibltsRcLoid9fsVdw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.3",
-        "@aws-sdk/credential-provider-env": "^3.972.29",
-        "@aws-sdk/credential-provider-http": "^3.972.31",
-        "@aws-sdk/credential-provider-login": "^3.972.33",
-        "@aws-sdk/credential-provider-process": "^3.972.29",
-        "@aws-sdk/credential-provider-sso": "^3.972.33",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.33",
-        "@aws-sdk/nested-clients": "^3.997.1",
+        "@aws-sdk/core": "^3.974.4",
+        "@aws-sdk/credential-provider-env": "^3.972.30",
+        "@aws-sdk/credential-provider-http": "^3.972.32",
+        "@aws-sdk/credential-provider-login": "^3.972.34",
+        "@aws-sdk/credential-provider-process": "^3.972.30",
+        "@aws-sdk/credential-provider-sso": "^3.972.34",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.34",
+        "@aws-sdk/nested-clients": "^3.997.2",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/credential-provider-imds": "^4.2.14",
         "@smithy/property-provider": "^4.2.14",
@@ -408,13 +408,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.33",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.33.tgz",
-      "integrity": "sha512-WyZuPVoDM1HGNl41eVg8HSSXIB+FGkuuK63GhDbh4TMdfWU03AciWvF/QqOVWvJtWVYaLddANJ+aUklVr2ieuw==",
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.34.tgz",
+      "integrity": "sha512-XVSklkRRQ/CQDmv3VVFdZRl5hTFgncFhZrLyi0Ai4LZk5o3jpY5HIfuTK7ad7tixPKa+iQmL9+vg9qNyYZB+nw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.3",
-        "@aws-sdk/nested-clients": "^3.997.1",
+        "@aws-sdk/core": "^3.974.4",
+        "@aws-sdk/nested-clients": "^3.997.2",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/protocol-http": "^5.3.14",
@@ -427,17 +427,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.34",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.34.tgz",
-      "integrity": "sha512-sPcisURibKU4x0PCWJkWF1KJYm49Cph9dCn/PAnG5FU0wq5Id3g2v7RuEWAtNlKv1Af4gUJYBVGOeNpSEEx41A==",
+      "version": "3.972.35",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.35.tgz",
+      "integrity": "sha512-nVrY7AdGfzYgAa/jd9m06p3ES7QQDaB7zN9c+vXnVXxBRkAs9MjRDPB5AKogWuC6phddltfvHGFqLDJmyU9u/A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.29",
-        "@aws-sdk/credential-provider-http": "^3.972.31",
-        "@aws-sdk/credential-provider-ini": "^3.972.33",
-        "@aws-sdk/credential-provider-process": "^3.972.29",
-        "@aws-sdk/credential-provider-sso": "^3.972.33",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.33",
+        "@aws-sdk/credential-provider-env": "^3.972.30",
+        "@aws-sdk/credential-provider-http": "^3.972.32",
+        "@aws-sdk/credential-provider-ini": "^3.972.34",
+        "@aws-sdk/credential-provider-process": "^3.972.30",
+        "@aws-sdk/credential-provider-sso": "^3.972.34",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.34",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/credential-provider-imds": "^4.2.14",
         "@smithy/property-provider": "^4.2.14",
@@ -450,12 +450,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.29",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.29.tgz",
-      "integrity": "sha512-DURisqWS3bUgiwMXTmzymVNGlcRW0FnbPZ3SZknhmxnCXm3n9idkTJ6T+Uir359KRKtJNFLRViskk8HsSVLi1w==",
+      "version": "3.972.30",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.30.tgz",
+      "integrity": "sha512-McJPomNTSEo+C6UA3Zq6pFrcyTUaVsoPPBOvbOHAoIFPc8Z2CMLndqFJOnB+9bVFiBTWQLutlVGmrocBbvv4MQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.3",
+        "@aws-sdk/core": "^3.974.4",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/shared-ini-file-loader": "^4.4.9",
@@ -467,14 +467,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.33",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.33.tgz",
-      "integrity": "sha512-9y9obU4IQWru9f+NiiscUeyCe5ZmQav4FKEb1qfUNrik/C3BzBGUnHQWyPEyXjOX9cb+vx1TYx0qZBtinKdzTA==",
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.34.tgz",
+      "integrity": "sha512-WngYb2K+/yhkDOmDfAOjoCa9Ja3he0DZiAraboKwgWoVRkajDIcDYBCVbUTxtTUldvQoe7VvHLTrBNxvftN1aQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.3",
-        "@aws-sdk/nested-clients": "^3.997.1",
-        "@aws-sdk/token-providers": "3.1034.0",
+        "@aws-sdk/core": "^3.974.4",
+        "@aws-sdk/nested-clients": "^3.997.2",
+        "@aws-sdk/token-providers": "3.1035.0",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/shared-ini-file-loader": "^4.4.9",
@@ -486,13 +486,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.33",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.33.tgz",
-      "integrity": "sha512-RazhlN0YAkna2T2p2v4YuuRlVBVRNo8V0SL+9JePTWDndEUAeOBAjYeQfAMbtDyCh120+zA0Op6V0jS4dw2+iw==",
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.34.tgz",
+      "integrity": "sha512-5KLUH+XmSNRj6amJiJSrPsCxU5l/PYDfxyqPa1MxWhHoQC3sxvGPrSib3IE+HQlfRA4e2kO0bnJy7HJdjvpuuA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.3",
-        "@aws-sdk/nested-clients": "^3.997.1",
+        "@aws-sdk/core": "^3.974.4",
+        "@aws-sdk/nested-clients": "^3.997.2",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/shared-ini-file-loader": "^4.4.9",
@@ -537,15 +537,15 @@
       }
     },
     "node_modules/@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.974.11",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.11.tgz",
-      "integrity": "sha512-jTrJFs4SMs9xjih45+QHtU79piovA6CAlofMt4jeknN5ef9zsVEHDtuwCnEe/3eANWewa9fd6Tvc54xEPpQ3RA==",
+      "version": "3.974.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.12.tgz",
+      "integrity": "sha512-v7n0//P95g+UnmyjCpJkDJFB+EP/9Wx/fQJC5BEiK9Y7VHgmhh6RNPVbqDYz9gsz8mXnxzyYt3tCEVJ1kzo01w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
         "@aws-crypto/crc32c": "5.2.0",
         "@aws-crypto/util": "5.2.0",
-        "@aws-sdk/core": "^3.974.3",
+        "@aws-sdk/core": "^3.974.4",
         "@aws-sdk/crc64-nvme": "^3.972.7",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/is-array-buffer": "^4.2.2",
@@ -621,12 +621,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.972.32",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.32.tgz",
-      "integrity": "sha512-dc2O2x0V5pGJhmdQYQveUIFtMZsur7GrGuSgoKM4oQJuEcfvwnJ3sj+ip6WnxR5l6TrX5zkl4KgcgswOy3wAzQ==",
+      "version": "3.972.33",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.33.tgz",
+      "integrity": "sha512-n8Eh/+kq3u/EodLr8n6sQupu03QGjf122RHXCTGLaHSkavz/2beSKpRlq2oDgfmJZNkAkWF113xbyaUmyOd+YA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.3",
+        "@aws-sdk/core": "^3.974.4",
         "@aws-sdk/types": "^3.973.8",
         "@aws-sdk/util-arn-parser": "^3.972.3",
         "@smithy/core": "^3.23.16",
@@ -660,12 +660,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.972.33",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.33.tgz",
-      "integrity": "sha512-mqtT3Fo7xanWMk2SbAcKLGGI/q1GHWNrExBj7cnWP2W2mkTMheXB4ntJvwPZ1UxPrQobrsv2dWFXmaOJeSOiDg==",
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.34.tgz",
+      "integrity": "sha512-jrmJHyYlTQocR7H4VhvSFhaoedMb2rmlOTvFWD6tNBQ/EVQhTsrNfQUYFuPiOc2wUGxbm5LgCHtnvVmCPgODHw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.3",
+        "@aws-sdk/core": "^3.974.4",
         "@aws-sdk/types": "^3.973.8",
         "@aws-sdk/util-endpoints": "^3.996.8",
         "@smithy/core": "^3.23.16",
@@ -679,24 +679,24 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.1.tgz",
-      "integrity": "sha512-Afc9hc2WZs3X4Jb8dnxyuYiZsLoWRO51roTCRf497gPnAKN2WRdXANu1vaVCTzwnDMOYFXb/cYv4ZSjxqAqcKA==",
+      "version": "3.997.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.2.tgz",
+      "integrity": "sha512-uGGQO08YetrqfInOKG5atRMrCDRQWRuZ9gGfKY6svPmuE4K7ac+XcbCkpWpjcA7yCYsBaKB/Nly4XKgPXUO1PA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.3",
+        "@aws-sdk/core": "^3.974.4",
         "@aws-sdk/middleware-host-header": "^3.972.10",
         "@aws-sdk/middleware-logger": "^3.972.10",
         "@aws-sdk/middleware-recursion-detection": "^3.972.11",
-        "@aws-sdk/middleware-user-agent": "^3.972.33",
+        "@aws-sdk/middleware-user-agent": "^3.972.34",
         "@aws-sdk/region-config-resolver": "^3.972.13",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.20",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.21",
         "@aws-sdk/types": "^3.973.8",
         "@aws-sdk/util-endpoints": "^3.996.8",
         "@aws-sdk/util-user-agent-browser": "^3.972.10",
-        "@aws-sdk/util-user-agent-node": "^3.973.19",
+        "@aws-sdk/util-user-agent-node": "^3.973.20",
         "@smithy/config-resolver": "^4.4.17",
         "@smithy/core": "^3.23.16",
         "@smithy/fetch-http-handler": "^5.3.17",
@@ -745,12 +745,12 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.20",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.20.tgz",
-      "integrity": "sha512-MEj6DhEcaO8RgVtFCJ+xpCQnZC3Iesr09avdY75qkMQfckQULu447IegK7Rs1MCGerVBfKnJQ4q+pQq9hI5lng==",
+      "version": "3.996.21",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.21.tgz",
+      "integrity": "sha512-3EpT+C0QdmTMB5aVeJ5odWSLt9vg2oGzUXl1xvUazKGlkr9OBYnegNWqhhjGgZdv8RmSi5eS8nqqB+euNP2aqA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "^3.972.32",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.33",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/protocol-http": "^5.3.14",
         "@smithy/signature-v4": "^5.3.14",
@@ -762,13 +762,13 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1034.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1034.0.tgz",
-      "integrity": "sha512-8E+KGcD4ET0H9FXJ2/ZWbfFnQNYEkTZZYJxAs1lkdJlve1AYuqaydInIFfvNgoz5GbYtzbK8/ugsSMu5wPm6kA==",
+      "version": "3.1035.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1035.0.tgz",
+      "integrity": "sha512-E6IO3Cn+OzBe6Sb5pnubd5Y8qSUMAsVKkD5QSwFfIx5fV1g5SkYwUDRDyPlm90RuIVcCo28wpMJU6W8wXH46Aw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.3",
-        "@aws-sdk/nested-clients": "^3.997.1",
+        "@aws-sdk/core": "^3.974.4",
+        "@aws-sdk/nested-clients": "^3.997.2",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/shared-ini-file-loader": "^4.4.9",
@@ -845,12 +845,12 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.973.19",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.19.tgz",
-      "integrity": "sha512-ZAfHjpzdbrzkAftC139JoYGfXzDh5HY+AxRzw8pGJ8cULsf+l721sKAMK8mV5NvRETaW/BwghSwQhGgoNgrxMw==",
+      "version": "3.973.20",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.20.tgz",
+      "integrity": "sha512-owEqyKr0z5hWwk+uHwudwNhyFMZ9f9eSWr/k/XD6yeDCI7hHyc56s4UOY1iBQmoramTbdAY4UCuLLEuKmjVXrg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "^3.972.33",
+        "@aws-sdk/middleware-user-agent": "^3.972.34",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/node-config-provider": "^4.3.14",
         "@smithy/types": "^4.14.1",
@@ -899,6 +899,31 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test:unit": "node --test 'tests/**/*.test.js' 'tests/**/*.test.mjs'",
     "test:frontend": "npx playwright test --project=frontend",
     "test:e2e": "npx playwright test --project=e2e",
+    "coverage:frontend": "rm -rf coverage/raw && COVERAGE=1 npx playwright test --project=frontend && node scripts/coverage-report.mjs",
     "screenshots": "npx playwright test --config=playwright.screenshots.config.js",
     "diagram": "node design/diagrams/generate-topology.js",
     "topology-pdf": "node design/docs/pdf/generate-topology-pdf.js",
@@ -25,10 +26,14 @@
     "@playwright/test": "1.56.0",
     "acorn": "^8.16.0",
     "aedes": "^1.0.2",
+    "istanbul-lib-coverage": "^3.2.2",
+    "istanbul-lib-report": "^3.0.1",
+    "istanbul-reports": "^3.2.0",
     "js-yaml": "^4.1.1",
     "knip": "^6.6.1",
     "pg-mem": "^3.0.14",
-    "serve": "^14.2.6"
+    "serve": "^14.2.6",
+    "v8-to-istanbul": "^9.3.0"
   },
   "overrides": {
     "@emnapi/core": "^1.10.0",

--- a/scripts/coverage-report.mjs
+++ b/scripts/coverage-report.mjs
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+// Merges per-spec V8 coverage dumps (written by tests/frontend/fixtures.js
+// when COVERAGE=1) into an istanbul coverage map and renders it to
+// coverage/{lcov-report, lcov.info, text summary}.
+//
+// Scope: tests/frontend only — the tests/e2e suite has so little
+// surface right now that running coverage against it adds noise, not
+// signal. See memory/feedback_* for context.
+//
+// Usage:
+//   COVERAGE=1 npx playwright test --project=frontend
+//   node scripts/coverage-report.mjs
+//
+// Or just:
+//   npm run coverage:frontend
+
+import { readFileSync, readdirSync, existsSync, rmSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import v8toIstanbul from 'v8-to-istanbul';
+import libCoverage from 'istanbul-lib-coverage';
+import libReport from 'istanbul-lib-report';
+import reports from 'istanbul-reports';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const RAW_DIR = path.join(ROOT, 'coverage/raw');
+const REPORT_DIR = path.join(ROOT, 'coverage');
+const PLAYGROUND_DIR = path.join(ROOT, 'playground');
+
+// Map the URL Playwright reports (http://localhost:3210/js/main.js)
+// to the local file v8-to-istanbul needs to resolve. Anything outside
+// playground/js/ or playground/public/ is dropped — we only care about
+// first-party code, not Playwright internals or vendored libraries.
+function urlToLocalPath(url) {
+  let pathname;
+  try {
+    pathname = new URL(url).pathname;
+  } catch {
+    return null;
+  }
+  // `serve` is run from the repo root, so URLs come through as
+  // /playground/js/main.js. Strip the /playground prefix when present.
+  if (pathname.startsWith('/playground/')) pathname = pathname.slice('/playground'.length);
+  if (pathname.startsWith('/js/') || pathname === '/sw.js') {
+    const candidate = path.join(PLAYGROUND_DIR, pathname);
+    return existsSync(candidate) ? candidate : null;
+  }
+  return null;
+}
+
+async function convertEntry(map, entry) {
+  const localPath = urlToLocalPath(entry.url);
+  if (!localPath) return;
+  const converter = v8toIstanbul(localPath, 0, { source: entry.source });
+  try {
+    await converter.load();
+    converter.applyCoverage(entry.functions);
+    const istanbulData = converter.toIstanbul();
+    map.merge(istanbulData);
+  } catch (err) {
+    // v8-to-istanbul chokes occasionally on source-map edge cases —
+    // don't let one bad file black-hole the whole report.
+    process.stderr.write(`[coverage] skipped ${localPath}: ${err.message}\n`);
+  } finally {
+    converter.destroy();
+  }
+}
+
+function listPlaygroundJsFiles() {
+  const root = path.join(PLAYGROUND_DIR, 'js');
+  const entries = readdirSync(root, { recursive: true, withFileTypes: true });
+  const out = [];
+  for (const ent of entries) {
+    if (!ent.isFile()) continue;
+    if (!ent.name.endsWith('.js') && !ent.name.endsWith('.mjs')) continue;
+    const abs = path.join(ent.parentPath || ent.path || root, ent.name);
+    out.push(abs);
+  }
+  return out;
+}
+
+async function seedZeroCoverage(map) {
+  for (const absPath of listPlaygroundJsFiles()) {
+    if (map.files().includes(absPath)) continue;
+    const source = readFileSync(absPath, 'utf8');
+    const converter = v8toIstanbul(absPath, 0, { source });
+    try {
+      await converter.load();
+      converter.applyCoverage([]);
+      const data = converter.toIstanbul();
+      // v8-to-istanbul defaults every statement/branch/function hit
+      // count to 1 and only drops counts based on explicit uncovered
+      // ranges. Empty coverage therefore reads as 100% — the opposite
+      // of what we want. Manually zero the counters so "never loaded"
+      // reports as 0%.
+      for (const file of Object.keys(data)) {
+        const entry = data[file];
+        for (const k of Object.keys(entry.s)) entry.s[k] = 0;
+        for (const k of Object.keys(entry.f)) entry.f[k] = 0;
+        for (const k of Object.keys(entry.b)) entry.b[k] = entry.b[k].map(() => 0);
+      }
+      map.merge(data);
+    } catch (err) {
+      process.stderr.write(`[coverage] zero-seed failed for ${absPath}: ${err.message}\n`);
+    } finally {
+      converter.destroy();
+    }
+  }
+}
+
+async function main() {
+  if (!existsSync(RAW_DIR)) {
+    process.stderr.write(`[coverage] no raw dump at ${RAW_DIR}. Run COVERAGE=1 npx playwright test --project=frontend first.\n`);
+    process.exit(1);
+  }
+
+  const rawFiles = readdirSync(RAW_DIR).filter(f => f.endsWith('.json'));
+  if (rawFiles.length === 0) {
+    process.stderr.write('[coverage] raw dir is empty — tests ran but no coverage entries matched playground/js/**.\n');
+    process.exit(1);
+  }
+
+  const map = libCoverage.createCoverageMap({});
+  for (const f of rawFiles) {
+    const entries = JSON.parse(readFileSync(path.join(RAW_DIR, f), 'utf8'));
+    for (const entry of entries) {
+      await convertEntry(map, entry);
+    }
+  }
+
+  // V8 coverage only records files V8 actually loaded. A playground
+  // module that no spec ever imports silently vanishes from the
+  // report — the opposite of what we want. Walk the playground/js
+  // tree and synthesise a 0% entry for anything not already in the
+  // map so "never loaded" shows up as "0% covered".
+  await seedZeroCoverage(map);
+
+  // Clear previous report artifacts so removed files don't linger.
+  const prior = ['lcov-report', 'lcov.info', 'coverage-summary.json'];
+  for (const p of prior) {
+    const abs = path.join(REPORT_DIR, p);
+    if (existsSync(abs)) rmSync(abs, { recursive: true, force: true });
+  }
+
+  const context = libReport.createContext({
+    dir: REPORT_DIR,
+    defaultSummarizer: 'nested',
+    coverageMap: map,
+  });
+
+  reports.create('text', { skipEmpty: false, skipFull: false }).execute(context);
+  reports.create('lcov').execute(context);
+  reports.create('json-summary').execute(context);
+
+  const htmlIndex = path.join(REPORT_DIR, 'lcov-report/index.html');
+  if (existsSync(htmlIndex)) {
+    process.stdout.write(`\n[coverage] HTML report: ${pathToFileURL(htmlIndex).href}\n`);
+  }
+}
+
+main().catch(err => {
+  process.stderr.write(err.stack + '\n');
+  process.exit(1);
+});

--- a/tests/frontend/fixtures.js
+++ b/tests/frontend/fixtures.js
@@ -10,14 +10,53 @@
  *
  * See tests/e2e/fixtures.js for the sibling suite that runs against
  * a real server + aedes + pg-mem.
+ *
+ * Coverage: when COVERAGE=1 is set, the page fixture starts V8 JS
+ * coverage at test start and dumps the raw output to
+ * `coverage/raw/<testId>.json` at teardown. `npm run coverage:frontend`
+ * reads that directory, filters to playground/js/**, and renders an
+ * istanbul HTML/lcov/text report. Running without the env var is the
+ * default so unit-test-speed Playwright runs stay unchanged.
  */
 import { test as base, expect } from '@playwright/test';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const COVERAGE_ENABLED = process.env.COVERAGE === '1';
+const COVERAGE_DIR = path.resolve(process.cwd(), 'coverage/raw');
+
+if (COVERAGE_ENABLED) {
+  fs.mkdirSync(COVERAGE_DIR, { recursive: true });
+}
 
 export const test = base.extend({
-  page: async ({ page }, use) => {
-    // Block Google Fonts — prevents page load hanging in offline environments
+  page: async ({ page }, use, testInfo) => {
     await page.route(/fonts\.(googleapis|gstatic)\.com/, route => route.abort());
+
+    if (COVERAGE_ENABLED) {
+      await page.coverage.startJSCoverage({ resetOnNavigation: false });
+    }
+
     await use(page);
+
+    if (COVERAGE_ENABLED) {
+      let entries;
+      try {
+        entries = await page.coverage.stopJSCoverage();
+      } catch {
+        // The page may already be closed by the time teardown runs.
+        // That's fine — a closed page just means there's nothing to collect.
+        return;
+      }
+      // Keep only scripts served from the playground tree. Anything
+      // else (Playwright's injected helpers, vendored libs served under
+      // /vendor, inline snippets without a URL) is noise for this report.
+      const filtered = entries.filter(e => /\/js\//.test(e.url) && !/\/vendor\//.test(e.url));
+      if (filtered.length > 0) {
+        const destFile = path.join(COVERAGE_DIR, `${testInfo.testId}.json`);
+        fs.writeFileSync(destFile, JSON.stringify(filtered));
+      }
+    }
   },
 });
 


### PR DESCRIPTION
## Summary
- `npm run coverage:frontend` — runs the frontend Playwright suite with \`COVERAGE=1\`, converts V8 coverage per spec via \`v8-to-istanbul\`, merges to an istanbul map, seeds 0% entries for playground/js files nothing loaded, outputs \`coverage/\` (HTML + lcov + text summary).
- Scoped deliberately to \`tests/frontend\`. The e2e suite has too little surface right now for its coverage to be more signal than noise — will revisit after we seed more e2e specs.
- Opt-in via env var so normal runs stay fast. Output gitignored. No CI wiring.

## First-run numbers (198 frontend specs)
Overall: 83.4% statements, 94.5% branches, 80.6% functions.

Notable gaps surfaced (consistent with the earlier qualitative coverage analysis):
- \`flow-tester.js\` — 0% (no spec loads flow-tester.html)
- \`crashes-view.js\` — 15.7%
- \`notifications.js\` — 44.0%
- \`sim-bootstrap.js\` — 51.5%
- \`auth.js\` — 56.0%

## Test plan
- [x] \`npm run test:unit\` — 792 pass
- [x] \`npm test\` — 202 Playwright pass, 792 unit pass (non-coverage run unaffected)
- [x] \`npm run coverage:frontend\` — generates a report with playground/js files only
- [x] \`npm run lint:debt\` — file-size/knip/assets all clean
- [x] \`npm ci\` — lockfile in sync
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)