### PR TITLE
server: source notification thresholds from control-logic DEFAULT_CONFIG

### DIFF
--- a/server/lib/notifications.js
+++ b/server/lib/notifications.js
@@ -22,6 +22,13 @@
 var createLogger = require('./logger');
 var log = createLogger('notifications');
 
+// Source freeze/overheat thresholds from the Shelly control-logic defaults
+// so the notification body never drifts from the device's actual drain
+// trigger. Previously these were copied as literals here and went stale
+// when the control-logic defaults moved (freezeDrainTemp 2->4 on 2026-04-22,
+// overheatDrainTemp was already 95 while this file still said 85).
+var CONTROL_DEFAULTS = require('../../shelly/control-logic.js').DEFAULT_CONFIG;
+
 var pushRef = null;
 var deviceConfigRef = null;
 
@@ -137,17 +144,13 @@ function predictValue(history, horizonMs) {
   return a + b * futureT;
 }
 
-// ── Default thresholds (from control-logic.js DEFAULT_CONFIG) ──
-var DEFAULT_OVERHEAT_TEMP = 85;
-var DEFAULT_FREEZE_TEMP = 2;
-
 function getThresholds() {
-  var cfg = deviceConfigRef ? deviceConfigRef.getConfig() : null;
-  // Device config uses compact keys but thresholds are in control-logic defaults.
-  // The device config doesn't carry these values — use the fixed defaults.
+  // Read live from control-logic's DEFAULT_CONFIG on every call so a
+  // future threshold change is picked up without redeploying the server
+  // (require cache holds the object reference; updates flow through).
   return {
-    overheat: DEFAULT_OVERHEAT_TEMP,
-    freeze: DEFAULT_FREEZE_TEMP,
+    overheat: CONTROL_DEFAULTS.overheatDrainTemp,
+    freeze: CONTROL_DEFAULTS.freezeDrainTemp,
   };
 }
 

