### PR TITLE
scheduleStep: defer runOpens to fresh Timer.set frame

### DIFF
--- a/shelly/control.js
+++ b/shelly/control.js
@@ -731,7 +731,17 @@ function scheduleStep() {
 
   runValveBatch(closePairs, function(okC) {
     if (!okC) { finalizeTransitionFail(); return; }
-    runOpens();
+    // Defer runOpens to a fresh Timer.set frame. Without this the chain
+    // {Shelly.call cb (last close) → setValve cb → onItem → done(okC) →
+    // cb1 → runOpens → runValveBatch(opens) → runBoundedPool → drain →
+    // dispatch → setValve → Shelly.call} synchronously stacks ~13-14
+    // frames before re-entering Shelly.call, blowing Espruino's tight
+    // stack budget on the Pro 4PM (2026-04-26 crash, ea=31, GH→AD
+    // forced-mode flip — neither the per-item drain re-entry guard
+    // (2026-04-20 #1) nor the skip-empty-batch fix (2026-04-20 #2)
+    // gates this cross-batch sync chain). Same trick scheduleResume()
+    // uses to re-enter on a fresh stack.
+    Timer.set(MIN_RESUME_MS, false, runOpens);
   });
 }
 

--- a/tests/override-forced-mode.test.js
+++ b/tests/override-forced-mode.test.js
@@ -532,4 +532,125 @@ describe('override-forced-mode :: mo.fm drives transitionTo', function() {
     });
   });
 
