### PR TITLE
Fix history retention by converting aggregate view to table

### DIFF
--- a/server/lib/db-maintenance.js
+++ b/server/lib/db-maintenance.js
@@ -1,0 +1,91 @@
+// Periodic db maintenance: incrementally extend the 30-second aggregate
+// table + delete old raw data. Extracted from db.js to keep that file
+// focused on the query API.
+//
+// Why incremental UPSERT (not REFRESH MATERIALIZED VIEW): the aggregate
+// has to outlive raw retention (RETENTION_INTERVAL) so the 7d/30d/1y
+// graph paths have data to draw. A REFRESH would rebuild from
+// sensor_readings and lose every bucket older than 48 h. INSERT ... ON
+// CONFLICT DO UPDATE adds new buckets without touching old ones.
+//
+// AGGREGATE_OVERLAP re-aggregates the boundary buckets — the most
+// recent bucket may still be filling between maintenance runs. UPSERT
+// makes the overlap idempotent.
+
+var MAINTENANCE_INTERVAL = 30 * 60 * 1000; // 30 minutes
+var INITIAL_DELAY = 60 * 1000;             // give the boot some breathing room
+var RETENTION_INTERVAL = '48 hours';
+var AGGREGATE_OVERLAP = '5 minutes';
+
+var UPSERT_SQL =
+  "INSERT INTO sensor_readings_30s (bucket, sensor_id, avg_value, min_value, max_value)\n" +
+  "SELECT time_bucket('30 seconds', ts) AS bucket,\n" +
+  "       sensor_id,\n" +
+  "       AVG(value)::double precision,\n" +
+  "       MIN(value)::double precision,\n" +
+  "       MAX(value)::double precision\n" +
+  "FROM sensor_readings\n" +
+  "WHERE ts >= $1::timestamptz - INTERVAL '" + AGGREGATE_OVERLAP + "'\n" +
+  "GROUP BY bucket, sensor_id\n" +
+  "ON CONFLICT (bucket, sensor_id) DO UPDATE SET\n" +
+  "  avg_value = EXCLUDED.avg_value,\n" +
+  "  min_value = EXCLUDED.min_value,\n" +
+  "  max_value = EXCLUDED.max_value";
+
+var PROBE_SQL =
+  "SELECT COALESCE(MAX(bucket), '1970-01-01'::timestamptz) AS max_bucket FROM sensor_readings_30s";
+
+var DELETE_SQL =
+  "DELETE FROM sensor_readings WHERE ts < NOW() - INTERVAL '" + RETENTION_INTERVAL + "'";
+
+function create(getPool, log) {
+  var timer = null;
+
+  function run(callback) {
+    var p = getPool();
+    if (!p) { if (callback) callback(); return; }
+
+    p.query(PROBE_SQL, [], function (probeErr, probe) {
+      if (probeErr) {
+        log.warn('aggregate probe failed', { error: probeErr.message });
+        retention();
+        return;
+      }
+      var since = probe.rows[0].max_bucket;
+      p.query(UPSERT_SQL, [since], function (err) {
+        if (err) {
+          log.warn('aggregate upsert failed', { error: err.message });
+        } else {
+          log.info('aggregate upsert done', { since: since });
+        }
+        retention();
+      });
+    });
+
+    function retention() {
+      p.query(DELETE_SQL, [], function (err2) {
+        if (err2) {
+          log.warn('retention cleanup failed', { error: err2.message });
+        } else {
+          log.info('retention cleanup done');
+        }
+        if (callback) callback();
+      });
+    }
+  }
+
+  function start() {
+    if (timer) return;
+    timer = setInterval(run, MAINTENANCE_INTERVAL);
+    setTimeout(run, INITIAL_DELAY);
+    log.info('maintenance scheduler started', { intervalMin: MAINTENANCE_INTERVAL / 60000 });
+  }
+
+  function stop() {
+    if (timer) { clearInterval(timer); timer = null; }
+  }
+
+  return { run: run, start: start, stop: stop };
+}
+
+module.exports = { create: create };

--- a/server/lib/db-schema.js
+++ b/server/lib/db-schema.js
@@ -59,20 +59,39 @@ var SCHEMA_SQL = [
   "CREATE INDEX IF NOT EXISTS script_crashes_ts ON script_crashes (ts DESC)",
 ];
 
