### PR TITLE
ui: convert status timeframe selector to progressive slider

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -254,14 +254,21 @@
               <h3 style="margin-bottom:0;">24h History</h3>
               <span class="graph-peak" id="graph-peak-label">Yesterday's High: --</span>
             </div>
-            <div class="time-range-pills" id="time-range-pills">
-              <button data-range="3600">1h</button>
-              <button data-range="21600">6h</button>
-              <button data-range="43200">12h</button>
-              <button data-range="86400" class="active">24h</button>
-              <button data-range="604800" class="live-only" style="display:none;">7d</button>
-              <button data-range="2592000" class="live-only" style="display:none;">30d</button>
-              <button data-range="31536000" class="live-only" style="display:none;">1y</button>
+            <div class="time-range-slider" id="time-range-slider" role="slider" tabindex="0" aria-label="Timeframe"
+                 aria-valuemin="0" aria-valuemax="6" aria-valuenow="3" aria-valuetext="24h">
+              <div class="time-range-slider-track">
+                <div class="time-range-slider-fill"></div>
+                <div class="time-range-slider-thumb"></div>
+              </div>
+              <div class="time-range-slider-steps">
+                <button type="button" class="time-range-slider-step" data-range="3600" data-step="0">1h</button>
+                <button type="button" class="time-range-slider-step" data-range="21600" data-step="1">6h</button>
+                <button type="button" class="time-range-slider-step" data-range="43200" data-step="2">12h</button>
+                <button type="button" class="time-range-slider-step active" data-range="86400" data-step="3">24h</button>
+                <button type="button" class="time-range-slider-step live-only" data-range="259200" data-step="4" style="display:none;">3d</button>
+                <button type="button" class="time-range-slider-step live-only" data-range="604800" data-step="5" style="display:none;">7d</button>
+                <button type="button" class="time-range-slider-step live-only" data-range="10368000" data-step="6" style="display:none;">4mo</button>
+              </div>
             </div>
             <div class="graph-option-toggle" id="graph-show-all-sensors-toggle">
               <span>All sensors</span>

