### PR TITLE
Add controller state snapshot to system logs export

### DIFF
--- a/playground/js/main/display-update.js
+++ b/playground/js/main/display-update.js
@@ -14,7 +14,7 @@
 
 import { store } from '../app-state.js';
 import { tankStoredEnergyKwh } from '../physics.js';
-import { timeSeriesStore, MODE_INFO, running } from './state.js';
+import { timeSeriesStore, MODE_INFO, running, setLastLiveFrame } from './state.js';
 import { detectLiveTransition, renderLogsList } from './logs.js';
 import { drawHistoryGraph, toSchematicState } from './history-graph.js';
 import { appendBalanceLivePoint, getLiveYesterdayHigh } from './balance-card.js';
@@ -442,6 +442,7 @@ export function updateDisplay(state, result) {
   // ── Schematic ──
   lastState = state;
   lastResult = result;
+  setLastLiveFrame(state, result);
   if (schematicHandle) {
     schematicHandle.update(toSchematicState(state, result));
   }

--- a/playground/js/main/logs.js
+++ b/playground/js/main/logs.js
@@ -11,6 +11,8 @@ import {
   formatReasonLabel, formatSensorsLine, escapeHtml, formatTimeOfDay,
 } from './time-format.js';
 import { model, params, MODE_INFO, timeSeriesStore, transitionLog } from './state.js';
+import { getLastFrame } from './display-update.js';
+import { getWatchdogSnapshot } from './watchdog-ui.js';
 
 export { transitionLog };
 
@@ -219,6 +221,15 @@ function buildLogsClipboardText() {
   lines.push('Exported: ' + formatFullTimeHelsinki(Date.now()));
   lines.push('');
 
+  // Controller-state snapshot — captures the evaluator-visible flags
+  // that gate mode transitions but are otherwise invisible from the
+  // sensor table alone (controls_enabled, manual override, collector
+  // drain flag, watchdog cool-offs). Live mode only — the simulator
+  // does not maintain these.
+  if (isLive) {
+    appendControllerState(lines);
+  }
+
   if (isLive) {
     // Live: include 24h sensor readings at 20-min resolution from timeSeriesStore
     lines.push('--- Sensor Readings (24h, 20-min resolution) ---');
@@ -315,6 +326,52 @@ function buildLogsClipboardText() {
   }
 
   return lines.join('\n');
+}
+
+function appendControllerState(lines) {
+  const frame = getLastFrame();
+  const result = (frame && frame.result) || null;
+  const wb = (getWatchdogSnapshot() || {}).wb || {};
+  const nowSec = Math.floor(Date.now() / 1000);
+
+  lines.push('--- Controller State ---');
+  if (!result) {
+    lines.push('(no live snapshot received yet)');
+    lines.push('');
+    return;
+  }
+
+  lines.push('Mode:               ' + (result.mode || 'idle'));
+  lines.push('Controls enabled:   ' + (result.controls_enabled ? 'yes' : 'no'));
+
+  const flags = result.flags || {};
+  lines.push('Collectors drained: ' + (flags.collectors_drained ? 'yes' : 'no'));
+  lines.push('Emergency heating:  ' + (flags.emergency_heating_active ? 'on' : 'off'));
+
+  const mo = result.manual_override;
+  if (mo && mo.active) {
+    const exp = mo.expiresAt ? formatFullTimeHelsinki(mo.expiresAt * 1000) : '—';
+    lines.push('Manual override:    ' + (mo.forcedMode || 'active') + ' (until ' + exp + ')');
+  } else {
+    lines.push('Manual override:    off');
+  }
+
+  const PERMANENT = 9999999999;
+  const banned = [];
+  Object.keys(wb).forEach(code => {
+    const until = wb[code];
+    if (typeof until !== 'number' || until <= nowSec) return;
+    if (until === PERMANENT) {
+      banned.push(code + '=disabled');
+    } else {
+      const rem = until - nowSec;
+      const h = Math.floor(rem / 3600);
+      const m = Math.floor((rem % 3600) / 60);
+      banned.push(code + '=' + h + 'h' + (m < 10 ? '0' : '') + m + 'm');
+    }
+  });
+  lines.push('Mode bans (wb):     ' + (banned.length ? banned.join(' ') : 'none'));
+  lines.push('');
 }
 
 // Format a temperature value as a right-aligned string for the clipboard table.

--- a/playground/js/main/logs.js
+++ b/playground/js/main/logs.js
@@ -10,8 +10,7 @@ import {
   formatClockTime, formatFullTimeHelsinki, formatCauseLabel,
   formatReasonLabel, formatSensorsLine, escapeHtml, formatTimeOfDay,
 } from './time-format.js';
-import { model, params, MODE_INFO, timeSeriesStore, transitionLog } from './state.js';
-import { getLastFrame } from './display-update.js';
+import { model, params, MODE_INFO, timeSeriesStore, transitionLog, lastLiveFrame } from './state.js';
 import { getWatchdogSnapshot } from './watchdog-ui.js';
 
 export { transitionLog };
@@ -328,49 +327,95 @@ function buildLogsClipboardText() {
   return lines.join('\n');
 }
 
+// Mirrors the deviceConfig actuator bitmask (server/lib/device-config.js
+// — `ea` field). Order is the bit order, not alphabetical.
+const EA_BITS = [
+  { bit: 1,  name: 'valves' },
+  { bit: 2,  name: 'pump' },
+  { bit: 4,  name: 'fan' },
+  { bit: 8,  name: 'space_heater' },
+  { bit: 16, name: 'immersion_heater' },
+];
+
+function formatEnabledActuators(ea) {
+  if (typeof ea !== 'number') return '(unknown)';
+  const on = EA_BITS.filter(b => (ea & b.bit) !== 0).map(b => b.name);
+  return (on.length ? on.join(', ') : 'none') + ' (ea=' + ea + ')';
+}
+
+function formatBanList(wb, nowSec) {
+  const PERMANENT = 9999999999;
+  const out = [];
+  Object.keys(wb || {}).forEach(code => {
+    const until = wb[code];
+    if (typeof until !== 'number' || until <= nowSec) return;
+    if (until === PERMANENT) {
+      out.push(code + '=disabled');
+    } else {
+      const rem = until - nowSec;
+      const h = Math.floor(rem / 3600);
+      const m = Math.floor((rem % 3600) / 60);
+      out.push(code + '=' + h + 'h' + (m < 10 ? '0' : '') + m + 'm');
+    }
+  });
+  return out.length ? out.join(' ') : 'none';
+}
+
+function formatWatchdogEnabled(we) {
+  const on = Object.keys(we || {}).filter(id => we[id]);
+  return on.length ? on.join(', ') : 'none';
+}
+
+function formatWatchdogSnoozed(wz, nowSec) {
+  const out = [];
+  Object.keys(wz || {}).forEach(id => {
+    const until = wz[id];
+    if (typeof until !== 'number' || until <= nowSec) return;
+    const rem = until - nowSec;
+    const m = Math.floor(rem / 60);
+    out.push(id + '=' + m + 'm');
+  });
+  return out.length ? out.join(' ') : 'none';
+}
+
 function appendControllerState(lines) {
-  const frame = getLastFrame();
-  const result = (frame && frame.result) || null;
-  const wb = (getWatchdogSnapshot() || {}).wb || {};
+  const result = (lastLiveFrame && lastLiveFrame.result) || null;
+  const snap = getWatchdogSnapshot() || {};
   const nowSec = Math.floor(Date.now() / 1000);
 
   lines.push('--- Controller State ---');
-  if (!result) {
+  if (!result && !snap.v) {
     lines.push('(no live snapshot received yet)');
     lines.push('');
     return;
   }
 
-  lines.push('Mode:               ' + (result.mode || 'idle'));
-  lines.push('Controls enabled:   ' + (result.controls_enabled ? 'yes' : 'no'));
-
-  const flags = result.flags || {};
+  // Live state (sensors / mode / flags) from the WS state push.
+  const flags = (result && result.flags) || {};
+  lines.push('Mode:               ' + ((result && result.mode) || 'idle'));
   lines.push('Collectors drained: ' + (flags.collectors_drained ? 'yes' : 'no'));
   lines.push('Emergency heating:  ' + (flags.emergency_heating_active ? 'on' : 'off'));
 
-  const mo = result.manual_override;
-  if (mo && mo.active) {
-    const exp = mo.expiresAt ? formatFullTimeHelsinki(mo.expiresAt * 1000) : '—';
-    lines.push('Manual override:    ' + (mo.forcedMode || 'active') + ' (until ' + exp + ')');
+  // Device config mirror (ce/ea/mo/we/wz/wb/v) from the watchdog-state
+  // broadcast. These are the evaluator's gating fields — invisible from
+  // the temperature table, but each one can independently keep the
+  // controller from picking a mode the temperatures would otherwise
+  // call for.
+  lines.push('Controls enabled:   ' + (snap.ce ? 'yes' : 'no'));
+  lines.push('Enabled actuators:  ' + formatEnabledActuators(snap.ea));
+
+  const mo = snap.mo;
+  if (mo && mo.a) {
+    const exp = mo.ex ? formatFullTimeHelsinki(mo.ex * 1000) : '—';
+    lines.push('Manual override:    ' + (mo.fm || 'active') + ' (until ' + exp + ')');
   } else {
     lines.push('Manual override:    off');
   }
 
-  const PERMANENT = 9999999999;
-  const banned = [];
-  Object.keys(wb).forEach(code => {
-    const until = wb[code];
-    if (typeof until !== 'number' || until <= nowSec) return;
-    if (until === PERMANENT) {
-      banned.push(code + '=disabled');
-    } else {
-      const rem = until - nowSec;
-      const h = Math.floor(rem / 3600);
-      const m = Math.floor((rem % 3600) / 60);
-      banned.push(code + '=' + h + 'h' + (m < 10 ? '0' : '') + m + 'm');
-    }
-  });
-  lines.push('Mode bans (wb):     ' + (banned.length ? banned.join(' ') : 'none'));
+  lines.push('Watchdogs enabled:  ' + formatWatchdogEnabled(snap.we));
+  lines.push('Watchdogs snoozed:  ' + formatWatchdogSnoozed(snap.wz, nowSec));
+  lines.push('Mode bans (wb):     ' + formatBanList(snap.wb, nowSec));
+  lines.push('Config version:     ' + (typeof snap.v === 'number' ? snap.v : '(unknown)'));
   lines.push('');
 }
 

--- a/playground/js/main/state.js
+++ b/playground/js/main/state.js
@@ -82,6 +82,16 @@ export const timeSeriesStore = {
 // both reach it through state.js without a cycle.
 export const transitionLog = [];
 
+// Last frame rendered by display-update.js. Stashed here (rather than
+// kept private in display-update) so logs.js can read it without
+// re-importing display-update — that import would close the cycle
+// display-update → logs → display-update, which the ESM-graph guard
+// in tests/playground-esm-imports.test.js rejects.
+export let lastLiveFrame = { state: null, result: null };
+export function setLastLiveFrame(state, result) {
+  lastLiveFrame = { state, result };
+}
+
 // Static per-mode UI metadata (label, description, icon). No
 // writes.
 export const MODE_INFO = {

--- a/server/lib/anomaly-manager.js
+++ b/server/lib/anomaly-manager.js
@@ -16,7 +16,14 @@ const {
 // Module-scoped state — set by init()
 let _deps = null;         // { deviceConfig, mqttBridge, push, wsBroadcast, history, log }
 let _pending = null;      // { id, firedAt, mode, triggerReason, dbEventId } | null
-let _lastSnapshot = {};   // { we, wz, wb } cached from latest device config
+// Mirror of deviceConfig fields that the playground needs to render
+// the watchdog UI and the System Logs export. Broadcast over WS as
+// `watchdog-state.snapshot`. Updated whenever a config push completes.
+// Keep this in sync with DEFAULT_CONFIG in server/lib/device-config.js
+// — every field the evaluator reads on the device should be visible
+// here, otherwise debugging "why did the controller pick mode X?" has
+// to fall back to direct device inspection.
+let _lastSnapshot = {};
 
 function init(deps) {
   _deps = deps;
@@ -93,9 +100,13 @@ function getPending() {
 
 function updateSnapshot(cfg) {
   _lastSnapshot = {
+    ce: !!cfg.ce,
+    ea: typeof cfg.ea === 'number' ? cfg.ea : 0,
+    mo: cfg.mo || null,
     we: cfg.we || {},
     wz: cfg.wz || {},
-    wb: cfg.wb || {}
+    wb: cfg.wb || {},
+    v: typeof cfg.v === 'number' ? cfg.v : null,
   };
 }
 

--- a/tests/anomaly-manager.test.js
+++ b/tests/anomaly-manager.test.js
@@ -313,4 +313,28 @@ describe('anomaly-manager setEnabled / getState / getHistory', () => {
     assert.strictEqual(state.recent.length, 1);
     assert.ok(Array.isArray(state.watchdogs));
   });
+
+  it('updateSnapshot mirrors the full deviceConfig (ce, ea, mo, v) so log export can render it', async () => {
+    const mocks = makeMocks();
+    mocks.history.list = () => Promise.resolve([]);
+    anomalyManager.init(mocks);
+    anomalyManager.updateSnapshot({
+      ce: true,
+      ea: 31,
+      mo: { a: true, ex: 1840000000, fm: 'I' },
+      we: { ggr: 1, sng: 1, scs: 1 },
+      wz: { ggr: 1840003600 },
+      wb: { GH: 1840014400 },
+      v: 42,
+    });
+
+    const state = await anomalyManager.getState();
+    assert.strictEqual(state.snapshot.ce, true);
+    assert.strictEqual(state.snapshot.ea, 31);
+    assert.deepStrictEqual(state.snapshot.mo, { a: true, ex: 1840000000, fm: 'I' });
+    assert.strictEqual(state.snapshot.v, 42);
+    assert.deepStrictEqual(state.snapshot.we, { ggr: 1, sng: 1, scs: 1 });
+    assert.deepStrictEqual(state.snapshot.wz, { ggr: 1840003600 });
+    assert.deepStrictEqual(state.snapshot.wb, { GH: 1840014400 });
+  });
 });

--- a/tests/frontend/copy-logs.spec.js
+++ b/tests/frontend/copy-logs.spec.js
@@ -230,6 +230,23 @@ async function mockHistoryApi(page, points, events) {
   }));
 }
 
+async function mockWatchdogStateApi(page, snapshot) {
+  await page.route('**/api/watchdog/state', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({
+      pending: null,
+      watchdogs: [
+        { id: 'sng', label: 'Stalled — no gain' },
+        { id: 'scs', label: 'Stalled — collector cooling' },
+        { id: 'ggr', label: 'Greenhouse not heating' },
+      ],
+      snapshot: snapshot || { ce: true, ea: 31, mo: null, we: {}, wz: {}, wb: {}, v: 1 },
+      recent: [],
+    }),
+  }));
+}
+
 test.describe('Copy System Logs — live mode', () => {
   test('clipboard text contains live mode header and sensor readings', async ({ page }) => {
     const now = Date.now();
@@ -289,6 +306,82 @@ test.describe('Copy System Logs — live mode', () => {
     const text = await getClipboardText(page);
     expect(text).not.toContain('(no history data available)');
     expect(text).toContain('idle');
+  });
+
+  test('controller state section reflects deviceConfig mirror (ce/ea/mo/wb/we)', async ({ page }) => {
+    // Reproduces the diagnostic case that motivated the section: idle
+    // mode with collectors flagged as drained and a GH watchdog cool-off
+    // ban active. Without this section, the user has to cross-reference
+    // the watchdog UI to see why mode transitions are gated.
+    const nowSec = Math.floor(Date.now() / 1000);
+    const banUntil = nowSec + 4 * 3600; // 4 h GH ban
+
+    await installMockWs(page, {
+      mode: 'idle',
+      flags: { collectors_drained: true, emergency_heating_active: false },
+    });
+    await mockHistoryApi(page);
+    await mockEventsApi(page, []);
+    await mockWatchdogStateApi(page, {
+      ce: true,
+      ea: 31,
+      mo: null,
+      we: { sng: 1, scs: 1, ggr: 1 },
+      wz: {},
+      wb: { GH: banUntil },
+      v: 42,
+    });
+
+    await page.goto('/playground/', { waitUntil: 'domcontentloaded' });
+    await expect(page.locator('#connection-dot')).toHaveClass(/connected/, { timeout: 5000 });
+    await waitForTestHook(page);
+
+    const text = await getClipboardText(page);
+
+    expect(text).toContain('--- Controller State ---');
+    expect(text).toContain('Mode:               idle');
+    expect(text).toContain('Collectors drained: yes');
+    expect(text).toContain('Emergency heating:  off');
+    expect(text).toContain('Controls enabled:   yes');
+    expect(text).toContain('Enabled actuators:  valves, pump, fan, space_heater, immersion_heater (ea=31)');
+    expect(text).toContain('Manual override:    off');
+    expect(text).toContain('Watchdogs enabled:  sng, scs, ggr');
+    expect(text).toContain('Watchdogs snoozed:  none');
+    expect(text).toMatch(/Mode bans \(wb\): {5}GH=[34]h\d{2}m/);
+    expect(text).toContain('Config version:     42');
+  });
+
+  test('controller state shows manual-override forced mode + permanent SC ban', async ({ page }) => {
+    const nowSec = Math.floor(Date.now() / 1000);
+
+    await installMockWs(page, {
+      mode: 'idle',
+      flags: { collectors_drained: false, emergency_heating_active: false },
+    });
+    await mockHistoryApi(page);
+    await mockEventsApi(page, []);
+    await mockWatchdogStateApi(page, {
+      ce: false,
+      ea: 0,
+      mo: { a: true, ex: nowSec + 1800, fm: 'I' },
+      we: { ggr: 1 },
+      wz: { ggr: nowSec + 600 },
+      wb: { SC: 9999999999 },
+      v: 7,
+    });
+
+    await page.goto('/playground/', { waitUntil: 'domcontentloaded' });
+    await expect(page.locator('#connection-dot')).toHaveClass(/connected/, { timeout: 5000 });
+    await waitForTestHook(page);
+
+    const text = await getClipboardText(page);
+
+    expect(text).toContain('Controls enabled:   no');
+    expect(text).toContain('Enabled actuators:  none (ea=0)');
+    expect(text).toMatch(/Manual override: {4}I \(until /);
+    expect(text).toContain('Watchdogs enabled:  ggr');
+    expect(text).toMatch(/Watchdogs snoozed: {2}ggr=\d+m/);
+    expect(text).toContain('Mode bans (wb):     SC=disabled');
   });
 });
 


### PR DESCRIPTION
## Summary
Adds a new "Controller State" section to the system logs clipboard export that displays device configuration and evaluator-visible flags that gate mode transitions. This helps users diagnose why the controller isn't picking an expected mode without having to cross-reference the watchdog UI.

## Key Changes

- **logs.js**: Added `appendControllerState()` function that formats and exports controller state including:
  - Mode and flags (collectors_drained, emergency_heating_active)
  - Device config mirror fields: controls_enabled, enabled_actuators, manual_override, watchdog status, mode bans, config version
  - Helper formatters for enabled actuators bitmask, ban list with remaining time, and watchdog state
  - Integrated into `buildLogsClipboardText()` for live mode only

- **state.js**: Exported `lastLiveFrame` and added `setLastLiveFrame()` setter to allow logs.js to access the latest rendered frame without creating a circular import dependency

- **display-update.js**: Updated to call `setLastLiveFrame()` when rendering live updates, capturing the current state and result

- **anomaly-manager.js**: Enhanced `updateSnapshot()` to mirror full deviceConfig fields (ce, ea, mo, v) in addition to existing watchdog state (we, wz, wb), making all evaluator-visible gating fields available for export

- **Tests**: Added comprehensive test coverage in `copy-logs.spec.js` for:
  - Controller state section with device config mirror fields
  - Manual override and permanent bans formatting
  - Added `mockWatchdogStateApi()` helper
  - Added unit test in `anomaly-manager.test.js` verifying snapshot mirroring

## Implementation Details

- The snapshot mirrors the exact fields the evaluator reads from deviceConfig, ensuring complete visibility into mode transition gating logic
- Permanent bans are displayed as "disabled", temporary bans show remaining time in hours and minutes
- Manual override displays the forced mode and expiration time
- Watchdog snoozed state shows remaining snooze duration in minutes
- Live mode only—simulator doesn't maintain these fields

https://claude.ai/code/session_01YP3StmkbK6FmTxECfRTv59