-// Regular materialized view (no TSL license required, unlike continuous aggregates).
-// Refreshed periodically by the app via startMaintenance().
+// Pre-aggregated 30-second buckets, used by getHistory for ranges ≥ 24 h.
+//
+// History: this used to be a regular MATERIALIZED VIEW refreshed by
+// `REFRESH MATERIALIZED VIEW CONCURRENTLY sensor_readings_30s`. That
+// rebuilt the view from scratch off `sensor_readings`, which is pruned at
+// 48 h by runMaintenance — so every refresh discarded all aggregates older
+// than 48 h, and the 7d/30d/1y graph paths never had more than two days of
+// data to draw. We now keep aggregates in a real (hyper)table and have
+// runMaintenance UPSERT new buckets incrementally; old buckets persist
+// indefinitely (independent of raw retention).
+//
+// The DROP MATERIALIZED VIEW migrates existing prod deployments. It runs
+// before CREATE TABLE because pg refuses to create a table that collides
+// with an existing relation of the same name. CASCADE handles the unique
+// index that used to back CONCURRENT refreshes.
 var AGGREGATE_SQL = [
-  "CREATE MATERIALIZED VIEW IF NOT EXISTS sensor_readings_30s AS\n" +
-  "SELECT time_bucket('30 seconds', ts) AS bucket,\n" +
-  "       sensor_id,\n" +
-  "       AVG(value) AS avg_value,\n" +
-  "       MIN(value) AS min_value,\n" +
-  "       MAX(value) AS max_value\n" +
-  "FROM sensor_readings\n" +
-  "GROUP BY bucket, sensor_id",
+  "DROP MATERIALIZED VIEW IF EXISTS sensor_readings_30s CASCADE",
 
-  // Unique index required for REFRESH MATERIALIZED VIEW CONCURRENTLY
-  "CREATE UNIQUE INDEX IF NOT EXISTS sensor_readings_30s_uniq ON sensor_readings_30s (bucket, sensor_id)",
+  "CREATE TABLE IF NOT EXISTS sensor_readings_30s (\n" +
+  "  bucket    TIMESTAMPTZ NOT NULL,\n" +
+  "  sensor_id TEXT        NOT NULL,\n" +
+  "  avg_value DOUBLE PRECISION NOT NULL,\n" +
+  "  min_value DOUBLE PRECISION NOT NULL,\n" +
+  "  max_value DOUBLE PRECISION NOT NULL,\n" +
+  "  PRIMARY KEY (bucket, sensor_id)\n" +
+  ")",
+
+  // Hypertable for efficient time-range scans. if_not_exists guards against
+  // re-runs; migrate_data is unnecessary because the table is empty on
+  // first creation (the legacy MATERIALIZED VIEW was just dropped).
+  "SELECT create_hypertable('sensor_readings_30s', 'bucket', if_not_exists => true)",
+
+  "CREATE INDEX IF NOT EXISTS sensor_readings_30s_bucket ON sensor_readings_30s (bucket DESC)",
 ];
 
 module.exports = { SCHEMA_SQL, AGGREGATE_SQL };

--- a/server/lib/db.js
+++ b/server/lib/db.js
@@ -113,28 +113,74 @@ function initSchema(callback) {
   });
 }
 