+  // Regression: 2026-04-26 the live Pro 4PM crashed with the same
+  //   "Too much recursion - the stack is about to overflow"
+  // error as the 2026-04-20 incidents — but the device had ea=31 (all
+  // permission bits set) so the previous setValve sync early-return /
+  // skip-empty-batches fixes did not apply. Trace:
+  //
+  //   at Shelly.call("HTTP.GET", {url: url}, function(res, err) {
+  //   in function "setValve" called from setValve(pair[0], pair[1], inner);
+  //   in function "dispatch"  called from dispatch(it, onItem);
+  //   in function "drain"     called from drain();
+  //   in function "runBoundedPool" called from }, cb);
+  //   in function "runValveBatch"  called fr…   ← truncated (runOpens)
+  //
+  // Root cause: scheduleStep chains `runValveBatch(closes) →
+  // runValveBatch(opens)` through a synchronous callback. When the last
+  // close's HTTP.GET cb fires via Shelly's event loop, the chain
+  //   Shelly.call cb → setValve cb → onItem → done(okC) → cb1 →
+  //   runOpens → runValveBatch → runBoundedPool → drain → dispatch →
+  //   setValve → Shelly.call
+  // accumulates ~13-14 frames before re-entering Shelly.call, blowing
+  // Espruino's tight stack budget on the Pro 4PM. The fix defers
+  // runOpens via Timer.set(MIN_RESUME_MS, ...) so the open batch starts
+  // on a fresh stack, the same trick scheduleResume() already uses.
+  //
+  // We pin the property by simulating Espruino's tighter event loop —
+  // Shelly.call HTTP.GET cbs fire SYNCHRONOUSLY rather than via
+  // setImmediate, so the close→runOpens chain accumulates real stack
+  // frames in Node. Stack depth at the open dispatch then exceeds the
+  // close dispatch by ~5-7 frames; the defer fix makes them match.
+  it('runOpens deferred — open batch starts on a fresh stack, not nested under close cb chain', function(t, done) {
+    // Custom runtime: same as createOrderingRuntime but with synchronous
+    // HTTP.GET callbacks. This is the Espruino model — when the device
+    // fires Shelly.call's cb, it does so on a thin event-loop frame, not
+    // a node-style setImmediate yield. Synchronously chaining the
+    // close-batch done callback into runOpens then accumulates real
+    // stack depth that Node can measure.
+    const rt = createOrderingRuntime();
+    const origShellyCall = rt.globals.Shelly.call;
+    rt.globals.Shelly.call = function(method, params, cb) {
+      // Replay the original Shelly.call's record/dispatch logic for
+      // every method except HTTP.GET; for HTTP.GET, fire cb on the
+      // current stack so close→open chaining is visible.
+      params = params || {};
+      if (method === 'HTTP.GET') {
+        // Mirror the runtime's record() side-effect for the events()
+        // log so order assertions in other tests still work.
+        rt.events().push({ kind: 'http_get', detail: { url: params.url || '' } });
+        if (cb) cb({ code: 200, body: '' }, null);
+        return;
+      }
+      return origShellyCall.call(this, method, params, cb);
+    };
+
+    bootScript(rt, function() {
+      const sysUnix = rt.globals.Shelly.getComponentStatus('sys').unixtime;
+      // Drive into GREENHOUSE_HEATING (vi_top + vo_rad open) so the
+      // subsequent forced AD requires both closes (vi_top, vo_rad) and
+      // opens (vi_coll, vo_tank).
+      rt.setConfig(Object.assign({}, BASE_CONFIG, {
+        mo: { a: true, ex: sysUnix + 3600, fm: 'GH' }
+      }));
+      rt.advance(40000, function() {
+        // Wait minOpenMs (60 s) so close-now is allowed for vi_top/vo_rad.
+        rt.advance(70000, function() {
+          // Now wrap Shelly.call AGAIN to capture stack depth at every
+          // valve HTTP.GET. The wrapper runs inside the synchronous
+          // chain that setValve sets up, so depths reflect the real
+          // script stack.
+          const valveCallDepths = [];
+          const innerCall = rt.globals.Shelly.call;
+          // Lift Node's default 10-frame Error.stack cap so we can see
+          // the full call chain at each Shelly.call entry.
+          const prevLimit = Error.stackTraceLimit;
+          Error.stackTraceLimit = Infinity;
+          rt.globals.Shelly.call = function(method, params, cb) {
+            if (method === 'HTTP.GET' && params && params.url &&
+                params.url.indexOf('/rpc/Switch.Set') >= 0) {
+              valveCallDepths.push({
+                depth: new Error().stack.split('\n').length,
+                on: params.url.indexOf('on=true') >= 0,
+                url: params.url,
+              });
+            }
+            return innerCall.call(this, method, params, cb);
+          };
+
+          rt.clearEvents();
+          // Force-mode flip GH → AD: needs to close vi_top, vo_rad and
+          // open vi_coll, vo_tank (v_air queues for next slot).
+          rt.setConfig(Object.assign({}, BASE_CONFIG, {
+            mo: { a: true, ex: sysUnix + 3600, fm: 'AD' }
+          }));
+          rt.advance(60000, function() {
+            const closes = valveCallDepths.filter(function(c) { return !c.on; });
+            const opens = valveCallDepths.filter(function(c) { return c.on; });
+            assert.ok(closes.length >= 2,
+              'expected ≥2 close HTTP.GETs (vi_top, vo_rad); saw ' + closes.length +
+              ' (urls=' + valveCallDepths.map(function(c) { return c.url; }).join(', ') + ')');
+            assert.ok(opens.length >= 1,
+              'expected ≥1 open HTTP.GET; saw ' + opens.length);
+            // Stack-depth invariant: with HTTP.GET cb firing on the
+            // current stack (the Espruino model), opens must still
+            // dispatch from approximately the same depth as closes
+            // because runOpens is deferred via Timer.set. Without the
+            // defer, open dispatches are ~5-7 frames deeper.
+            const maxClose = Math.max.apply(null, closes.map(function(c) { return c.depth; }));
+            const maxOpen = Math.max.apply(null, opens.map(function(c) { return c.depth; }));
+            Error.stackTraceLimit = prevLimit;
+            assert.ok(
+              maxOpen <= maxClose + 3,
+              'open dispatch must not nest deeper than close dispatch ' +
+              '(close maxDepth=' + maxClose + ', open maxDepth=' + maxOpen + '). ' +
+              'runOpens must defer via Timer.set so the open batch starts on a fresh stack.'
+            );
+            done();
+          });
+        });
+      });
+    });
+  });
+
 });


