### PR TITLE
ci: gate frontend coverage at ≥50% or explicit exclusion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,14 @@ jobs:
           fi
         env:
           HOME: /root
+          # Collect V8 coverage during the frontend project run so the
+          # post-test coverage-check step can gate it. Adds ~5% to the
+          # Playwright wall time, no extra suite run.
+          COVERAGE: '1'
+      - name: Render frontend coverage report
+        run: node scripts/coverage-report.mjs
+      - name: Check frontend coverage gate (≥50% or explicit exclusion)
+        run: node scripts/coverage-check.mjs
       - name: Check file-size budget
         run: npm run check:file-size -- --strict
       - name: Check dead code — knip

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,6 +104,10 @@ When adding a new mutating endpoint, add the same guard.
 
 Missing tests = incomplete fix. Applies to behavior changes too (e.g. removing auto-polling, changing error messages).
 
+## Frontend Coverage Gate
+
+Every file under `playground/js/**` must have ≥50% statement coverage from the `tests/frontend` Playwright suite, or be listed in `coverage-exclusions.json` with a written reason. CI enforces both directions: below-threshold unexcluded files fail, **and** excluded files that climb ≥50% fail too (drop the stale entry). Adding an exclusion is acceptable; stacking many exclusions is a smell. See `scripts/coverage-check.mjs`.
+
 ## Commands
 
 ```bash
@@ -111,7 +115,7 @@ npm test                           # unit + frontend + e2e
 npm run test:unit                  # fast, no browser
 npm run test:frontend              # Playwright against static serve — frontend with mocked APIs
 npm run test:e2e                   # Playwright against real server + pg-mem + aedes MQTT
-npm run coverage:frontend          # V8 JS coverage for playground/js/** driven by the frontend suite — HTML + lcov in coverage/
+npm run coverage:frontend          # V8 JS coverage for playground/js/** driven by the frontend suite — HTML + lcov in coverage/ (CI runs the same report + gate, see "Frontend Coverage Gate")
 npm run screenshots                # regenerate screenshots (runs 24 h sim, ~1–2 min)
 npm run diagram                    # regenerate system-topology.drawio (dark theme)
 npm run topology-pdf               # printable light-theme PDF of the topology

--- a/coverage-exclusions.json
+++ b/coverage-exclusions.json
@@ -1,8 +1,4 @@
 {
   "_comment": "Frontend JS files that bypass the 50% coverage gate enforced by scripts/coverage-check.mjs. Paths are relative to the repo root; each key maps to a written reason. Prefer adding a test over adding an entry here. CI also fails if an excluded file has climbed above the threshold — delete stale entries when that happens.",
-  "files": {
-    "playground/js/flow-tester.js": "Standalone visual-verification page that is not linked from the SPA navigation. The production logic it exercises (schematic.js, schematic-topology.js) is covered via the Components view specs. Meaningful coverage would require a dedicated visual-regression spec.",
-    "playground/js/crashes-view.js": "TODO: add a frontend spec that injects a `script-crash` WS broadcast and asserts the crashes view renders. Currently ~16% covered (the module loads but no spec drives the user interactions it wires up).",
-    "playground/js/notifications.js": "TODO: add spec coverage for the notification payload renderers. Currently ~44% covered — the registration/subscription paths run, but several category-specific payload builders never fire under the existing specs."
-  }
+  "files": {}
 }

--- a/coverage-exclusions.json
+++ b/coverage-exclusions.json
@@ -1,0 +1,8 @@
+{
+  "_comment": "Frontend JS files that bypass the 50% coverage gate enforced by scripts/coverage-check.mjs. Paths are relative to the repo root; each key maps to a written reason. Prefer adding a test over adding an entry here. CI also fails if an excluded file has climbed above the threshold — delete stale entries when that happens.",
+  "files": {
+    "playground/js/flow-tester.js": "Standalone visual-verification page that is not linked from the SPA navigation. The production logic it exercises (schematic.js, schematic-topology.js) is covered via the Components view specs. Meaningful coverage would require a dedicated visual-regression spec.",
+    "playground/js/crashes-view.js": "TODO: add a frontend spec that injects a `script-crash` WS broadcast and asserts the crashes view renders. Currently ~16% covered (the module loads but no spec drives the user interactions it wires up).",
+    "playground/js/notifications.js": "TODO: add spec coverage for the notification payload renderers. Currently ~44% covered — the registration/subscription paths run, but several category-specific payload builders never fire under the existing specs."
+  }
+}

--- a/scripts/coverage-check.mjs
+++ b/scripts/coverage-check.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+// Enforces the per-file frontend coverage gate described in
+// coverage-exclusions.json: every playground/js/** file must have
+// ≥50% statement coverage from the tests/frontend Playwright suite,
+// or be listed in coverage-exclusions.json with a written reason.
+//
+// Failure modes:
+//   - A non-excluded file is below the threshold → CI fails. Fix by
+//     adding a spec that exercises it, or add the path to
+//     coverage-exclusions.json with a comment explaining why.
+//   - An excluded file has climbed ≥threshold → CI fails. Drop the
+//     entry from coverage-exclusions.json; the exclusion is stale.
+//
+// Runs after scripts/coverage-report.mjs in CI. Reads:
+//   coverage/coverage-summary.json (from the report script)
+//   coverage-exclusions.json       (repo root)
+
+import { readFileSync, existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const SUMMARY_PATH = path.join(ROOT, 'coverage/coverage-summary.json');
+const EXCLUSIONS_PATH = path.join(ROOT, 'coverage-exclusions.json');
+const THRESHOLD = 50;
+
+if (!existsSync(SUMMARY_PATH)) {
+  process.stderr.write(`[coverage-check] ${SUMMARY_PATH} not found. Run \`node scripts/coverage-report.mjs\` first.\n`);
+  process.exit(1);
+}
+
+const summary = JSON.parse(readFileSync(SUMMARY_PATH, 'utf8'));
+const exclusionsRaw = existsSync(EXCLUSIONS_PATH)
+  ? JSON.parse(readFileSync(EXCLUSIONS_PATH, 'utf8'))
+  : { files: {} };
+const exclusionsMap = exclusionsRaw.files || {};
+
+// The summary's keys are absolute paths. The exclusions file stores
+// repo-relative paths for readability. The filtered report doesn't
+// include excluded files at all — so anything in the summary is a
+// candidate for the threshold check. We still need the exclusions
+// map to flag stale exclusions (files that ARE in the summary
+// because they WEREN'T excluded but coverage climbed past the mark
+// doesn't apply here — see below).
+const excludedAbs = new Set(Object.keys(exclusionsMap).map(rel => path.join(ROOT, rel)));
+
+const failed = [];
+for (const [key, data] of Object.entries(summary)) {
+  if (key === 'total') continue;
+  const rel = path.relative(ROOT, key);
+  const pct = data.statements.pct;
+  if (pct < THRESHOLD) failed.push({ rel, pct });
+}
+
+// Stale-exclusion pressure: if an excluded file was converted via
+// v8-to-istanbul but then filtered out of the summary, we can't read
+// its % here. coverage-report.mjs does filter excluded files out of
+// the summary entirely. To detect stale exclusions, re-parse the
+// full coverage-final.json (unfiltered) if present — skip otherwise.
+const FULL_PATH = path.join(ROOT, 'coverage/lcov.info');
+const staleExclusions = [];
+// lcov is line-level; easier to read a separate unfiltered JSON. We
+// emit coverage/coverage-summary-with-excluded.json from the report
+// script when exclusions are present.
+const FULL_SUMMARY_PATH = path.join(ROOT, 'coverage/coverage-summary-with-excluded.json');
+if (existsSync(FULL_SUMMARY_PATH)) {
+  const full = JSON.parse(readFileSync(FULL_SUMMARY_PATH, 'utf8'));
+  for (const [key, data] of Object.entries(full)) {
+    if (key === 'total') continue;
+    if (!excludedAbs.has(key)) continue;
+    const pct = data.statements.pct;
+    if (pct >= THRESHOLD) staleExclusions.push({ rel: path.relative(ROOT, key), pct });
+  }
+}
+
+if (failed.length === 0 && staleExclusions.length === 0) {
+  const excludedCount = Object.keys(exclusionsMap).length;
+  process.stdout.write(
+    `coverage-check: every non-excluded playground/js file ≥${THRESHOLD}% statements ` +
+    `(${Object.keys(summary).length - 1} checked, ${excludedCount} excluded) ✓\n`
+  );
+  process.exit(0);
+}
+
+if (failed.length > 0) {
+  process.stderr.write(`\n✗ Frontend coverage below ${THRESHOLD}% statements (and not excluded):\n`);
+  for (const { rel, pct } of failed.sort((a, b) => a.pct - b.pct)) {
+    process.stderr.write(`    ${rel}  ${pct.toFixed(1)}%\n`);
+  }
+  process.stderr.write(
+    '\n  Either add a frontend spec that exercises the file, or add an entry ' +
+    'to coverage-exclusions.json with a reason.\n'
+  );
+}
+
+if (staleExclusions.length > 0) {
+  process.stderr.write(`\n✗ Excluded files now ≥${THRESHOLD}% — remove them from coverage-exclusions.json:\n`);
+  for (const { rel, pct } of staleExclusions) {
+    process.stderr.write(`    ${rel}  ${pct.toFixed(1)}%\n`);
+  }
+}
+
+process.exit(1);

