### PR TITLE
playground: carry transition reason from MQTT snapshot to live log

### DIFF
--- a/playground/js/data-source.js
+++ b/playground/js/data-source.js
@@ -204,8 +204,12 @@ export class LiveSource extends DataSource {
       // 2026-04-20: carry transition-cause tag + temps snapshot through
       // to detectLiveTransition() so the System Logs card can show why
       // the controller changed mode and what the sensors read at the
-      // moment of the transition.
+      // moment of the transition. `reason` is the evaluator's decision
+      // code (solar_enter, solar_stall, …); without it, live-detected
+      // transitions show only the bare cause until a reload pulls the
+      // row back from /api/events.
       cause: data.cause || null,
+      reason: data.reason || null,
       temps: data.temps || null,
       // Carries `collectors_drained` / `emergency_heating_active` from
       // the controller snapshot. Consumed by display-update.js so the

--- a/tests/data-source.test.js
+++ b/tests/data-source.test.js
@@ -50,6 +50,26 @@ describe('data-source contract', () => {
     assert.strictEqual(result.controls_enabled, true);
   });
 
+  it('LiveSource carries cause + reason from MQTT snapshot to result', () => {
+    // Regression: the WebSocket → result mapping was dropping `reason`,
+    // so live transitions appeared in System Logs as bare "[automation]"
+    // until a page reload pulled the row back from /api/events with the
+    // reason intact. Both fields originate in the device's
+    // buildSnapshotFromState() and must reach detectLiveTransition().
+    const fs = require('node:fs');
+    const path = require('node:path');
+    const src = fs.readFileSync(
+      path.join(__dirname, '..', 'playground', 'js', 'data-source.js'),
+      'utf8'
+    );
+    const handleStateBody = src.match(/_handleState\(data\) \{([\s\S]*?)\n {2}\}/)[1];
+    assert.match(
+      handleStateBody,
+      /reason: data\.reason \|\| null/,
+      '_handleState must propagate data.reason into the result object'
+    );
+  });
+
   it('LiveSource maps transitioning state correctly', () => {
     const data = {
       mode: 'solar_charging',


### PR DESCRIPTION
## Summary

Live-detected mode transitions in System Logs were rendered as bare `[automation]` with no reason line, while a page reload showed the same rows with the proper `[automation: solar_enter]` / `solar_stall` reason. Root cause: `LiveSource._handleState` (`playground/js/data-source.js`) propagated `cause` from the WebSocket state payload but dropped `reason`, so `detectLiveTransition()` stored `reason: null`. The DB-backed `/api/events` path was unaffected, which is why reload "fixed" it.

- Add `reason: data.reason || null` next to the existing `cause` propagation.
- Regression test in `tests/data-source.test.js` asserts `_handleState` propagates `data.reason` (source-inspection so we don't have to spin up the browser ESM).

## Test plan

- [x] `node --test tests/data-source.test.js` — new test fails before the fix, passes after.
- [x] `npm run test:unit` — 811/811 pass.
- [x] `npm run lint` — 0 errors.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CSbnSKziWiCgtKyvB1A6Nn)_