--- a/server/lib/push.js
+++ b/server/lib/push.js
@@ -308,7 +308,11 @@ function buildMockPayload(category) {
   if (category === 'overheat_warning') {
     return {
       title: '[Test] Overheat Warning',
-      body: 'Tank temperature is 82.4\u00b0C and rising. Overheat drain may activate at 85\u00b0C.',
+      body: (function () {
+        var oh = require('../../shelly/control-logic.js').DEFAULT_CONFIG.overheatDrainTemp;
+        return 'Tank temperature is ' + (oh - 2.6).toFixed(1) + '\u00b0C and rising. ' +
+               'Overheat drain may activate at ' + oh + '\u00b0C.';
+      })(),
       tag: 'test-overheat-warning',
       icon: iconFor(category),
       url: '/#status',
@@ -317,7 +321,11 @@ function buildMockPayload(category) {
   if (category === 'freeze_warning') {
     return {
       title: '[Test] Freeze Warning',
-      body: 'Outdoor temperature is 2.8\u00b0C and falling. Freeze drain may activate at 2\u00b0C.',
+      body: (function () {
+        var fz = require('../../shelly/control-logic.js').DEFAULT_CONFIG.freezeDrainTemp;
+        return 'Outdoor temperature is ' + (fz + 0.8).toFixed(1) + '\u00b0C and falling. ' +
+               'Freeze drain may activate at ' + fz + '\u00b0C.';
+      })(),
       tag: 'test-freeze-warning',
       icon: iconFor(category),
       url: '/#status',

--- a/tests/notifications.test.js
+++ b/tests/notifications.test.js
@@ -128,19 +128,29 @@ describe('notifications', () => {
       notifications.init({ push: mockPush, deviceConfig: null });
     });
 
-    it('sends overheat warning when tank temp trending toward 85', () => {
+    it('sends overheat warning when tank temp trending toward the control-logic default', () => {
+      var CONTROL = require('../shelly/control-logic.js');
+      var overheatT = CONTROL.DEFAULT_CONFIG.overheatDrainTemp;  // currently 95
       var now = Date.now();
       var tankHistory = [];
+      // Ramp from (overheatT - 7) up to (overheatT - 2) so linear extrapolation
+      // over 15 min predicts crossing the threshold.
       for (var k = 0; k <= 5; k++) {
-        notifications.addSample(tankHistory, now - (5 - k) * 60000, 78 + k);
+        notifications.addSample(tankHistory, now - (5 - k) * 60000, overheatT - 7 + k);
       }
       notifications._setTankHistory(tankHistory);
 
-      notifications.evaluate({ temps: { tank_top: 83, outdoor: 10 }, mode: 'SOLAR_CHARGING' });
+      notifications.evaluate({
+        temps: { tank_top: overheatT - 2, outdoor: 10 }, mode: 'SOLAR_CHARGING',
+      });
 
       var overheatNotifs = sentNotifications.filter(function (n) { return n.type === 'overheat_warning'; });
       assert.strictEqual(overheatNotifs.length, 1);
-      assert.ok(overheatNotifs[0].payload.body.indexOf('83.0') >= 0);
+      // Body must reflect the current control-logic threshold, not a stale copy.
+      assert.ok(
+        overheatNotifs[0].payload.body.indexOf(String(overheatT)) >= 0,
+        'expected overheat body to mention ' + overheatT + '°C, got: ' + overheatNotifs[0].payload.body
+      );
     });
 
     it('does not send overheat warning when temp is stable below threshold', () => {
@@ -158,42 +168,55 @@ describe('notifications', () => {
     });
 
     it('does not send overheat warning when already above threshold', () => {
+      var CONTROL = require('../shelly/control-logic.js');
+      var overheatT = CONTROL.DEFAULT_CONFIG.overheatDrainTemp;
       var now = Date.now();
       var history = [];
       for (var i = 0; i <= 5; i++) {
-        notifications.addSample(history, now - (5 - i) * 60000, 86 + i);
+        notifications.addSample(history, now - (5 - i) * 60000, overheatT + 1 + i);
       }
       notifications._setTankHistory(history);
 
-      notifications.evaluate({ temps: { tank_top: 91, outdoor: 10 }, mode: 'SOLAR_CHARGING' });
+      notifications.evaluate({ temps: { tank_top: overheatT + 6, outdoor: 10 }, mode: 'SOLAR_CHARGING' });
 
       var overheatNotifs = sentNotifications.filter(function (n) { return n.type === 'overheat_warning'; });
       assert.strictEqual(overheatNotifs.length, 0);
     });
 
-    it('sends freeze warning when outdoor temp trending toward 2', () => {
+    it('sends freeze warning when outdoor temp trending toward the control-logic default', () => {
+      var CONTROL = require('../shelly/control-logic.js');
+      var freezeT = CONTROL.DEFAULT_CONFIG.freezeDrainTemp;  // currently 4
       var now = Date.now();
       var history = [];
+      // Ramp from (freezeT + 3) down toward (freezeT + 0.1) so linear
+      // extrapolation predicts crossing the threshold within 15 min.
       for (var i = 0; i <= 6; i++) {
-        notifications.addSample(history, now - (6 - i) * 60000, 5 - i * 0.5);
+        notifications.addSample(history, now - (6 - i) * 60000, freezeT + 3 - i * 0.5);
       }
       notifications._setOutdoorHistory(history);
 
-      notifications.evaluate({ temps: { tank_top: 50, outdoor: 2.1 }, mode: 'IDLE' });
+      notifications.evaluate({ temps: { tank_top: 50, outdoor: freezeT + 0.1 }, mode: 'IDLE' });
 
       var freezeNotifs = sentNotifications.filter(function (n) { return n.type === 'freeze_warning'; });
       assert.strictEqual(freezeNotifs.length, 1);
+      // Body must reference the current drain threshold, not a stale hardcoded value.
+      assert.ok(
+        freezeNotifs[0].payload.body.indexOf(String(freezeT)) >= 0,
+        'expected freeze body to mention ' + freezeT + '°C, got: ' + freezeNotifs[0].payload.body
+      );
     });
 
     it('does not send freeze warning when already below threshold', () => {
+      var CONTROL = require('../shelly/control-logic.js');
+      var freezeT = CONTROL.DEFAULT_CONFIG.freezeDrainTemp;
       var now = Date.now();
       var history = [];
       for (var i = 0; i <= 5; i++) {
-        notifications.addSample(history, now - (5 - i) * 60000, 1 - i * 0.1);
+        notifications.addSample(history, now - (5 - i) * 60000, freezeT - 1 - i * 0.1);
       }
       notifications._setOutdoorHistory(history);
 
-      notifications.evaluate({ temps: { tank_top: 50, outdoor: 0.5 }, mode: 'IDLE' });
+      notifications.evaluate({ temps: { tank_top: 50, outdoor: freezeT - 1.5 }, mode: 'IDLE' });
 
       var freezeNotifs = sentNotifications.filter(function (n) { return n.type === 'freeze_warning'; });
       assert.strictEqual(freezeNotifs.length, 0);


### PR DESCRIPTION
## Summary

Fixes a stale-config bug surfaced by a user notification: **"Freeze drain may activate at 2°C"** arrived while the collector was at 2.6 °C — but the device had already drained at 4 °C (the new threshold from #57). The notification body referenced the old `freezeDrainTemp: 2`, and the corresponding overheat body said `85°C` when control-logic has been on `95` for a while. Both were literal copies of `DEFAULT_CONFIG` that went out of sync.

## Fix

`server/lib/notifications.js` and `server/lib/push.js` now `require('../../shelly/control-logic.js').DEFAULT_CONFIG` and read `.freezeDrainTemp` / `.overheatDrainTemp` live at call time. `push.js` test-notification payloads do the same so the **Send test notification** button in the playground also reflects reality.

Deleted: the two `DEFAULT_OVERHEAT_TEMP = 85` / `DEFAULT_FREEZE_TEMP = 2` constants.

## Guard

Existing freeze/overheat tests rewritten to derive expectations from `DEFAULT_CONFIG` and extended with a content assertion that the notification body contains the current threshold value — the assertion that would have caught this bug at CI time.

## Test plan

- [x] `npm run test:unit` — 788/788 pass (~21 s)
- [x] Failing test reproduces the bug before the fix: `AssertionError: expected freeze body to mention 4°C`
- [ ] CI green on the PR
- [ ] After merge + deploy, the next test-notification click from the UI shows `4°C` / `95°C` in the body

https://claude.ai/code/session_012WRzcoLteizgZgG5d1K1Zb

---
_Generated by [Claude Code](https://claude.ai/code/session_012WRzcoLteizgZgG5d1K1Zb)_