-// Periodic maintenance: refresh materialized view + delete old raw data.
-// Called automatically via startMaintenance() after server boot.
+// Periodic maintenance: incrementally extend the 30-second aggregate
+// table + delete old raw data. Called via startMaintenance() after boot.
+//
+// Why incremental UPSERT (not REFRESH MATERIALIZED VIEW): the aggregate
+// has to outlive raw retention (48 h) so the 7d/30d/1y graph paths have
+// data to draw. A REFRESH would rebuild from sensor_readings and lose
+// every bucket older than 48 h. INSERT ... ON CONFLICT DO UPDATE adds new
+// buckets without touching old ones.
+//
+// The 5-minute overlap re-aggregates the boundary buckets (the most
+// recent bucket may still be filling between maintenance runs). UPSERT
+// makes this idempotent.
+var AGGREGATE_OVERLAP = '5 minutes';
+
 function runMaintenance(callback) {
   var p = getPool();
   if (!p) { if (callback) callback(); return; }
 
-  p.query('REFRESH MATERIALIZED VIEW CONCURRENTLY sensor_readings_30s', [], function (err) {
-    if (err) {
-      log.warn('materialized view refresh failed', { error: err.message });
-    } else {
-      log.info('materialized view refreshed');
-    }
-
-    p.query("DELETE FROM sensor_readings WHERE ts < NOW() - INTERVAL '" + RETENTION_INTERVAL + "'", [], function (err2) {
-      if (err2) {
-        log.warn('retention cleanup failed', { error: err2.message });
-      } else {
-        log.info('retention cleanup done');
+  p.query(
+    "SELECT COALESCE(MAX(bucket), '1970-01-01'::timestamptz) AS max_bucket FROM sensor_readings_30s",
+    [],
+    function (probeErr, probe) {
+      if (probeErr) {
+        log.warn('aggregate probe failed', { error: probeErr.message });
+        proceedToRetention();
+        return;
       }
-      if (callback) callback();
-    });
-  });
+      var since = probe.rows[0].max_bucket;
+      var upsertSql =
+        "INSERT INTO sensor_readings_30s (bucket, sensor_id, avg_value, min_value, max_value)\n" +
+        "SELECT time_bucket('30 seconds', ts) AS bucket,\n" +
+        "       sensor_id,\n" +
+        "       AVG(value)::double precision,\n" +
+        "       MIN(value)::double precision,\n" +
+        "       MAX(value)::double precision\n" +
+        "FROM sensor_readings\n" +
+        "WHERE ts >= $1::timestamptz - INTERVAL '" + AGGREGATE_OVERLAP + "'\n" +
+        "GROUP BY bucket, sensor_id\n" +
+        "ON CONFLICT (bucket, sensor_id) DO UPDATE SET\n" +
+        "  avg_value = EXCLUDED.avg_value,\n" +
+        "  min_value = EXCLUDED.min_value,\n" +
+        "  max_value = EXCLUDED.max_value";
+
+      p.query(upsertSql, [since], function (err) {
+        if (err) {
+          log.warn('aggregate upsert failed', { error: err.message });
+        } else {
+          log.info('aggregate upsert done', { since: since });
+        }
+        proceedToRetention();
+      });
+    },
+  );
+
+  function proceedToRetention() {
+    p.query(
+      "DELETE FROM sensor_readings WHERE ts < NOW() - INTERVAL '" + RETENTION_INTERVAL + "'",
+      [],
+      function (err2) {
+        if (err2) {
+          log.warn('retention cleanup failed', { error: err2.message });
+        } else {
+          log.info('retention cleanup done');
+        }
+        if (callback) callback();
+      },
+    );
+  }
 }
 
 function startMaintenance() {
@@ -228,6 +274,21 @@ var RANGE_INTERVALS = {
   '1y': '1 year',
 };
 
+// For long views, re-bucket the 30-second aggregates to a coarser
+// resolution. Without this, 7 days at 30 s = ~20 160 points per sensor —
+// noisy on screen and at the edge of the client's 20 000-point store cap.
+// The values are SQL fragments interpolated into time_bucket(...); they
+// must stay constants (never user input) because we string-concat them.
+//
+// `all` is intentionally absent: there's no UI button for it and the
+// e2e harness relies on `range=all` resolving against pg-mem (which has
+// no time_bucket).
+var COARSE_BUCKETS = {
+  '7d': '5 minutes',
+  '30d': '30 minutes',
+  '1y': '6 hours',
+};
+
 function getHistory(range, sensor, callback) {
   var p = getPool();
   var interval = RANGE_INTERVALS[range];
@@ -252,8 +313,18 @@ function getHistory(range, sensor, callback) {
       params.push(sensor);
       paramIdx++;
     }
-    sql = 'SELECT bucket AS ts, sensor_id, avg_value AS value FROM sensor_readings_30s' +
-      aggWhereTime + aggWhereSensor + ' ORDER BY bucket';
+    var coarse = COARSE_BUCKETS[range];
+    if (coarse) {
+      // Re-bucket the 30 s aggregates to a coarser resolution to smooth
+      // the long view and keep the response under the client's point cap.
+      sql = "SELECT time_bucket('" + coarse + "', bucket) AS ts, sensor_id," +
+        " AVG(avg_value) AS value FROM sensor_readings_30s" +
+        aggWhereTime + aggWhereSensor +
+        ' GROUP BY ts, sensor_id ORDER BY ts';
+    } else {
+      sql = 'SELECT bucket AS ts, sensor_id, avg_value AS value FROM sensor_readings_30s' +
+        aggWhereTime + aggWhereSensor + ' ORDER BY bucket';
+    }
   } else if (useBlended) {
     // Raw for last 6h, aggregate for older. Sensor param appears in both sub-queries.
     var rawSensorClause = '';
@@ -539,4 +610,5 @@ module.exports = {
   getEventsPaginated: getEventsPaginated,
   close: close,
   _reset: function () { pool = null; resolvedCa = null; stopMaintenance(); },
+  _runMaintenanceForTest: runMaintenance,
 };

--- a/server/lib/db.js
+++ b/server/lib/db.js
@@ -86,10 +86,7 @@ function getPool() {
 }
 
 var { SCHEMA_SQL, AGGREGATE_SQL } = require('./db-schema');
-
-var maintenanceTimer = null;
-var MAINTENANCE_INTERVAL = 30 * 60 * 1000; // 30 minutes
-var RETENTION_INTERVAL = '48 hours';
+var maintenance = require('./db-maintenance').create(getPool, log);
 
 function initSchema(callback) {
   var p = getPool();
@@ -111,92 +108,6 @@ function initSchema(callback) {
       });
     });
   });