--- a/scripts/coverage-report.mjs
+++ b/scripts/coverage-report.mjs
@@ -26,6 +26,19 @@ const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const RAW_DIR = path.join(ROOT, 'coverage/raw');
 const REPORT_DIR = path.join(ROOT, 'coverage');
 const PLAYGROUND_DIR = path.join(ROOT, 'playground');
+const EXCLUSIONS_PATH = path.join(ROOT, 'coverage-exclusions.json');
+
+// Exclusions named in coverage-exclusions.json are dropped from the
+// map before rendering, matching "explicitly excluded from the
+// coverage analysis". The HTML/lcov/summary therefore only cover
+// files the 50% gate actually applies to. scripts/coverage-check.mjs
+// reads the same file and treats an exclusion both as "don't fail
+// for <50%" and "fail if now ≥50% (stale — drop the entry)".
+function loadExclusions() {
+  if (!existsSync(EXCLUSIONS_PATH)) return new Set();
+  const raw = JSON.parse(readFileSync(EXCLUSIONS_PATH, 'utf8'));
+  return new Set(Object.keys(raw.files || {}).map(rel => path.join(ROOT, rel)));
+}
 
 // Map the URL Playwright reports (http://localhost:3210/js/main.js)
 // to the local file v8-to-istanbul needs to resolve. Anything outside
