### PR TITLE
notifications: skip freeze/overheat warnings when collectors are drained

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -334,6 +334,13 @@
           </div>
           <div class="component-card">
             <div>
+              <div class="component-label">Collectors</div>
+              <div class="component-value component-value-off" id="comp-collectors">FILLED</div>
+            </div>
+            <span class="material-symbols-outlined component-icon" id="comp-collectors-icon">water_drop</span>
+          </div>
+          <div class="component-card">
+            <div>
               <div class="component-label">Controller</div>
               <div class="component-value component-value-optimal" id="comp-controller">READY</div>
             </div>

--- a/playground/js/control.js
+++ b/playground/js/control.js
@@ -113,6 +113,10 @@ export class ControlStateMachine {
         space_heater: !!result.actuators.space_heater,
       },
       valves: result.valves,
+      flags: {
+        collectors_drained: !!this.collectorsDrained,
+        emergency_heating_active: !!this.emergencyHeatingActive,
+      },
       transition,
     };
   }

--- a/playground/js/data-source.js
+++ b/playground/js/data-source.js
@@ -207,6 +207,11 @@ export class LiveSource extends DataSource {
       // moment of the transition.
       cause: data.cause || null,
       temps: data.temps || null,
+      // Carries `collectors_drained` / `emergency_heating_active` from
+      // the controller snapshot. Consumed by display-update.js so the
+      // Status view can show whether the collector loop currently
+      // holds water.
+      flags: data.flags || {},
     };
 
     this._emitUpdate(state, result);

--- a/playground/js/main/display-update.js
+++ b/playground/js/main/display-update.js
@@ -275,6 +275,24 @@ export function updateDisplay(state, result) {
   updateComponent('comp-pump', result.actuators.pump, 'ACTIVE', 'OFF');
   updateComponent('comp-fan', result.actuators.fan, 'ON', 'OFF');
   updateComponent('comp-heater', result.actuators.space_heater, 'ON', 'OFF');
+
+  // Collectors fluid state. Drained = the freeze-drain or overheat-drain
+  // sequence has emptied the collector loop into the tank; refilling
+  // happens automatically on the next safe SOLAR_CHARGING window.
+  // Highlighted when drained because that's the protected (and the
+  // operator-actionable) state — drained means no freeze warning will
+  // fire, the system is parked.
+  const drained = !!(result.flags && result.flags.collectors_drained);
+  const collectorsEl = document.getElementById('comp-collectors');
+  if (collectorsEl) {
+    collectorsEl.textContent = drained ? 'DRAINED' : 'FILLED';
+    collectorsEl.className = 'component-value ' +
+      (drained ? 'component-value-optimal' : 'component-value-off');
+  }
+  const collectorsIcon = document.getElementById('comp-collectors-icon');
+  if (collectorsIcon) {
+    collectorsIcon.textContent = drained ? 'humidity_low' : 'water_drop';
+  }
   // Live mode: 'running' is meaningless (sim-only). Reflect actual
   // operation by checking whether mode is non-idle.
   const isLivePhase = store.get('phase') === 'live';

--- a/server/lib/notifications.js
+++ b/server/lib/notifications.js
@@ -234,8 +234,14 @@ function evaluate(payload) {
   }
 
   // ── Pre-emergency alerts (only with fresh data) ──
-  checkOverheatWarning(temps);
-  checkFreezeWarning(temps);
+  // Drained collectors hold no water, so neither the freeze drain nor
+  // the overheat drain (which both circulate fluid through the
+  // collector loop) can fire. Suppressing the predictive warnings
+  // avoids cluttering the operator with alerts that reference a
+  // physically-impossible action.
+  const collectorsDrained = !!(payload.flags && payload.flags.collectors_drained);
+  checkOverheatWarning(temps, collectorsDrained);
+  checkFreezeWarning(temps, collectorsDrained);
 
   // ── Scheduled reports (only with fresh data) ──
   checkEveningReport();
@@ -298,7 +304,8 @@ function tick() {
   }
 }
 
