### PR TITLE
Guard: history aggregate data must persist beyond raw retention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,14 @@ Users with role `readonly` can browse but the following must reject with 403. Se
 
 When adding a new mutating endpoint, add the same guard.
 
+### History aggregate must persist beyond raw retention
+
+`sensor_readings_30s` is a real (hyper)table, not a materialized view. Raw `sensor_readings` is pruned at 48 h, but the 30-second aggregate must accumulate forever — the 7d/30d/1y graph views draw from it and fill in over time.
+
+**Never** add a cleanup / retention policy / TRUNCATE / `DELETE FROM sensor_readings_30s` anywhere. `runMaintenance` in `server/lib/db-maintenance.js` only ever does `INSERT … ON CONFLICT DO UPDATE` on the aggregate, and the retention `DELETE` targets raw `sensor_readings` only. Guard tests in `tests/history-retention.test.js` enforce both halves — if you need to change the maintenance flow, keep those guards passing.
+
+The original bug (PR #64): aggregate was a MATERIALIZED VIEW refreshed from raw, so each refresh silently discarded everything older than 48 h and long-range graphs only ever showed ~2 days.
+
 ## Testing Policy
 
 **Bug fixes and behavior changes follow test-first:**

--- a/tests/history-retention.test.js
+++ b/tests/history-retention.test.js
@@ -139,6 +139,48 @@ describe('runMaintenance — incremental UPSERT, never REFRESH', () => {
     });
     done();
   });
+
+  // Load-bearing invariant: old aggregate buckets must persist forever so the
+  // 7d/30d/1y graph views keep filling in beyond raw retention (48 h). These
+  // guards catch the "someone adds a cleanup job to the aggregate" refactor
+  // that would silently re-break long-range history with the same symptom as
+  // the original bug.
+  it('never issues DELETE or TRUNCATE against sensor_readings_30s', (t, done) => {
+    db._runMaintenanceForTest(function () {
+      const destructive = capturedQueries.find(q =>
+        typeof q.sql === 'string' &&
+        /sensor_readings_30s/i.test(q.sql) &&
+        /\b(DELETE\s+FROM|TRUNCATE|DROP\s+TABLE)\b/i.test(q.sql),
+      );
+      assert.equal(
+        destructive,
+        undefined,
+        'aggregate rows must persist forever; any cleanup job here re-introduces the ' +
+        '"7d view shows only 48 h" bug. Found: ' + (destructive && destructive.sql),
+      );
+      done();
+    });
+  });
+
+  it('retention DELETE only targets sensor_readings, never the aggregate', (t, done) => {
+    db._runMaintenanceForTest(function () {
+      const deletes = capturedQueries.filter(q =>
+        typeof q.sql === 'string' && /\bDELETE\s+FROM\b/i.test(q.sql),
+      );
+      assert.ok(deletes.length > 0, 'expected a raw-retention DELETE for sanity');
+      for (const q of deletes) {
+        // The DELETE must reference sensor_readings (raw) and must NOT reference
+        // the aggregate. Matching the raw table alone is not enough — a naive
+        // `DELETE FROM sensor_readings_30s` also contains the substring
+        // "sensor_readings".
+        assert.match(q.sql, /DELETE\s+FROM\s+sensor_readings\b(?!_30s)/i,
+          'retention DELETE must target sensor_readings (raw), not the aggregate: ' + q.sql);
+        assert.doesNotMatch(q.sql, /sensor_readings_30s/i,
+          'retention DELETE must not touch sensor_readings_30s: ' + q.sql);
+      }
+      done();
+    });
+  });
 });
 
 describe('getHistory — long-range smoothing via coarser time_buckets', () => {


### PR DESCRIPTION
## Summary

Follow-up to #64. Adds guard tests + a CLAUDE.md entry so a future "clean up the aggregate" refactor can't silently re-introduce the "7d view shows only 48 h" bug.

- **Two new tests** in `tests/history-retention.test.js`:
  - `runMaintenance` never issues `DELETE` / `TRUNCATE` / `DROP TABLE` against `sensor_readings_30s`.
  - The retention `DELETE` only ever targets raw `sensor_readings` (negative-lookahead so `sensor_readings_30s` can't slip through a substring match).
- **CLAUDE.md Critical Rules**: new "History aggregate must persist beyond raw retention" entry — documents the invariant, names the guard tests, and references PR #64 so the reasoning stays traceable.

## Test plan

- [x] `npm run test:unit` — 805 tests pass (803 + 2 new guards)
- [x] Tests fail under mutation: adding a `DELETE FROM sensor_readings_30s` to `runMaintenance` trips both guards (verified by logic — `capturedQueries` would include the destructive statement)

https://claude.ai/code/session_01AbQhGgJU9ozLkfYWDF9uJc

---
_Generated by [Claude Code](https://claude.ai/code/session_01AbQhGgJU9ozLkfYWDF9uJc)_