-}
-
-// Periodic maintenance: incrementally extend the 30-second aggregate
-// table + delete old raw data. Called via startMaintenance() after boot.
-//
-// Why incremental UPSERT (not REFRESH MATERIALIZED VIEW): the aggregate
-// has to outlive raw retention (48 h) so the 7d/30d/1y graph paths have
-// data to draw. A REFRESH would rebuild from sensor_readings and lose
-// every bucket older than 48 h. INSERT ... ON CONFLICT DO UPDATE adds new
-// buckets without touching old ones.
-//
-// The 5-minute overlap re-aggregates the boundary buckets (the most
-// recent bucket may still be filling between maintenance runs). UPSERT
-// makes this idempotent.
-var AGGREGATE_OVERLAP = '5 minutes';
-
-function runMaintenance(callback) {
-  var p = getPool();
-  if (!p) { if (callback) callback(); return; }
-
-  p.query(
-    "SELECT COALESCE(MAX(bucket), '1970-01-01'::timestamptz) AS max_bucket FROM sensor_readings_30s",
-    [],
-    function (probeErr, probe) {
-      if (probeErr) {
-        log.warn('aggregate probe failed', { error: probeErr.message });
-        proceedToRetention();
-        return;
-      }
-      var since = probe.rows[0].max_bucket;
-      var upsertSql =
-        "INSERT INTO sensor_readings_30s (bucket, sensor_id, avg_value, min_value, max_value)\n" +
-        "SELECT time_bucket('30 seconds', ts) AS bucket,\n" +
-        "       sensor_id,\n" +
-        "       AVG(value)::double precision,\n" +
-        "       MIN(value)::double precision,\n" +
-        "       MAX(value)::double precision\n" +
-        "FROM sensor_readings\n" +
-        "WHERE ts >= $1::timestamptz - INTERVAL '" + AGGREGATE_OVERLAP + "'\n" +
-        "GROUP BY bucket, sensor_id\n" +
-        "ON CONFLICT (bucket, sensor_id) DO UPDATE SET\n" +
-        "  avg_value = EXCLUDED.avg_value,\n" +
-        "  min_value = EXCLUDED.min_value,\n" +
-        "  max_value = EXCLUDED.max_value";
-
-      p.query(upsertSql, [since], function (err) {
-        if (err) {
-          log.warn('aggregate upsert failed', { error: err.message });
-        } else {
-          log.info('aggregate upsert done', { since: since });
-        }
-        proceedToRetention();
-      });
-    },
-  );
-
-  function proceedToRetention() {
-    p.query(
-      "DELETE FROM sensor_readings WHERE ts < NOW() - INTERVAL '" + RETENTION_INTERVAL + "'",
-      [],
-      function (err2) {
-        if (err2) {
-          log.warn('retention cleanup failed', { error: err2.message });
-        } else {
-          log.info('retention cleanup done');
-        }
-        if (callback) callback();
-      },
-    );
-  }
-}
-
-function startMaintenance() {
-  if (maintenanceTimer) return;
-  // Run once shortly after boot (give time for initial data), then every 30 min
-  maintenanceTimer = setInterval(runMaintenance, MAINTENANCE_INTERVAL);
-  // Initial refresh after 60s
-  setTimeout(runMaintenance, 60 * 1000);
-  log.info('maintenance scheduler started', { intervalMin: MAINTENANCE_INTERVAL / 60000 });
-}
-
-function stopMaintenance() {
-  if (maintenanceTimer) {
-    clearInterval(maintenanceTimer);
-    maintenanceTimer = null;
-  }
 }
 
 function runStatements(client, stmts, idx, callback) {
@@ -597,8 +508,8 @@ module.exports = {
   resolveUrl: resolveUrl,
   getPool: getPool,
   initSchema: initSchema,
-  startMaintenance: startMaintenance,
-  stopMaintenance: stopMaintenance,
+  startMaintenance: maintenance.start,
+  stopMaintenance: maintenance.stop,
   insertSensorReadings: insertSensorReadings,
   insertStateEvent: insertStateEvent,
   insertScriptCrash: insertScriptCrash,
@@ -609,6 +520,6 @@ module.exports = {
   getEvents: getEvents,
   getEventsPaginated: getEventsPaginated,
   close: close,
-  _reset: function () { pool = null; resolvedCa = null; stopMaintenance(); },
-  _runMaintenanceForTest: runMaintenance,
+  _reset: function () { pool = null; resolvedCa = null; maintenance.stop(); },
+  _runMaintenanceForTest: maintenance.run,
 };

--- a/tests/history-retention.test.js
+++ b/tests/history-retention.test.js
@@ -1,0 +1,222 @@
+/**
+ * Regression: switching the status-page graph to "7d" only showed ~48 h of
+ * data even though the server was supposed to retain pre-aggregated history
+ * for far longer.
+ *
+ * Root cause: `sensor_readings_30s` was a regular MATERIALIZED VIEW, and
+ * runMaintenance() did `REFRESH MATERIALIZED VIEW CONCURRENTLY`, which
+ * rebuilds the view from scratch off the current contents of
+ * `sensor_readings`. Raw readings are pruned at 48 h (RETENTION_INTERVAL),
+ * so each refresh wiped every aggregate older than that. The 7d/30d/1y
+ * queries hit the aggregate, but the aggregate itself only ever held 48 h.
+ *
+ * Fix: `sensor_readings_30s` is now a real (hyper)table; maintenance does
+ * an incremental UPSERT (`INSERT ... ON CONFLICT DO UPDATE`) of new buckets
+ * so historical aggregates persist beyond the raw retention window.
+ *
+ * Related: for ranges > 24 h the server now coarsens the 30 s aggregates
+ * via an additional `time_bucket()` (5 min for 7d, 30 min for 30d, 6 h for
+ * 1y). 7 days × 2 points/min = 20 160 points was visually noisy and bumped
+ * up against the client's 20 000-point store cap.
+ */
+
+const { describe, it, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+describe('sensor_readings_30s schema — table, not materialized view', () => {
+  const schemaSrc = fs.readFileSync(
+    path.join(__dirname, '..', 'server', 'lib', 'db-schema.js'),
+    'utf8',
+  );
+
+  it('does NOT declare sensor_readings_30s as a MATERIALIZED VIEW', () => {
+    // A MATERIALIZED VIEW is computed from sensor_readings on REFRESH, so
+    // pruning raw readings at 48 h would discard all older aggregates.
+    assert.doesNotMatch(
+      schemaSrc,
+      /CREATE\s+MATERIALIZED\s+VIEW[^;]*sensor_readings_30s/i,
+      'sensor_readings_30s must not be a MATERIALIZED VIEW — it loses data on REFRESH after raw retention prunes',
+    );
+  });
+
+  it('declares sensor_readings_30s as a CREATE TABLE', () => {
+    assert.match(
+      schemaSrc,
+      /CREATE\s+TABLE[^;]*sensor_readings_30s/i,
+      'sensor_readings_30s must be a real table so aggregates can outlive raw retention',
+    );
+  });
+
+  it('drops any pre-existing materialized view to migrate prod deployments', () => {
+    // Existing prod has the old MATERIALIZED VIEW. Schema must drop it
+    // before creating the new table or the CREATE TABLE will fail with
+    // "relation already exists".
+    assert.match(
+      schemaSrc,
+      /DROP\s+MATERIALIZED\s+VIEW[^;]*sensor_readings_30s/i,
+      'schema must drop the legacy MATERIALIZED VIEW before creating the table',
+    );
+  });
+
+  it('keeps the (bucket, sensor_id) uniqueness constraint for ON CONFLICT upserts', () => {
+    // The upsert path needs a unique constraint to target.
+    assert.match(
+      schemaSrc,
+      /sensor_readings_30s[\s\S]*?(PRIMARY\s+KEY|UNIQUE)/i,
+      'sensor_readings_30s must have a unique key on (bucket, sensor_id) for ON CONFLICT',
+    );
+  });
+});
+
+describe('runMaintenance — incremental UPSERT, never REFRESH', () => {
+  let db;
+  let capturedQueries;
+
+  beforeEach(() => {
+    capturedQueries = [];
+    delete require.cache[require.resolve('../server/lib/db.js')];
+
+    const mockPool = {
+      on: function () {},
+      query: function (sql, params, cb) {
+        if (typeof params === 'function') { cb = params; params = []; }
+        capturedQueries.push({ sql, params });
+        // MAX(bucket) probe returns a sentinel timestamp.
+        if (/MAX\(bucket\)/i.test(sql)) {
+          if (cb) cb(null, { rows: [{ max_bucket: new Date('2026-04-22T00:00:00Z') }] });
+          return;
+        }
+        if (cb) cb(null, { rows: [] });
+      },
+      connect: function (cb) {
+        const mockClient = {
+          query: function (sql, cb2) {
+            capturedQueries.push({ sql });
+            if (cb2) cb2(null, { rows: [] });
+          },
+        };
+        cb(null, mockClient, function () {});
+      },
+      end: function (cb) { if (cb) cb(); },
+    };
+
+    require.cache[require.resolve('pg')] = {
+      id: require.resolve('pg'),
+      exports: { Pool: function () { return mockPool; } },
+    };
+
+    process.env.DATABASE_URL = 'postgres://test:test@localhost/test';
+    db = require('../server/lib/db.js');
+  });
+
+  it('does not call REFRESH MATERIALIZED VIEW (would discard old aggregates)', (t, done) => {
+    db._runMaintenanceForTest(function () {
+      const refresh = capturedQueries.find(q => /REFRESH\s+MATERIALIZED\s+VIEW/i.test(q.sql || ''));
+      assert.equal(
+        refresh,
+        undefined,
+        'maintenance must not REFRESH the aggregate; that drops every bucket older than raw retention',
+      );
+      done();
+    });
+  });
+
+  it('upserts new buckets into sensor_readings_30s using INSERT ... ON CONFLICT', (t, done) => {
+    db._runMaintenanceForTest(function () {
+      const upsert = capturedQueries.find(q =>
+        /INSERT\s+INTO\s+sensor_readings_30s/i.test(q.sql || '') &&
+        /ON\s+CONFLICT/i.test(q.sql || ''),
+      );
+      assert.ok(
+        upsert,
+        'maintenance must INSERT ... ON CONFLICT into sensor_readings_30s to incrementally extend the aggregate',
+      );
+      // The upsert should reference time_bucket so it actually aggregates raw rows.
+      assert.match(upsert.sql, /time_bucket/i,
+        'upsert SQL must use time_bucket to aggregate raw readings');
+    });
+    done();
+  });
+});
+
+describe('getHistory — long-range smoothing via coarser time_buckets', () => {
+  let db;
+  let capturedQueries;
+
+  beforeEach(() => {
+    capturedQueries = [];
+    delete require.cache[require.resolve('../server/lib/db.js')];
+
+    const mockPool = {
+      on: function () {},
+      query: function (sql, params, cb) {
+        if (typeof params === 'function') { cb = params; params = []; }
+        capturedQueries.push({ sql, params });
+        if (cb) cb(null, { rows: [] });
+      },
+      connect: function (cb) {
+        cb(null, { query: function (s, c) { if (c) c(null, { rows: [] }); } }, function () {});
+      },
+      end: function (cb) { if (cb) cb(); },
+    };
+    require.cache[require.resolve('pg')] = {
+      id: require.resolve('pg'),
+      exports: { Pool: function () { return mockPool; } },
+    };
+    process.env.DATABASE_URL = 'postgres://test:test@localhost/test';
+    db = require('../server/lib/db.js');
+  });
+
+  function findHistoryQuery() {
+    return capturedQueries.find(q =>
+      q.sql && /sensor_readings_30s/i.test(q.sql) && /SELECT/i.test(q.sql),
+    );
+  }
+
+  it('7d uses time_bucket coarser than 30 s to smooth the long view', (t, done) => {
+    db.getHistory('7d', null, function () {
+      const q = findHistoryQuery();
+      assert.ok(q, 'expected an aggregate-table query for 7d');
+      assert.match(q.sql, /time_bucket\s*\(\s*'5 minutes'/i,
+        '7d should re-bucket the 30 s aggregates to 5-minute resolution');
+      done();
+    });
+  });
+
+  it('30d uses 30-minute buckets', (t, done) => {
+    db.getHistory('30d', null, function () {
+      const q = findHistoryQuery();
+      assert.ok(q);
+      assert.match(q.sql, /time_bucket\s*\(\s*'30 minutes'/i,
+        '30d should re-bucket to 30-minute resolution');
+      done();
+    });
+  });
+
+  it('1y uses 6-hour buckets', (t, done) => {
+    db.getHistory('1y', null, function () {
+      const q = findHistoryQuery();
+      assert.ok(q);
+      assert.match(q.sql, /time_bucket\s*\(\s*'6 hours'/i,
+        '1y should re-bucket to 6-hour resolution');
+      done();
+    });
+  });
+
+  it('24h still serves 30 s resolution (no extra coarsening)', (t, done) => {
+    // 24h is already a manageable point count and benefits from full
+    // resolution near the right edge — leave it on the blended path.
+    db.getHistory('24h', null, function () {
+      const allSql = capturedQueries.map(q => q.sql || '').join('\n');
+      // 24h must NOT include a time_bucket coarser than 30 seconds.
+      const coarseMatch = allSql.match(/time_bucket\s*\(\s*'(\d+)\s*(minute|hour|day)s?'/i);
+      if (coarseMatch) {
+        // Allow only the 30-seconds bucket if present (it isn't, but be explicit).
+        assert.fail('24h should not coarsen the aggregate, found: ' + coarseMatch[0]);
+      }
+      done();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a critical bug where the 7-day, 30-day, and 1-year graph views only displayed ~48 hours of data despite the server being configured to retain aggregates for much longer. The root cause was that `sensor_readings_30s` was a materialized view that got completely rebuilt on each refresh, discarding all aggregates older than the raw data retention window (48 hours).

## Key Changes

- **Convert aggregate from materialized view to real table**: `sensor_readings_30s` is now a persistent hypertable instead of a materialized view, allowing aggregates to outlive raw data retention
  
- **Replace REFRESH with incremental UPSERT**: `runMaintenance()` now uses `INSERT ... ON CONFLICT DO UPDATE` to incrementally extend the aggregate table with new 30-second buckets, rather than rebuilding from scratch. A 5-minute overlap re-aggregates boundary buckets to handle in-flight data between maintenance runs

- **Add coarse bucketing for long-range queries**: For ranges > 24h, `getHistory()` now re-buckets the 30-second aggregates to coarser resolutions:
  - 7d: 5-minute buckets
  - 30d: 30-minute buckets  
  - 1y: 6-hour buckets
  
  This reduces the point count from ~20,160 points/sensor (7d at 30s) to a more manageable ~2,000 points, improving visual clarity and staying well under the client's 20,000-point store cap

- **Migration support**: Schema includes `DROP MATERIALIZED VIEW IF EXISTS` to safely migrate existing production deployments before creating the new table

## Implementation Details

- The upsert query uses `time_bucket('30 seconds', ts)` to aggregate raw readings and targets the `(bucket, sensor_id)` primary key for conflict resolution
- The hypertable conversion enables efficient time-range scans via TimescaleDB
- 24-hour queries continue to use 30-second resolution (no coarsening) to preserve detail near the right edge of the graph
- All long-range coarse buckets are hardcoded SQL constants (never user input) to prevent injection vulnerabilities

https://claude.ai/code/session_01AbQhGgJU9ozLkfYWDF9uJc