### PR DESCRIPTION
## Summary

Third "Too much recursion - the stack is about to overflow" crash on the live Pro 4PM (2026-04-26). This time the device had `ea=31` (all permission bits set) so neither prior fix applied:

- 2026-04-20 #1 (e188833): drain() re-entry guard for synchronous setValve early-returns. Required `ea=30`; current device has `ea=31`.
- 2026-04-20 #2 (5759923): skip empty `runValveBatch` + 20 ms `Timer.set` floor. Required both batches empty; current crash hit a non-empty cross-mode flip.

## Root cause

When `scheduleStep` runs both close and open batches sequentially (cross-mode flip like GH→AD), the close batch's `done(okC)` fires from inside the LAST close's HTTP.GET cb chain on Espruino's event loop. `cb1` then calls `runOpens`, which calls `runValveBatch(opens)` — synchronously, on the same stack — descending through `runBoundedPool → drain → dispatch → setValve → Shelly.call`. ~13-14 frames before re-entering `Shelly.call`, past Espruino's tight stack budget on the Pro 4PM.

Crash trace from the device:
```
at Shelly.call("HTTP.GET", {url: url}, function(res, err) {
in function "setValve" called from setValve(pair[0], pair[1], inner);
in function "dispatch"  called from dispatch(it, onItem);
in function "drain"     called from drain();
in function "runBoundedPool" called from }, cb);
in function "runValveBatch"  called fr...   ← truncated (runOpens)
```

## Fix

Defer `runOpens` via `Timer.set(MIN_RESUME_MS, ...)` so the open batch starts on a fresh stack — same trick `scheduleResume()` already uses. 20 ms is well below human perception, comfortably above whatever fast-path Espruino's timer uses internally.

## Live-timer budget

Stays at 2/3 — never holds both timers simultaneously:
- Before fix: peak during transition = `controlLoop` (1) + `transitionTimer` (1) = 2
- With fix: new `Timer.set(MIN_RESUME_MS, runOpens)` is alive for ~20 ms between close completion and open dispatch, then auto-removed (non-repeating). Never overlaps `transitionTimer` because the latter is only set later by `scheduleResume`.

24h platform-limits sim (`tests/shelly-platform-limits.test.js`) confirms `peakTimers <= 3` still passes.

## Regression test

`tests/override-forced-mode.test.js` drives the GH → AD forced-mode flip (closes vi_top, vo_rad; opens vi_coll, vo_tank, v_air) under a runtime variant where Shelly.call HTTP.GET cbs fire **synchronously** (simulates Espruino's event loop, not Node's `setImmediate` yield). Tracks `Error().stack` depth at every `Shelly.call` entry and asserts open dispatches are at most 3 frames deeper than closes.

- Without the fix: opens dispatch at depth 24, closes at 13 (11-frame nesting).
- With the fix: both at 12-14.

## Test plan

- [x] 850 unit tests pass
- [x] `tests/scheduler-stack-fuzz.test.js` (mode-transition matrix) passes
- [x] `tests/override-forced-mode.test.js` (incl. new regression test) passes
- [x] `tests/shelly-platform-limits.test.js` 24h sim passes (timer budget unchanged)
- [x] `npm run lint` — 0 errors
- [x] `node shelly/lint/bin/shelly-lint.js` — no issues
- [x] `npm run check:file-size --strict` — 0 over hard cap
- [ ] CI green


---
_Generated by [Claude Code](https://claude.ai/code/session_01AdPBmsHyGRwr2UYRTWm8nw)_