### PR TITLE
Render all user-visible times in Europe/Helsinki

### DIFF
--- a/playground/js/auth.js
+++ b/playground/js/auth.js
@@ -569,6 +569,7 @@ function formatWhen(isoString) {
     day: 'numeric',
     hour: '2-digit',
     minute: '2-digit',
+    timeZone: 'Europe/Helsinki',
   });
 }
 

--- a/playground/js/crashes-view.js
+++ b/playground/js/crashes-view.js
@@ -15,6 +15,7 @@ function formatTs(ms) {
       day: '2-digit', month: '2-digit', year: 'numeric',
       hour: '2-digit', minute: '2-digit', second: '2-digit',
       hour12: false,
+      timeZone: 'Europe/Helsinki',
     });
   } catch (e) {
     return String(ms);

--- a/playground/js/crashes-view.js
+++ b/playground/js/crashes-view.js
@@ -8,6 +8,8 @@
  * it's easy to paste into a bug report or chat.
  */
 
+import { formatIsoHelsinki } from './main/time-format.js';
+
 function formatTs(ms) {
   if (!ms) return '—';
   try {
@@ -32,12 +34,12 @@ function detailTemplate(row) {
   const copyBtn = '<button class="crashes-copy" type="button">Copy JSON</button>';
   const detail = JSON.stringify({
     id: row.id,
-    ts: new Date(row.ts).toISOString(),
+    ts: formatIsoHelsinki(row.ts),
     error_msg: row.error_msg,
     error_trace: row.error_trace,
     sys_status: row.sys_status,
     recent_states: row.recent_states,
-    resolved_at: row.resolved_at ? new Date(row.resolved_at).toISOString() : null,
+    resolved_at: row.resolved_at ? formatIsoHelsinki(row.resolved_at) : null,
   }, null, 2);
   return '<div class="crashes-detail">' + escapeHtml(detail) + '</div>' + copyBtn;
 }

--- a/playground/js/main/balance-card.js
+++ b/playground/js/main/balance-card.js
@@ -18,6 +18,21 @@ import {
   editorialDaySentence,
   editorialNightSentence,
 } from '../energy-balance.js';
+import { helsinkiParts } from './time-format.js';
+
+const HELSINKI_TZ = 'Europe/Helsinki';
+const fmtWindowClock = new Intl.DateTimeFormat('en-GB', {
+  hour: '2-digit', minute: '2-digit', hour12: false, timeZone: HELSINKI_TZ,
+});
+const fmtWindowDate = new Intl.DateTimeFormat('en-GB', {
+  day: 'numeric', month: 'short', timeZone: HELSINKI_TZ,
+});
+// Helsinki date key "YYYY-MM-DD" used for same-day / yesterday checks
+// against the user's wall clock rather than the browser's.
+function helsinkiDateKey(tsMs) {
+  const p = helsinkiParts(tsMs);
+  return p.year + '-' + p.month + '-' + p.day;
+}
 
 // 48 h slice decoupled from the graph's 1H/6H/… pill so the numbers
 // don't shrink when the user flips the range. balanceHistory holds
@@ -137,18 +152,17 @@ function fmtBalanceKwh(v, { sign = false } = {}) {
 }
 
 function fmtBalanceWindow(startTs, endTs, complete) {
-  const now = new Date();
-  const fmt = (ts, refDate) => {
-    const d = new Date(ts);
-    const sameDay = d.toDateString() === refDate.toDateString();
-    const hm = d.toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit' });
-    if (sameDay) return hm;
-    const yesterday = new Date(refDate);
-    yesterday.setDate(refDate.getDate() - 1);
-    if (d.toDateString() === yesterday.toDateString()) return hm + ' yesterday';
-    return hm + ' ' + d.toLocaleDateString('en-GB', { day: 'numeric', month: 'short' });
+  const nowMs = Date.now();
+  const todayKey = helsinkiDateKey(nowMs);
+  const yesterdayKey = helsinkiDateKey(nowMs - 24 * 3600 * 1000);
+  const fmt = (ts) => {
+    const key = helsinkiDateKey(ts);
+    const hm = fmtWindowClock.format(new Date(ts));
+    if (key === todayKey) return hm;
+    if (key === yesterdayKey) return hm + ' yesterday';
+    return hm + ' ' + fmtWindowDate.format(new Date(ts));
   };
-  return fmt(startTs, now) + ' → ' + (complete ? fmt(endTs, now) : 'now');
+  return fmt(startTs) + ' → ' + (complete ? fmt(endTs) : 'now');
 }
 
 function statHtml(label, kwh, { sign = false, extra = '' } = {}) {

--- a/playground/js/main/graph-inspector.js
+++ b/playground/js/main/graph-inspector.js
@@ -7,6 +7,7 @@ import { store } from '../app-state.js';
 import { SIM_START_HOUR } from '../sim-bootstrap.js';
 import { timeSeriesStore, graphRange, showAllSensors } from './state.js';
 import { tankAvgOf } from './history-graph.js';
+import { formatClockTime } from './time-format.js';
 
 let inspectorX = null; // null = hidden, otherwise CSS pixel x relative to canvas
 
@@ -72,19 +73,18 @@ export function setupInspector() {
     const v = timeSeriesStore.values[bestIdx];
     const t = timeSeriesStore.times[bestIdx];
 
-    // Time of day — live data stores Unix epoch seconds, simulation
-    // stores seconds since sim start + SIM_START_HOUR offset.
-    let todH, todM;
+    // Time of day — live data stores Unix epoch seconds (shown in
+    // Europe/Helsinki), simulation stores seconds since sim start +
+    // SIM_START_HOUR offset.
+    let label;
     if (store.get('phase') === 'live') {
-      const d = new Date(t * 1000);
-      todH = d.getHours();
-      todM = d.getMinutes();
+      label = formatClockTime(t * 1000);
     } else {
-      todH = Math.floor((SIM_START_HOUR + t / 3600) % 24);
-      todM = Math.floor(((SIM_START_HOUR + t / 3600) % 1) * 60);
+      const todH = Math.floor((SIM_START_HOUR + t / 3600) % 24);
+      const todM = Math.floor(((SIM_START_HOUR + t / 3600) % 1) * 60);
+      label = todH.toString().padStart(2, '0') + ':' + todM.toString().padStart(2, '0');
     }
-    document.getElementById('inspector-time').textContent =
-      todH.toString().padStart(2, '0') + ':' + todM.toString().padStart(2, '0');
+    document.getElementById('inspector-time').textContent = label;
 
     // Temperature values (null-tolerant for unbound live sensors)
     const fmtInspTemp = function (x) { return isNum(x) ? x.toFixed(1) + '°C' : TEMP_PLACEHOLDER; };

--- a/playground/js/main/logs.js
+++ b/playground/js/main/logs.js
@@ -216,7 +216,7 @@ function buildLogsClipboardText() {
   // Header
   lines.push('=== Greenhouse Solar Heater — System Logs ===');
   lines.push('Mode: ' + (isLive ? 'Live' : 'Simulation'));
-  lines.push('Exported: ' + new Date().toISOString());
+  lines.push('Exported: ' + formatFullTimeHelsinki(Date.now()));
   lines.push('');
 
   if (isLive) {
@@ -226,7 +226,7 @@ function buildLogsClipboardText() {
     const readings = downsampleHistory(1200); // 20 minutes = 1200 seconds
     for (let i = 0; i < readings.length; i++) {
       const r = readings[i];
-      const ts = new Date(r.time * 1000).toISOString().replace('T', ' ').slice(0, 19);
+      const ts = formatFullTimeHelsinki(r.time * 1000);
       lines.push(
         ts + '  ' +
         fmtTempCol(r.t_collector) + '  ' +

--- a/playground/js/main/time-format.js
+++ b/playground/js/main/time-format.js
@@ -15,7 +15,7 @@ export function formatTimeOfDay(simSeconds) {
   return h.toString().padStart(2, '0') + ':' + m.toString().padStart(2, '0');
 }
 
-const HELSINKI_TZ = 'Europe/Helsinki';
+export const HELSINKI_TZ = 'Europe/Helsinki';
 const fmtClockHelsinki = new Intl.DateTimeFormat('fi-FI', {
   hour: '2-digit', minute: '2-digit', hour12: false, timeZone: HELSINKI_TZ,
 });
@@ -24,9 +24,27 @@ const fmtFullHelsinki = new Intl.DateTimeFormat('fi-FI', {
   hour: '2-digit', minute: '2-digit', second: '2-digit',
   hour12: false, timeZone: HELSINKI_TZ,
 });
+const fmtDayPartsHelsinki = new Intl.DateTimeFormat('en-GB', {
+  year: 'numeric', month: 'numeric', day: 'numeric',
+  hour: 'numeric', minute: 'numeric',
+  hour12: false, timeZone: HELSINKI_TZ,
+});
 
 export function formatClockTime(unixMs) {
   return fmtClockHelsinki.format(new Date(unixMs));
+}
+
+// Returns { year, month, day, hour, minute } as numbers for the wall
+// clock in Europe/Helsinki. Handy for same-day comparisons or for
+// building custom chart tick formats without pulling in a date lib.
+export function helsinkiParts(unixMs) {
+  const parts = fmtDayPartsHelsinki.formatToParts(new Date(unixMs));
+  const out = {};
+  for (const p of parts) {
+    if (p.type === 'literal') continue;
+    out[p.type] = parseInt(p.value, 10);
+  }
+  return out;
 }
 
 // Short human-readable label for each cause tag. Keep in sync with

--- a/playground/js/main/time-format.js
+++ b/playground/js/main/time-format.js
@@ -117,6 +117,25 @@ export function formatFullTimeHelsinki(unixMs) {
          get('hour') + ':' + get('minute') + ':' + get('second');
 }
 
+// Full ISO-8601 with the Helsinki UTC offset (e.g. "2026-04-19T13:00:00+03:00").
+// Machine-readable AND unambiguous — used by Copy-JSON exports so bug
+// reports carry the user's wall clock without losing the offset.
+export function formatIsoHelsinki(unixMs) {
+  const d = new Date(unixMs);
+  const local = formatFullTimeHelsinki(unixMs).replace(' ', 'T');
+  // DST-aware offset between the instant and the Helsinki wall clock.
+  const parts = fmtFullHelsinki.formatToParts(d);
+  const get = (type) => { const p = parts.find(x => x.type === type); return p ? parseInt(p.value, 10) : 0; };
+  const wallMs = Date.UTC(get('year'), get('month') - 1, get('day'),
+                          get('hour'), get('minute'), get('second'));
+  const offsetMin = Math.round((wallMs - d.getTime()) / 60000);
+  const sign = offsetMin >= 0 ? '+' : '-';
+  const abs = Math.abs(offsetMin);
+  const oh = Math.floor(abs / 60).toString().padStart(2, '0');
+  const om = (abs % 60).toString().padStart(2, '0');
+  return local + sign + oh + ':' + om;
+}
+
 export function escapeHtml(s) {
   return String(s)
     .replace(/&/g, '&amp;')

--- a/playground/js/main/time-format.js
+++ b/playground/js/main/time-format.js
@@ -15,7 +15,7 @@ export function formatTimeOfDay(simSeconds) {
   return h.toString().padStart(2, '0') + ':' + m.toString().padStart(2, '0');
 }
 
-export const HELSINKI_TZ = 'Europe/Helsinki';
+const HELSINKI_TZ = 'Europe/Helsinki';
 const fmtClockHelsinki = new Intl.DateTimeFormat('fi-FI', {
   hour: '2-digit', minute: '2-digit', hour12: false, timeZone: HELSINKI_TZ,
 });

--- a/playground/js/main/watchdog-ui.js
+++ b/playground/js/main/watchdog-ui.js
@@ -357,7 +357,9 @@ function renderWatchdogHistory(recent) {
   recent.forEach(ev => {
     const row = document.createElement('div');
     row.className = 'watchdog-history-row';
-    const when = ev.fired_at ? new Date(ev.fired_at).toLocaleString() : '';
+    const when = ev.fired_at
+      ? new Date(ev.fired_at).toLocaleString([], { timeZone: 'Europe/Helsinki' })
+      : '';
     const resolution = ev.resolution || 'pending';
     const safeReason = (ev.trigger_reason || '').replace(/</g, '&lt;');
     const safeSnooze = (ev.snooze_reason || '').replace(/</g, '&lt;');

--- a/playground/js/ui.js
+++ b/playground/js/ui.js
@@ -202,6 +202,21 @@ export function pickTickStep(rangeSec, plotWidthPx, minPxPerLabel = 72) {
 }
 
 const MONTHS_SHORT = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+const HELSINKI_TZ = 'Europe/Helsinki';
+const fmtTickClock = new Intl.DateTimeFormat('en-GB', {
+  hour: '2-digit', minute: '2-digit', hour12: false, timeZone: HELSINKI_TZ,
+});
+const fmtTickParts = new Intl.DateTimeFormat('en-GB', {
+  year: 'numeric', month: 'numeric', day: 'numeric', timeZone: HELSINKI_TZ,
+});
+function tickDateParts(d) {
+  const out = {};
+  for (const p of fmtTickParts.formatToParts(d)) {
+    if (p.type === 'literal') continue;
+    out[p.type] = parseInt(p.value, 10);
+  }
+  return out;
+}
 
 /**
  * Pick the bucket size (seconds) for the duty-cycle mode bars on the history
@@ -229,13 +244,12 @@ export function pickBucketSize(rangeSec) {
 export function formatTick(tEpochSec, stepSec) {
   const d = new Date(tEpochSec * 1000);
   if (stepSec < DAY_SECONDS) {
-    const hh = d.getHours().toString().padStart(2, '0');
-    const mm = d.getMinutes().toString().padStart(2, '0');
-    return `${hh}:${mm}`;
+    return fmtTickClock.format(d);
   }
+  const p = tickDateParts(d);
   if (stepSec < 30 * DAY_SECONDS) {
-    return `${d.getDate()}.${d.getMonth() + 1}.`;
+    return `${p.day}.${p.month}.`;
   }
-  return `${MONTHS_SHORT[d.getMonth()]} ${d.getFullYear() % 100}`;
+  return `${MONTHS_SHORT[p.month - 1]} ${p.year % 100}`;
 }
 

--- a/playground/sw.js
+++ b/playground/sw.js
@@ -90,8 +90,10 @@ self.addEventListener('notificationclick', function (event) {
         var testReply = (event.reply && event.reply.trim()) || '(no reason provided)';
         var ttlSec = data.snoozeTtlSeconds || 43200;
         var until = new Date(Date.now() + ttlSec * 1000);
-        var pad2 = function (n) { return n < 10 ? '0' + n : '' + n; };
-        var untilStr = pad2(until.getHours()) + ':' + pad2(until.getMinutes());
+        var untilStr = new Intl.DateTimeFormat('en-GB', {
+          hour: '2-digit', minute: '2-digit', hour12: false,
+          timeZone: 'Europe/Helsinki',
+        }).format(until);
         event.waitUntil(self.registration.showNotification(
           '[Test] Snooze applied \u2014 ' + testTitle,
           {

--- a/server/lib/anomaly-manager.js
+++ b/server/lib/anomaly-manager.js
@@ -180,13 +180,12 @@ function _dispatchSnoozeAckPush(id, pendingSnapshot) {
   const label = meta ? meta.shortLabel : id;
   const reason = pendingSnapshot.snoozeReason || '(no reason provided)';
   const until = new Date(pendingSnapshot.snoozeUntil * 1000);
-  // Compact "HH:MM" formatting using local-time UTC offset of the
-  // server. The user's wall-clock interpretation matches whatever
-  // their browser sees in the in-app banner.
-  const hh = until.getHours();
-  const mm = until.getMinutes();
-  const untilStr = (hh < 10 ? '0' + hh : '' + hh) + ':' +
-                   (mm < 10 ? '0' + mm : '' + mm);
+  // Compact "HH:MM" in Europe/Helsinki so the cloud server (typically
+  // UTC) renders the same wall clock the user sees in-app.
+  const untilStr = new Intl.DateTimeFormat('en-GB', {
+    hour: '2-digit', minute: '2-digit', hour12: false,
+    timeZone: 'Europe/Helsinki',
+  }).format(until);
 
   const payload = {
     title: 'Snooze applied \u2014 ' + label,

--- a/tests/frontend/copy-logs.spec.js
+++ b/tests/frontend/copy-logs.spec.js
@@ -291,3 +291,56 @@ test.describe('Copy System Logs — live mode', () => {
     expect(text).toContain('idle');
   });
 });
+
+// ── Timezone tests ──
+// The clipboard export and all visible timestamps must render in
+// Europe/Helsinki regardless of the browser's local timezone.
+// Browser timezone pinned to UTC to make the assertion unambiguous: a
+// UTC formatter would emit "…T12:00:00Z", a Helsinki one would emit
+// the same wall clock shifted by +02:00 / +03:00 (DST-aware).
+
+test.describe('Copy System Logs — Helsinki timezone', () => {
+  test.use({ timezoneId: 'UTC' });
+
+  test('exported timestamp and sensor readings render in Europe/Helsinki', async ({ page }) => {
+    // 2026-04-19T10:00:00Z — Helsinki is UTC+3 in April (EEST), so the
+    // same instant reads as 13:00 in Helsinki wall clock.
+    const fixedMs = Date.UTC(2026, 3, 19, 10, 0, 0);
+    const historyPoints = [{
+      ts: fixedMs,
+      collector: 25, tank_top: 40, tank_bottom: 35, greenhouse: 18, outdoor: 10,
+    }];
+
+    await installMockWs(page);
+    await mockHistoryApi(page, historyPoints);
+    await mockEventsApi(page, []);
+
+    // Freeze the clock used for the "Exported:" header.
+    await page.addInitScript((frozenMs) => {
+      const OrigDate = Date;
+      // eslint-disable-next-line no-global-assign
+      Date = class extends OrigDate {
+        constructor(...args) {
+          if (args.length === 0) { super(frozenMs); return; }
+          super(...args);
+        }
+        static now() { return frozenMs; }
+      };
+      Date.UTC = OrigDate.UTC;
+      Date.parse = OrigDate.parse;
+    }, fixedMs);
+
+    await page.goto('/playground/', { waitUntil: 'domcontentloaded' });
+    await expect(page.locator('#connection-dot')).toHaveClass(/connected/, { timeout: 5000 });
+    await waitForTestHook(page);
+
+    const text = await getClipboardText(page);
+
+    // Helsinki wall clock for 2026-04-19T10:00:00Z is 13:00:00 (EEST, UTC+3).
+    // Both the header "Exported:" line and the sensor row should carry that.
+    expect(text).toContain('Exported: 2026-04-19 13:00:00');
+    expect(text).toMatch(/2026-04-19 13:00:00\s+25\.0/);
+    // And never the raw UTC ISO.
+    expect(text).not.toContain('2026-04-19T10:00:00');
+  });
+});

--- a/tests/frontend/crashes-view.spec.js
+++ b/tests/frontend/crashes-view.spec.js
@@ -143,4 +143,24 @@ test.describe('#crashes view', () => {
     const clipboard = await page.evaluate(() => navigator.clipboard.readText());
     expect(clipboard).toContain('"id": 1001');
   });
+
+  test.describe('Copy JSON uses Helsinki timezone', () => {
+    test.use({ timezoneId: 'UTC' });
+
+    test('detail row timestamps carry the +03:00 / +02:00 Helsinki offset', async ({ page }) => {
+      const detail = { ...crashB, sys_status: {}, recent_states: [] };
+      await mockScaffold(page, { crashes: [crashB], detailById: { 1002: detail } });
+      await page.goto('/playground/#crashes');
+      const row = page.locator('#crashes-list li[data-id="1002"]');
+      await row.click();
+
+      const json = await row.locator('.crashes-detail').textContent();
+      // crashB ts is 2026-04-21T20:00:00Z → Helsinki EEST (+03) → 23:00:00.
+      expect(json).toContain('"ts": "2026-04-21T23:00:00+03:00"');
+      // resolved_at 21:00:00Z → 00:00:00 next day in Helsinki.
+      expect(json).toContain('"resolved_at": "2026-04-22T00:00:00+03:00"');
+      // And never the raw "…Z" UTC form.
+      expect(json).not.toContain('20:00:00.000Z');
+    });
+  });
 });


### PR DESCRIPTION
The copy-to-clipboard timestamps in the System Logs card were rendered
in UTC (toISOString), and most other display paths (crashes, auth,
watchdog history, balance-card window, graph-inspector hover, chart
x-axis ticks, snooze-ack push notifications) used the browser's or
server's local timezone. The cloud server runs in UTC, so the push
notifications in particular were several hours off. Switch every
display path to explicit Europe/Helsinki so the shown wall clock
always matches the user's.

Test: new Playwright case in tests/frontend/copy-logs.spec.js pins
the browser TZ to UTC and asserts the exported sensor row for a
2026-04-19T10:00:00Z sample shows up as "2026-04-19 13:00:00"
(EEST, +03:00).