--- a/playground/js/main.js
+++ b/playground/js/main.js
@@ -108,7 +108,7 @@ async function init() {
   initNavigation(store);
 
   setupControls();
-  setupTimeRangePills();
+  setupTimeRangeSlider();
   setupAllSensorsToggle();
   setupFAB();
   resetSim();
@@ -189,21 +189,154 @@ function buildFallbackConfig() {
 // ── Navigation is now store-driven via js/actions/navigation.js + js/subscriptions.js ──
 
 
-// ── Time range pills ──
+// ── Timeframe progressive slider ──
 
-function setupTimeRangePills() {
-  document.getElementById('time-range-pills').addEventListener('click', (e) => {
-    const btn = e.target.closest('button');
-    if (!btn) return;
-    setGraphRange(parseInt(btn.dataset.range));
-    document.querySelectorAll('#time-range-pills button').forEach(b => b.classList.remove('active'));
-    btn.classList.add('active');
-    if (store.get('phase') === 'live') {
-      fetchLiveHistory(graphRange);
-    } else {
-      drawHistoryGraph();
+// Haptic tick on snap. Matches the createSlider pattern in ui.js so the
+// feel is consistent with the simulation-controls sliders (8 ms pulse).
+function hapticTick() {
+  try { if (navigator.vibrate) navigator.vibrate(8); } catch (e) { /* noop */ }
+}
+
+function setupTimeRangeSlider() {
+  const slider = document.getElementById('time-range-slider');
+  if (!slider) return;
+  const thumb = slider.querySelector('.time-range-slider-thumb');
+  const fill = slider.querySelector('.time-range-slider-fill');
+  const stepsWrap = slider.querySelector('.time-range-slider-steps');
+  const allSteps = Array.from(stepsWrap.querySelectorAll('.time-range-slider-step'));
+
+  function visibleSteps() {
+    return allSteps.filter(el => el.style.display !== 'none');
+  }
+
+  function updateThumb(stepEls, activeIdx) {
+    if (stepEls.length === 0) return;
+    // Position thumb over the active step. Width/position are fractions of
+    // the steps-container width so the thumb tracks flex sizing regardless
+    // of how many steps are visible.
+    const widthPct = 100 / stepEls.length;
+    const leftPct = widthPct * activeIdx;
+    thumb.style.width = widthPct + '%';
+    thumb.style.transform = 'translateX(' + (leftPct / widthPct * 100) + '%)';
+    fill.style.width = (leftPct + widthPct) + '%';
+    allSteps.forEach(b => b.classList.remove('active'));
+    stepEls[activeIdx].classList.add('active');
+    slider.setAttribute('aria-valuemin', '0');
+    slider.setAttribute('aria-valuemax', String(stepEls.length - 1));
+    slider.setAttribute('aria-valuenow', String(activeIdx));
+    slider.setAttribute('aria-valuetext', stepEls[activeIdx].textContent);
+  }
+
+  function commit(stepEls, idx, fromUser) {
+    idx = Math.max(0, Math.min(stepEls.length - 1, idx));
+    const el = stepEls[idx];
+    const seconds = parseInt(el.dataset.range, 10);
+    const changed = graphRange !== seconds;
+    setGraphRange(seconds);
+    updateThumb(stepEls, idx);
+    if (changed) {
+      if (fromUser) hapticTick();
+      if (store.get('phase') === 'live') {
+        fetchLiveHistory(graphRange);
+      } else {
+        drawHistoryGraph();
+      }
     }
+  }
+
+  function idxFromClientX(stepEls, clientX) {
+    const rect = stepsWrap.getBoundingClientRect();
+    const frac = (clientX - rect.left) / rect.width;
+    return Math.round(frac * (stepEls.length - 1));
+  }
+
+  // Initialize: reflect the current graphRange (default 24h / step 3).
+  function syncFromState() {
+    const stepEls = visibleSteps();
+    let idx = stepEls.findIndex(el => parseInt(el.dataset.range, 10) === graphRange);
+    if (idx < 0) {
+      // graphRange points at a step hidden in this phase (e.g. switched
+      // live→sim while on 7d). Clamp to the largest visible step and
+      // rewrite state so subsequent fetches use a supported range.
+      idx = stepEls.length - 1;
+      const el = stepEls[idx];
+      setGraphRange(parseInt(el.dataset.range, 10));
+    }
+    updateThumb(stepEls, idx);
+  }
+  syncFromState();
+
+  // Clicks on an individual step snap directly — same as the old pills.
+  stepsWrap.addEventListener('click', (e) => {
+    const btn = e.target.closest('.time-range-slider-step');
+    if (!btn || btn.style.display === 'none') return;
+    const stepEls = visibleSteps();
+    const idx = stepEls.indexOf(btn);
+    if (idx >= 0) commit(stepEls, idx, true);
   });
+
+  // Drag support: pointer events cover mouse + touch + pen uniformly.
+  let dragging = false;
+  let activePointer = null;
+  let lastIdx = -1;
+
+  function onDown(e) {
+    // Only react to the primary button; touch/pen pointer types always have button=0.
+    if (e.button !== undefined && e.button !== 0) return;
+    dragging = true;
+    activePointer = e.pointerId;
+    slider.classList.add('dragging');
+    try { slider.setPointerCapture(e.pointerId); } catch (_) { /* noop */ }
+    const stepEls = visibleSteps();
+    const idx = idxFromClientX(stepEls, e.clientX);
+    lastIdx = idx;
+    commit(stepEls, idx, true);
+    e.preventDefault();
+  }
+
+  function onMove(e) {
+    if (!dragging || e.pointerId !== activePointer) return;
+    const stepEls = visibleSteps();
+    const idx = idxFromClientX(stepEls, e.clientX);
+    if (idx !== lastIdx) {
+      lastIdx = idx;
+      commit(stepEls, idx, true);
+    }
+  }
+
+  function onUp(e) {
+    if (!dragging || (activePointer !== null && e.pointerId !== activePointer)) return;
+    dragging = false;
+    activePointer = null;
+    lastIdx = -1;
+    slider.classList.remove('dragging');
+  }
+
+  slider.addEventListener('pointerdown', onDown);
+  slider.addEventListener('pointermove', onMove);
+  slider.addEventListener('pointerup', onUp);
+  slider.addEventListener('pointercancel', onUp);
+
+  // Keyboard access: arrow keys step, Home/End jump to bounds.
+  slider.addEventListener('keydown', (e) => {
+    const stepEls = visibleSteps();
+    const current = stepEls.findIndex(el => parseInt(el.dataset.range, 10) === graphRange);
+    const cur = current < 0 ? 0 : current;
+    let next = cur;
+    if (e.key === 'ArrowLeft' || e.key === 'ArrowDown') next = cur - 1;
+    else if (e.key === 'ArrowRight' || e.key === 'ArrowUp') next = cur + 1;
+    else if (e.key === 'Home') next = 0;
+    else if (e.key === 'End') next = stepEls.length - 1;
+    else return;
+    e.preventDefault();
+    commit(stepEls, next, true);
+  });
+
+  // Re-sync when phase flips live↔sim — .live-only steps show/hide and
+  // the visible set changes. subscriptions.js has already toggled
+  // display:none by the time this subscriber fires (it registers earlier
+  // via initSubscriptions).
+  store.subscribe('phase', () => { syncFromState(); });
 }
 
 function setupAllSensorsToggle() {

--- a/playground/js/main/live-history.js
+++ b/playground/js/main/live-history.js
@@ -15,7 +15,7 @@ import { rerenderWithHistoryFallback } from './display-update.js';
 
 const RANGE_MAP = {
   3600: '1h', 21600: '6h', 43200: '12h', 86400: '24h',
-  604800: '7d', 2592000: '30d', 31536000: '1y',
+  259200: '3d', 604800: '7d', 10368000: '4mo',
 };
 
 let liveHistoryData = null;

--- a/playground/public/style.css
+++ b/playground/public/style.css
@@ -552,34 +552,87 @@ select, input, textarea { max-width: 100%; }
 
 .graph-header h3 { margin-bottom: 0; }
 
-.time-range-pills {
-  display: flex;
-  gap: 4px;
+/* Progressive timeframe slider — replaces the old discrete pill bar.
+   Steps snap, the thumb glides between them, and a subtle vibration
+   pulses on each snap boundary for tactile feedback on touch devices. */
+.time-range-slider {
+  position: relative;
   background: var(--surface-container-lowest);
   border-radius: 9999px;
   padding: 4px;
+  touch-action: pan-y;
+  user-select: none;
+  -webkit-user-select: none;
+  outline: none;
 }
 
-.time-range-pills button {
+.time-range-slider-track {
+  position: absolute;
+  inset: 4px;
+  border-radius: 9999px;
+  pointer-events: none;
+}
+
+.time-range-slider-fill {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 0;
+  background: var(--surface-container-highest);
+  border-radius: 9999px;
+  transition: width 160ms cubic-bezier(0.2, 0, 0, 1);
+}
+
+.time-range-slider-thumb {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: calc(100% / 4);
+  background: var(--surface-container-highest);
+  border-radius: 9999px;
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.04), 0 2px 8px rgba(0, 0, 0, 0.25);
+  transition:
+    transform 180ms cubic-bezier(0.2, 0, 0, 1),
+    width 180ms cubic-bezier(0.2, 0, 0, 1);
+  will-change: transform;
+}
+
+.time-range-slider.dragging .time-range-slider-thumb,
+.time-range-slider.dragging .time-range-slider-fill {
+  transition: none;
+}
+
+.time-range-slider-steps {
+  position: relative;
+  display: flex;
+}
+
+.time-range-slider-step {
+  flex: 1 1 0;
   background: none;
   border: none;
   color: var(--on-surface-variant);
   font-family: 'Manrope', sans-serif;
   font-size: 11px;
   font-weight: 700;
-  padding: 8px 12px;
+  padding: 8px 6px;
   border-radius: 9999px;
   cursor: pointer;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  transition: all 0.2s;
+  transition: color 160ms ease;
+  position: relative;
+  z-index: 1;
 }
 
-.time-range-pills button:hover { color: var(--on-surface); }
+.time-range-slider-step:hover { color: var(--on-surface); }
 
-.time-range-pills button.active {
-  background: var(--surface-container-highest);
-  color: var(--on-surface);
+.time-range-slider-step.active { color: var(--on-surface); }
+
+.time-range-slider:focus-visible {
+  box-shadow: 0 0 0 2px var(--primary, #69d0c5);
 }
 
 .graph-peak {

--- a/server/lib/db.js
+++ b/server/lib/db.js
@@ -180,8 +180,10 @@ const RANGE_INTERVALS = {
   '12h': '12 hours',
   '24h': '24 hours',
   '48h': '48 hours',
+  '3d': '3 days',
   '7d': '7 days',
   '30d': '30 days',
+  '4mo': '4 months',
   '1y': '1 year',
 };
 
@@ -195,8 +197,10 @@ const RANGE_INTERVALS = {
 // e2e harness relies on `range=all` resolving against pg-mem (which has
 // no time_bucket).
 const COARSE_BUCKETS = {
+  '3d': '2 minutes',
   '7d': '5 minutes',
   '30d': '30 minutes',
+  '4mo': '2 hours',
   '1y': '6 hours',
 };
 
@@ -208,8 +212,9 @@ function getHistory(range, sensor, callback) {
     return;
   }
 
-  // Choose resolution: raw for ≤6h, 30s aggregate for ≥7d, blended for 24h/48h
-  const useAggregate = range === '7d' || range === '30d' || range === '1y' || range === 'all';
+  // Choose resolution: raw for ≤6h, 30s aggregate for ≥3d, blended for 24h/48h.
+  // 3d must use the aggregate — raw sensor_readings is pruned at 48h.
+  const useAggregate = range === '3d' || range === '7d' || range === '30d' || range === '4mo' || range === '1y' || range === 'all';
   const useBlended = range === '24h' || range === '48h';
 
   const params = [];

--- a/tests/frontend/take-screenshots.spec.js
+++ b/tests/frontend/take-screenshots.spec.js
@@ -102,7 +102,7 @@ test.describe('Generate Screenshots (24h simulation)', () => {
     // ── Status view — desktop ──
     // Switch to status while sim is still running so chart renders
     await goToView(page, 'status');
-    await page.locator('#time-range-pills button[data-range="86400"]').click();
+    await page.locator('#time-range-slider .time-range-slider-step[data-range="86400"]').click();
     // Let the chart render a few frames with 24h data visible
     await page.waitForTimeout(1000);
     // Now pause
@@ -145,7 +145,7 @@ test.describe('Generate Screenshots (24h simulation)', () => {
     // ── README hero screenshot (desktop, status view, 24h chart visible) ──
     await page.setViewportSize({ width: 1280, height: 1100 });
     await goToView(page, 'status');
-    await page.locator('#time-range-pills button[data-range="86400"]').click();
+    await page.locator('#time-range-slider .time-range-slider-step[data-range="86400"]').click();
     await page.waitForTimeout(300);
     await page.screenshot({
       path: path.join(screenshotDir, 'readme-hero.png'),

--- a/tests/history-range-12h.test.js
+++ b/tests/history-range-12h.test.js
@@ -3,6 +3,10 @@
  * because server/lib/db.js:RANGE_INTERVALS was missing the `12h` entry even
  * though playground/index.html ships a "12h" button. The UI silently
  * dropped the empty response and the chart looked blank.
+ *
+ * Extended to cover the progressive-slider step set: the Status view's
+ * timeframe slider exposes 1h/6h/12h/24h/3d/7d/4mo steps (24h default,
+ * 4mo upper bound). Every step must have a matching RANGE_INTERVALS entry.
  */
 
 const { describe, it } = require('node:test');
@@ -10,20 +14,26 @@ const assert = require('node:assert/strict');
 const fs = require('fs');
 const path = require('path');
 
-describe('getHistory / RANGE_INTERVALS — 12h support', () => {
-  it('index.html declares a 12h range button', () => {
+const SLIDER_STEPS = ['1h', '6h', '12h', '24h', '3d', '7d', '4mo'];
+
+describe('getHistory / RANGE_INTERVALS — slider step coverage', () => {
+  it('index.html declares the progressive timeframe slider with the expected step values', () => {
     const html = fs.readFileSync(path.join(__dirname, '..', 'playground', 'index.html'), 'utf8');
-    assert.match(html, /data-range="43200"/, 'index.html should expose a 12h (43200s) range button');
+    assert.match(html, /id="time-range-slider"/, 'index.html should expose a #time-range-slider element');
+    const secondsForStep = { '1h': 3600, '6h': 21600, '12h': 43200, '24h': 86400, '3d': 259200, '7d': 604800, '4mo': 10368000 };
+    for (const step of SLIDER_STEPS) {
+      const secs = secondsForStep[step];
+      assert.match(html, new RegExp(`data-range="${secs}"`), `slider markup should expose step ${step} (${secs}s)`);
+    }
   });
 
-  it('server/lib/db.js RANGE_INTERVALS covers every range that has a button', () => {
+  it('server/lib/db.js RANGE_INTERVALS covers every slider step', () => {
     // Read the source so we don't need a live DB to assert the mapping.
     const src = fs.readFileSync(path.join(__dirname, '..', 'server', 'lib', 'db.js'), 'utf8');
     const match = src.match(/(?:var|let|const)\s+RANGE_INTERVALS\s*=\s*\{([^}]+)\}/);
     assert.ok(match, 'RANGE_INTERVALS object not found in db.js');
     const body = match[1];
-    const ranges = ['1h', '6h', '12h', '24h', '7d', '30d', '1y'];
-    for (const r of ranges) {
+    for (const r of SLIDER_STEPS) {
       assert.match(body, new RegExp("'" + r + "':\\s*'"), `RANGE_INTERVALS missing entry for '${r}'`);
     }
   });


### PR DESCRIPTION
Swap the 7 discrete pill buttons on the Status view for a draggable,
step-snapping slider with haptic feedback (navigator.vibrate(8)) on every
boundary crossing — mouse, touch, and keyboard paths all go through the
same commit() so the vibrate fires consistently. Pointer events unify
input handling and setPointerCapture keeps a drag alive if the finger
drifts off the track.

New step set (24h default): 1h · 6h · 12h · 24h · 3d · 7d · 4mo.
3d and 4mo are added to server RANGE_INTERVALS + COARSE_BUCKETS (2 min
and 2 h buckets respectively; 3d is forced onto the 30 s aggregate
because raw sensor_readings is pruned at 48 h). 30d and 1y stay in the
server enum for backward compatibility but no longer have UI steps.

live-only visibility behaves as before — 3d/7d/4mo are hidden in sim
mode via the existing .live-only class; the slider re-computes step
positions on phase change and clamps graphRange to the largest visible
step when switching live→sim so fetches never hit a hidden range.

history-range test updated to assert the slider markup + new server
enum entries; screenshot spec selector updated for the new DOM.