-function checkOverheatWarning(temps) {
+function checkOverheatWarning(temps, collectorsDrained) {
+  if (collectorsDrained) return;
   if (typeof temps.tank_top !== 'number') return;
   const thresholds = getThresholds();
   const current = temps.tank_top;
@@ -321,7 +328,8 @@ function checkOverheatWarning(temps) {
   }
 }
 
-function checkFreezeWarning(temps) {
+function checkFreezeWarning(temps, collectorsDrained) {
+  if (collectorsDrained) return;
   // Match control-logic's trigger: whichever of outdoor/collector is
   // colder drives the drain. On clear nights the sky-facing collector
   // reads several K below sheltered ambient, so warning on outdoor

--- a/tests/frontend/live-display.spec.js
+++ b/tests/frontend/live-display.spec.js
@@ -300,3 +300,29 @@ test.describe("Graph 'All sensors' toggle", () => {
     await expect(page.locator('#inspector-tank-bottom')).toHaveText(/\d+\.\d°C/);
   });
 });
+
+test.describe('Collectors fluid-state indicator', () => {
+  test('shows DRAINED when the live frame reports collectors_drained=true', async ({ page }) => {
+    await installMockWs(page, {
+      mode: 'idle',
+      flags: { collectors_drained: true, emergency_heating_active: false },
+    });
+    await mockHistoryApi(page);
+    await page.goto('/playground/#status', { waitUntil: 'domcontentloaded' });
+
+    await expect(page.locator('#connection-dot')).toHaveClass(/connected/, { timeout: 3000 });
+    await expect(page.locator('#comp-collectors')).toHaveText('DRAINED');
+  });
+
+  test('shows FILLED when the live frame reports collectors_drained=false', async ({ page }) => {
+    await installMockWs(page, {
+      mode: 'solar_charging',
+      flags: { collectors_drained: false, emergency_heating_active: false },
+    });
+    await mockHistoryApi(page);
+    await page.goto('/playground/#status', { waitUntil: 'domcontentloaded' });
+
+    await expect(page.locator('#connection-dot')).toHaveClass(/connected/, { timeout: 3000 });
+    await expect(page.locator('#comp-collectors')).toHaveText('FILLED');
+  });
+});

--- a/tests/notifications.test.js
+++ b/tests/notifications.test.js
@@ -222,6 +222,54 @@ describe('notifications', () => {
       assert.strictEqual(freezeNotifs.length, 0);
     });
 
+    it('does not send freeze warning when collectors are already drained', () => {
+      // Same trending payload as the "sends freeze warning" test, but
+      // with flags.collectors_drained=true. There is no water in the
+      // collector loop to freeze, so warning the operator that "freeze
+      // drain may activate" is misleading — it cannot, the system is
+      // already in the post-drain state.
+      const CONTROL = require('../shelly/control-logic.js');
+      const freezeT = CONTROL.DEFAULT_CONFIG.freezeDrainTemp;
+      const now = Date.now();
+      const history = [];
+      for (let i = 0; i <= 6; i++) {
+        notifications.addSample(history, now - (6 - i) * 60000, freezeT + 3 - i * 0.5);
+      }
+      notifications._setOutdoorHistory(history);
+
+      notifications.evaluate({
+        temps: { tank_top: 50, outdoor: freezeT + 0.1 },
+        mode: 'IDLE',
+        flags: { collectors_drained: true },
+      });
+
+      const freezeNotifs = sentNotifications.filter(function (n) { return n.type === 'freeze_warning'; });
+      assert.strictEqual(freezeNotifs.length, 0);
+    });
+
+    it('does not send overheat warning when collectors are already drained', () => {
+      // Overheat drain only activates during SOLAR_CHARGING, which
+      // requires water in the collectors. If they are drained, the
+      // drain mode the warning references cannot trigger.
+      const CONTROL = require('../shelly/control-logic.js');
+      const overheatT = CONTROL.DEFAULT_CONFIG.overheatDrainTemp;
+      const now = Date.now();
+      const tankHistory = [];
+      for (let k = 0; k <= 5; k++) {
+        notifications.addSample(tankHistory, now - (5 - k) * 60000, overheatT - 7 + k);
+      }
+      notifications._setTankHistory(tankHistory);
+
+      notifications.evaluate({
+        temps: { tank_top: overheatT - 2, outdoor: 10 },
+        mode: 'SOLAR_CHARGING',
+        flags: { collectors_drained: true },
+      });
+
+      const overheatNotifs = sentNotifications.filter(function (n) { return n.type === 'overheat_warning'; });
+      assert.strictEqual(overheatNotifs.length, 0);
+    });
+
     it('tracks energy during solar charging', () => {
       notifications.evaluate({ temps: { tank_top: 50, outdoor: 10 }, mode: 'SOLAR_CHARGING' });
       assert.strictEqual(notifications._getDailyEnergyWh(), 0);


### PR DESCRIPTION
A drained collector loop holds no water, so neither the freeze drain
nor the overheat drain (which both circulate fluid through the loop)
can fire. Sending operators a "Freeze drain may activate at 4°C"
notification in that state is misleading — the system is already in
the post-drain protected state.

Guards both checkFreezeWarning and checkOverheatWarning on the
flags.collectors_drained field already published in the controller's
state snapshot. Adds a Collectors / DRAINED · FILLED tile to the
Status view's Critical Components grid so the protected state is
visible at a glance.

https://claude.ai/code/session_01585WeiBn3yUW6Z91fdaweE