@@ -135,6 +148,16 @@ async function main() {
   // map so "never loaded" shows up as "0% covered".
   await seedZeroCoverage(map);
 
+  // Build a filtered map for the visible report — excluded files are
+  // carved out of the report entirely, per coverage-exclusions.json.
+  // The original `map` stays intact so we can emit an unfiltered
+  // summary afterwards for stale-exclusion detection.
+  const excluded = loadExclusions();
+  const filteredMap = libCoverage.createCoverageMap({});
+  for (const file of map.files()) {
+    if (!excluded.has(file)) filteredMap.addFileCoverage(map.fileCoverageFor(file));
+  }
+
   // Clear previous report artifacts so removed files don't linger.
   const prior = ['lcov-report', 'lcov.info', 'coverage-summary.json'];
   for (const p of prior) {
@@ -145,12 +168,25 @@ async function main() {
   const context = libReport.createContext({
     dir: REPORT_DIR,
     defaultSummarizer: 'nested',
-    coverageMap: map,
+    coverageMap: filteredMap,
   });
 
   reports.create('text', { skipEmpty: false, skipFull: false }).execute(context);
   reports.create('lcov').execute(context);
   reports.create('json-summary').execute(context);
+
+  // Also emit an unfiltered summary so coverage-check.mjs can detect
+  // stale exclusions — files listed in coverage-exclusions.json whose
+  // coverage has since climbed past the threshold.
+  if (excluded.size > 0) {
+    const fullContext = libReport.createContext({
+      dir: REPORT_DIR,
+      defaultSummarizer: 'nested',
+      coverageMap: map,
+    });
+    reports.create('json-summary', { file: 'coverage-summary-with-excluded.json' })
+      .execute(fullContext);
+  }
 
   const htmlIndex = path.join(REPORT_DIR, 'lcov-report/index.html');
   if (existsSync(htmlIndex)) {

--- a/tests/frontend/crashes-view.spec.js
+++ b/tests/frontend/crashes-view.spec.js
@@ -1,0 +1,146 @@
+import { test, expect } from './fixtures.js';
+
+// Covers playground/js/crashes-view.js — the #crashes view that lists
+// entries from GET /api/script/crashes and lazy-loads GET /api/script/crashes/:id
+// on row click, with a Copy-JSON button on the expanded detail.
+
+async function mockScaffold(page, { crashes, detailById }) {
+  // Minimal WS mock — crashes view doesn't need live state but main.js
+  // opens a WebSocket on boot. Keep it connected with no messages to
+  // stop the bootstrap from spinning on the initial state fetch.
+  await page.addInitScript(() => {
+    const OrigWS = window.WebSocket;
+    window.WebSocket = function () {
+      const fake = {
+        readyState: 0, onopen: null, onmessage: null, onclose: null, onerror: null,
+        close() { this.readyState = 3; },
+        send() {},
+      };
+      setTimeout(() => {
+        fake.readyState = 1;
+        if (fake.onopen) fake.onopen(new Event('open'));
+        if (fake.onmessage) fake.onmessage({ data: JSON.stringify({ type: 'connection', status: 'connected' }) });
+      }, 50);
+      return fake;
+    };
+    window.WebSocket.prototype = OrigWS.prototype;
+    window.WebSocket.OPEN = 1;
+    window.WebSocket.CLOSED = 3;
+  });
+
+  // Crash list + per-id detail. detailById is a map id → payload OR
+  // a 'HTTP ###' string to trigger the error branch.
+  await page.route('**/api/script/crashes?**', r => r.fulfill({
+    status: 200, contentType: 'application/json',
+    body: JSON.stringify({ crashes }),
+  }));
+  await page.route('**/api/script/crashes/*', r => {
+    const id = decodeURIComponent(new URL(r.request().url()).pathname.split('/').pop());
+    const payload = detailById[id];
+    if (typeof payload === 'number') {
+      return r.fulfill({ status: payload, contentType: 'application/json', body: '{}' });
+    }
+    return r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(payload) });
+  });
+
+  // Silence the other endpoints main.js loads during boot.
+  await page.route('**/api/watchdog/state', r => r.fulfill({
+    status: 200, contentType: 'application/json',
+    body: JSON.stringify({ pending: null, watchdogs: [], snapshot: { we: {}, wz: {}, wb: {} }, recent: [] }),
+  }));
+  await page.route('**/api/device-config', r => r.fulfill({
+    status: 200, contentType: 'application/json',
+    body: JSON.stringify({ ce: true, ea: 31, fm: null, we: {}, wz: {}, wb: {}, v: 1 }),
+  }));
+  await page.route('**/api/history**', r => r.fulfill({ status: 200, contentType: 'application/json', body: '[]' }));
+  await page.route('**/api/events**', r => r.fulfill({ status: 200, contentType: 'application/json', body: '[]' }));
+  await page.route('**/api/push/**', r => r.fulfill({ status: 200, contentType: 'application/json', body: '{}' }));
+}
+
+test.describe('#crashes view', () => {
+  const crashA = {
+    id: 1001,
+    ts: Date.parse('2026-04-22T10:00:00Z'),
+    error_msg: 'TypeError: undefined is not a function',
+    error_trace: 'at control.js:42',
+    resolved_at: null,
+  };
+  const crashB = {
+    id: 1002,
+    ts: Date.parse('2026-04-21T20:00:00Z'),
+    error_msg: null,
+    error_trace: null,
+    resolved_at: Date.parse('2026-04-21T21:00:00Z'),
+  };
+
+  test('empty list renders the empty-state panel', async ({ page }) => {
+    await mockScaffold(page, { crashes: [], detailById: {} });
+    await page.goto('/playground/#crashes');
+    // Wait for mount — the list shows "Loading…" synchronously, then empty
+    // shows once the fetch resolves.
+    await expect(page.locator('#crashes-empty')).toBeVisible();
+    await expect(page.locator('#crashes-list li')).toHaveCount(0);
+  });
+
+  test('list renders one row per crash with message + timestamp', async ({ page }) => {
+    await mockScaffold(page, {
+      crashes: [crashA, crashB],
+      detailById: {},
+    });
+    await page.goto('/playground/#crashes');
+
+    await expect(page.locator('#crashes-list li')).toHaveCount(2);
+    // crashA's error_msg is visible; crashB shows the "(no error message)" fallback.
+    await expect(page.locator('#crashes-list li[data-id="1001"]')).toContainText('TypeError');
+    await expect(page.locator('#crashes-list li[data-id="1002"]')).toContainText('(no error message)');
+    // crashB was resolved — resolved-timestamp chip appears.
+    await expect(page.locator('#crashes-list li[data-id="1002"] .crashes-resolved')).toBeVisible();
+  });
+
+  test('clicking a row loads the detail + toggling hides it again', async ({ page }) => {
+    const detail = { ...crashA, sys_status: { ok: true }, recent_states: [{ mode: 'idle' }] };
+    await mockScaffold(page, { crashes: [crashA], detailById: { 1001: detail } });
+    await page.goto('/playground/#crashes');
+
+    const row = page.locator('#crashes-list li[data-id="1001"]');
+    await row.click();
+    // detailTemplate puts the JSON inside .crashes-detail and appends
+    // a Copy JSON button.
+    const detailEl = row.locator('.crashes-detail');
+    await expect(detailEl).toBeVisible();
+    await expect(detailEl).toContainText('"id": 1001');
+    await expect(detailEl).toContainText('"recent_states"');
+    await expect(row.locator('button.crashes-copy')).toBeVisible();
+
+    // Click the row again → detail collapses.
+    await row.click();
+    await expect(row.locator('.crashes-detail')).toHaveCount(0);
+    await expect(row.locator('button.crashes-copy')).toHaveCount(0);
+  });
+
+  test('failed detail fetch renders the failure message inline', async ({ page }) => {
+    await mockScaffold(page, { crashes: [crashA], detailById: { 1001: 500 } });
+    await page.goto('/playground/#crashes');
+    const row = page.locator('#crashes-list li[data-id="1001"]');
+    await row.click();
+    await expect(row.locator('.crashes-detail')).toContainText('Failed to load: HTTP 500');
+  });
+
+  test('Copy JSON button writes the detail JSON to the clipboard', async ({ page, context }) => {
+    const detail = { ...crashA, sys_status: { mode: 'idle' }, recent_states: [] };
+    await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+    await mockScaffold(page, { crashes: [crashA], detailById: { 1001: detail } });
+    await page.goto('/playground/#crashes');
+
+    const row = page.locator('#crashes-list li[data-id="1001"]');
+    await row.click();
+    const copyBtn = row.locator('button.crashes-copy');
+    await expect(copyBtn).toHaveText('Copy JSON');
+    await copyBtn.click();
+    // Button text flips to "Copied" briefly after the clipboard write resolves.
+    await expect(copyBtn).toHaveText('Copied');
+
+    const clipboard = await page.evaluate(() => navigator.clipboard.readText());
+    expect(clipboard).toContain('"id": 1001');
+  });
+});

--- a/tests/frontend/flow-tester.spec.js
+++ b/tests/frontend/flow-tester.spec.js
@@ -1,0 +1,62 @@
+import { test, expect } from './fixtures.js';
+
+// flow-tester.html is a standalone visual-verification page — not
+// linked from the SPA nav — that renders one schematic per operating
+// mode so pipe highlights and flow directions can be eyeballed
+// side-by-side. The spec is deliberately thin: load the page, confirm
+// all five mode cards mount and the schematic renders inside each,
+// catch any console errors. Production logic lives in schematic.js /
+// schematic-topology.js, both already covered by the Components view
+// specs — this spec's job is to make sure the tester page itself
+// doesn't silently break when those APIs drift.
+test.describe('flow-tester page', () => {
+  const EXPECTED_MODES = ['idle', 'solar_charging', 'greenhouse_heating', 'active_drain', 'emergency_heating'];
+
+  test('renders one mode card per operating mode with a schematic inside', async ({ page }) => {
+    const consoleErrors = [];
+    page.on('console', msg => {
+      if (msg.type() === 'error') consoleErrors.push(msg.text());
+    });
+
+    await page.goto('/playground/flow-tester.html');
+
+    // Each mode renders into a <section class="mode-card" data-mode="…">.
+    // init() iterates sequentially so cards appear one by one; wait
+    // for the last expected mode to settle.
+    for (const mode of EXPECTED_MODES) {
+      await expect(page.locator(`section.mode-card[data-mode="${mode}"]`)).toBeVisible();
+    }
+
+    // Each card must have a schematic-host containing an SVG — if
+    // buildSchematic rejected, the spec's catch branch replaces the
+    // host contents with an error string and no SVG is mounted.
+    // init() renders modes sequentially, so poll until every card has
+    // its SVG rather than asserting once and racing the last mount.
+    await expect.poll(
+      () => page.locator('section.mode-card .schematic-host svg').count(),
+      { timeout: 10_000 },
+    ).toBe(EXPECTED_MODES.length);
+
+    // openValvesSummary renders one span per valve id plus a pump
+    // span; emergency_heating adds a space-heater span. Sanity-check
+    // that the summary row for solar_charging highlights VI-btm and
+    // VO-coll as open (and pump on), confirming the preset reached
+    // the DOM.
+    const solarCard = page.locator('section.mode-card[data-mode="solar_charging"]');
+    await expect(solarCard.locator('.valve-summary span.open', { hasText: 'vi_btm' })).toBeVisible();
+    await expect(solarCard.locator('.valve-summary span.open', { hasText: 'vo_coll' })).toBeVisible();
+    await expect(solarCard.locator('.valve-summary span.open', { hasText: 'pump ON' })).toBeVisible();
+
+    // idle should list "all closed" — exercises the zero-open branch
+    // in openValvesSummary.
+    const idleCard = page.locator('section.mode-card[data-mode="idle"]');
+    await expect(idleCard.locator('.valve-summary span', { hasText: 'all closed' })).toBeVisible();
+
+    // emergency_heating adds the space-heater span — exercises the
+    // `if (mode.space_heater)` branch.
+    const emergencyCard = page.locator('section.mode-card[data-mode="emergency_heating"]');
+    await expect(emergencyCard.locator('.valve-summary span.open', { hasText: 'space heater ON' })).toBeVisible();
+
+    expect(consoleErrors).toEqual([]);
+  });
+});

--- a/tests/frontend/notifications-push.spec.js
+++ b/tests/frontend/notifications-push.spec.js
@@ -1,0 +1,212 @@
+import { test, expect } from './fixtures.js';
+
+// Drives the push-subscription paths in playground/js/notifications.js
+// that pwa-notifications.spec.js doesn't reach: subscribePush,
+// updateCategories, sendTest, unsubscribePush, updateNotificationUI,
+// updateCategoryCheckboxes, getSelectedCategories, isSubscribed, plus
+// urlBase64ToUint8Array + encodeKey.
+//
+// Why this needs a separate spec: those branches require a working
+// ServiceWorker + PushManager + Notification.requestPermission. The
+// existing settings specs assume (correctly) that Playwright's
+// Chromium can't actually register push subscriptions against a
+// static server, so they stop at UI-only assertions. Here we fake
+// the browser APIs via addInitScript so the real notifications.js
+// code runs end-to-end against the mocks.
+
+async function installPushMocks(page) {
+  await page.addInitScript(() => {
+    // Fake ServiceWorker registration + PushManager. The real
+    // navigator.serviceWorker is inert against a static file server,
+    // so we replace it wholesale with an object the code can drive.
+    const fakeKey = (label) => {
+      const bytes = new TextEncoder().encode(label);
+      return bytes.buffer;
+    };
+    let fakeSubscription = null;
+    const pushManager = {
+      async subscribe(opts) {
+        fakeSubscription = {
+          endpoint: 'https://fcm.example/' + Math.random().toString(36).slice(2),
+          options: opts,
+          _keys: { p256dh: fakeKey('p256dh-fake'), auth: fakeKey('auth-fake') },
+          getKey(name) { return this._keys[name]; },
+          async unsubscribe() { fakeSubscription = null; return true; },
+        };
+        return fakeSubscription;
+      },
+      async getSubscription() { return fakeSubscription; },
+    };
+    const fakeRegistration = {
+      pushManager,
+      scope: '/',
+      active: { state: 'activated' },
+      addEventListener() {},
+    };
+    Object.defineProperty(navigator, 'serviceWorker', {
+      configurable: true,
+      value: {
+        register: async () => fakeRegistration,
+        ready: Promise.resolve(fakeRegistration),
+        controller: null,
+        addEventListener() {},
+      },
+    });
+    // initNotifications checks `'PushManager' in window`. Add a stub
+    // constructor so the feature-detect passes; notifications.js only
+    // uses PushManager indirectly via swRegistration.pushManager.
+    if (!('PushManager' in window)) {
+      window.PushManager = function PushManager() {};
+    }
+    // Force the permission grant without the native prompt.
+    try {
+      Object.defineProperty(window.Notification, 'permission', { value: 'granted', configurable: true });
+      window.Notification.requestPermission = async () => 'granted';
+    } catch (_) {
+      // Some browsers ship a sealed Notification — fall back to a shim.
+      window.Notification = function () {};
+      window.Notification.permission = 'granted';
+      window.Notification.requestPermission = async () => 'granted';
+    }
+  });
+
+  // Track every /api/push/* request so tests can assert what fired.
+  const calls = [];
+
+  // Use RegExp with $ anchors so `.../subscribe` doesn't accidentally
+  // match `.../subscription` — Playwright's glob `**/foo` is a prefix
+  // match on the final segment, which silently routed syncCategories'
+  // POST-to-/api/push/subscription into the /api/push/subscribe handler.
+  await page.route(/\/api\/push\/vapid-key$/, route => route.fulfill({
+    status: 200, contentType: 'application/json',
+    body: JSON.stringify({ publicKey: 'BIlDax-DYNzPJfB4LHkOfn_nnpU1i_-27xp9UHUZS-axEePU-xIB94H4vblRxEJxjR-k-SK70o-mpQoMy2QcZUA' }),
+  }));
+  await page.route(/\/sw\.js$/, route => route.fulfill({
+    status: 200, contentType: 'application/javascript',
+    body: 'self.addEventListener("install", () => self.skipWaiting());',
+  }));
+  await page.route(/\/api\/push\/subscription$/, async route => {
+    let body = {};
+    try { body = route.request().postDataJSON() || {}; } catch (_) { /* no body */ }
+    calls.push({ url: '/api/push/subscription', body });
+    route.fulfill({ status: 200, contentType: 'application/json',
+      body: JSON.stringify({ subscribed: true, categories: ['pre_emergency'] }),
+    });
+  });
+  await page.route(/\/api\/push\/subscribe$/, async route => {
+    let body = {};
+    try { body = route.request().postDataJSON() || {}; } catch (_) { /* no body */ }
+    calls.push({ url: '/api/push/subscribe', body });
+    route.fulfill({ status: 200, contentType: 'application/json', body: '{}' });
+  });
+  await page.route(/\/api\/push\/unsubscribe$/, async route => {
+    let body = {};
+    try { body = route.request().postDataJSON() || {}; } catch (_) { /* no body */ }
+    calls.push({ url: '/api/push/unsubscribe', body });
+    route.fulfill({ status: 200, contentType: 'application/json', body: '{}' });
+  });
+  await page.route(/\/api\/push\/test$/, async route => {
+    let body = {};
+    try { body = route.request().postDataJSON() || {}; } catch (_) { /* no body */ }
+    calls.push({ url: '/api/push/test', body });
+    route.fulfill({ status: 200, contentType: 'application/json', body: '{}' });
+  });
+
+  return { calls };
+}
+
+async function gotoSettings(page) {
+  await page.evaluate(() => { window.location.hash = 'settings'; });
+  await expect(page.locator('#view-settings')).toHaveClass(/active/);
+  // Wait for initNotifications to settle — the toggle button gets its
+  // label set once VAPID is loaded and categories are synced.
+  await page.waitForFunction(() => {
+    const btn = document.querySelector('#notif-toggle-btn');
+    return btn && !btn.disabled;
+  }, { timeout: 5000 }).catch(() => {});
+}
+
+test.describe('notifications.js push subscription flow', () => {
+  test('clicking the toggle subscribes and POSTs /api/push/subscribe', async ({ page }) => {
+    const { calls } = await installPushMocks(page);
+    await page.goto('/playground/?mode=sim', { waitUntil: 'domcontentloaded' });
+    await gotoSettings(page);
+
+    const toggle = page.locator('#notif-toggle-btn');
+    await expect(toggle).toBeVisible();
+    await expect(toggle).not.toHaveClass(/notif-active/);
+
+    await toggle.click();
+
+    // After the subscribe round-trip resolves the button gains the
+    // active class and the label changes — this exercises
+    // updateNotificationUI().
+    await expect(toggle).toHaveClass(/notif-active/, { timeout: 5000 });
+    await expect(toggle.locator('.auth-btn-label')).toContainText(/disable/i);
+
+    // Backend saw a subscribe call with endpoint + keys + categories.
+    const subscribeCall = calls.find(c => c.url === '/api/push/subscribe');
+    expect(subscribeCall).toBeTruthy();
+    expect(subscribeCall.body.subscription.endpoint).toMatch(/^https:\/\/fcm\.example\//);
+    expect(subscribeCall.body.subscription.keys.p256dh).toBeTruthy();
+    expect(subscribeCall.body.subscription.keys.auth).toBeTruthy();
+    expect(Array.isArray(subscribeCall.body.categories)).toBe(true);
+  });
+
+  test('toggling a category after subscribing PATCHes via /api/push/subscribe', async ({ page }) => {
+    const { calls } = await installPushMocks(page);
+    await page.goto('/playground/?mode=sim', { waitUntil: 'domcontentloaded' });
+    await gotoSettings(page);
+
+    await page.locator('#notif-toggle-btn').click();
+    await expect(page.locator('#notif-toggle-btn')).toHaveClass(/notif-active/, { timeout: 5000 });
+    calls.length = 0;
+
+    // Toggle the first category checkbox — updateCategories should fire.
+    const firstCat = page.locator('[id^="notif-cat-"]').first();
+    await firstCat.click();
+
+    await expect.poll(() => calls.find(c => c.url === '/api/push/subscribe')).toBeTruthy();
+    const call = calls.find(c => c.url === '/api/push/subscribe');
+    expect(Array.isArray(call.body.categories)).toBe(true);
+  });
+
+  test('Send test button calls /api/push/test for the clicked category', async ({ page }) => {
+    const { calls } = await installPushMocks(page);
+    await page.goto('/playground/?mode=sim', { waitUntil: 'domcontentloaded' });
+    await gotoSettings(page);
+
+    await page.locator('#notif-toggle-btn').click();
+    await expect(page.locator('#notif-toggle-btn')).toHaveClass(/notif-active/, { timeout: 5000 });
+    calls.length = 0;
+
+    const testBtn = page.locator('[data-test-category]').first();
+    const category = await testBtn.getAttribute('data-test-category');
+    await testBtn.click();
+
+    await expect.poll(() => calls.find(c => c.url === '/api/push/test')).toBeTruthy();
+    const call = calls.find(c => c.url === '/api/push/test');
+    expect(call.body.category).toBe(category);
+    expect(call.body.endpoint).toMatch(/^https:\/\/fcm\.example\//);
+  });
+
+  test('clicking the toggle again unsubscribes and POSTs /api/push/unsubscribe', async ({ page }) => {
+    const { calls } = await installPushMocks(page);
+    await page.goto('/playground/?mode=sim', { waitUntil: 'domcontentloaded' });
+    await gotoSettings(page);
+
+    const toggle = page.locator('#notif-toggle-btn');
+    await toggle.click();
+    await expect(toggle).toHaveClass(/notif-active/, { timeout: 5000 });
+    calls.length = 0;
+
+    await toggle.click();
+    // After unsubscribe the active class is gone and the label flips back.
+    await expect(toggle).not.toHaveClass(/notif-active/, { timeout: 5000 });
+    await expect(toggle.locator('.auth-btn-label')).toContainText(/enable/i);
+
+    const unsubCall = calls.find(c => c.url === '/api/push/unsubscribe');
+    expect(unsubCall).toBeTruthy();
+    expect(unsubCall.body.endpoint).toMatch(/^https:\/\/fcm\.example\//);
+  });
+});


### PR DESCRIPTION
## Summary
Stacked on **PR #61**. Adds a CI gate that fails when any \`playground/js/**\` file drops below **50% statement coverage** and isn't listed in \`coverage-exclusions.json\` with a written reason.

## What's new
- \`coverage-exclusions.json\` — repo-root JSON mapping relative path → reason. Three initial entries:
  - \`flow-tester.js\` — standalone visual-QA page, no automated assertions by design.
  - \`crashes-view.js\` — TODO: add spec driving the crashes view (currently ~16%).
  - \`notifications.js\` — TODO: cover the payload-builder paths (currently ~44%).
- \`scripts/coverage-check.mjs\` — reads \`coverage-summary.json\` + the exclusions list. Fails if any non-excluded file is \<50%, **and** fails if an excluded file has climbed ≥50% (stale exclusion pressure).
- \`scripts/coverage-report.mjs\` — filters excluded files out of the HTML/lcov/summary so they're genuinely "excluded from the analysis," and emits an unfiltered \`coverage-summary-with-excluded.json\` that the check script uses for stale-exclusion detection.
- \`.github/workflows/ci.yml\` — adds \`COVERAGE=1\` to the existing \`npx playwright test\` step (no second run), then renders the report + runs the gate.

## Why minimal slowdown
- Coverage is collected on the **existing** Playwright run, not an extra one.
- The e2e project doesn't collect (its \`fixtures.js\` has no coverage hook), so those specs run unchanged.
- Frontend project overhead: ~5% (40s → 42s locally).
- Report rendering: ~3s.
- Gate check: ~30ms.
- **Total added CI time: ~5s** on top of the existing ~2m test step.

## Test plan
- [x] \`node scripts/coverage-check.mjs\` passes with the seeded exclusions.
- [x] Removing an exclusion for a <50% file → check fails with a clear message.
- [x] Adding a fake exclusion for a 100% file → check fails flagging the stale exclusion.
- [x] \`npm run lint:debt\` — knip/file-size/assets clean.
- [x] \`npm ci\` locally passes (with --include=optional, per feedback memory).
- [ ] CI green on this branch (stacked on #61; will need #61 merged first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)