### PR TITLE
Add 3-minute pump hold during refill to ensure collectors fill

### DIFF
--- a/playground/js/main/drainage-control.js
+++ b/playground/js/main/drainage-control.js
@@ -27,6 +27,7 @@ import { store } from '../app-state.js';
 let _getLiveSource = () => null;
 let pendingOp = null;        // null | 'drain' | 'refill'
 let pendingStartedAt = 0;    // ms timestamp — for ack-timeout detection
+let refillSCStartedAt = 0;   // ms — when SOLAR_CHARGING was first observed for our refill op
 let lastResult = null;       // most recent state frame (for button-disable logic)
 let ackTimer = null;
 let msgFadeTimer = null;
@@ -34,6 +35,11 @@ let msgFadeTimer = null;
 const DRAIN_TTL_S = 600;      // 10 min — drain takes ~5 min plus exit handling
 const REFILL_TTL_S = 1800;    // 30 min — leave room for fill + a charging window
 const ACK_TIMEOUT_MS = 5000;
+// Minimum pump runtime once SOLAR_CHARGING starts during a manual refill.
+// drained=false flips early (as soon as flow begins) but the collectors are
+// not actually full yet — hold the override so the pump keeps pushing water
+// up the loop long enough to displace trapped air.
+const MIN_REFILL_PUMP_MS = 3 * 60 * 1000;
 
 export function initDrainageControl({ getLiveSource } = {}) {
   if (typeof getLiveSource === 'function') _getLiveSource = getLiveSource;
@@ -120,6 +126,7 @@ function abortPending() {
   const wasOp = pendingOp;
   pendingOp = null;
   pendingStartedAt = 0;
+  refillSCStartedAt = 0;
   hideProgress();
   liveSource.sendCommand({ type: 'override-exit' });
   showMsg(wasOp === 'drain' ? 'Drain aborted.' : 'Refill aborted.', 'var(--on-surface-variant)');
@@ -166,7 +173,12 @@ export function updateDrainageControl(result) {
     return;
   }
   if (pendingOp === 'refill' && overrideActive && overrideFm === 'SC'
-      && !drained && mode === 'solar_charging') {
+      && mode === 'solar_charging' && !refillSCStartedAt) {
+    refillSCStartedAt = Date.now();
+  }
+  if (pendingOp === 'refill' && overrideActive && overrideFm === 'SC'
+      && !drained && mode === 'solar_charging'
+      && refillSCStartedAt && Date.now() - refillSCStartedAt >= MIN_REFILL_PUMP_MS) {
     completeOp('refill', 'Refill complete — automation resumed.');
     return;
   }
@@ -196,6 +208,7 @@ export function updateDrainageControl(result) {
     // tab, or controller dropped offline) — clear our pending flag.
     pendingOp = null;
     pendingStartedAt = 0;
+    refillSCStartedAt = 0;
     hideProgress();
     setActionsDisabled(false);
     showMsg('Override ended before completion.', 'var(--on-surface-variant)');
@@ -218,6 +231,7 @@ export function updateDrainageControl(result) {
 function completeOp(op, msg) {
   pendingOp = null;
   pendingStartedAt = 0;
+  refillSCStartedAt = 0;
   if (ackTimer) { clearTimeout(ackTimer); ackTimer = null; }
   hideProgress();
   setActionsDisabled(false);

--- a/tests/frontend/drainage-control.spec.js
+++ b/tests/frontend/drainage-control.spec.js
@@ -217,7 +217,8 @@ test.describe('drainage control card — live state interaction', () => {
     await expect(page.locator('#drainage-progress')).toBeHidden();
   });
 
-  test('refill auto-exits override once controller reports !drained && solar_charging', async ({ page }) => {
+  test('refill holds pump for 3 minutes before auto-exiting, even if controller reports !drained earlier', async ({ page }) => {
+    await page.clock.install();
     // 1. Initial drained state
     await pushState(page, buildFrame({ flags: { collectors_drained: true, emergency_heating_active: false } }));
     await expect(page.locator('#drainage-refill-btn')).toBeEnabled({ timeout: 3000 });
@@ -234,17 +235,32 @@ test.describe('drainage control card — live state interaction', () => {
     }));
     await expect(page.locator('#drainage-progress-title')).toHaveText('Refilling collectors…', { timeout: 3000 });
 
-    // 4. Controller clears the drained flag once the SC transition completes
+    // 4. Controller clears the drained flag a few seconds in — pump must keep
+    //    running for the full 3-minute hold so collectors actually fill.
+    await page.clock.fastForward(10_000);
     await pushState(page, buildFrame({
       mode: 'solar_charging',
       flags: { collectors_drained: false, emergency_heating_active: false },
       manual_override: { active: true, expiresAt: exp, forcedMode: 'SC' },
     }));
 
-    // 5. Card should auto-send override-exit
+    // 5. Verify NO auto-exit yet — we are still inside the 3-minute hold.
+    await page.waitForTimeout(200);
+    const sent = await page.evaluate(() => /** @type {any} */ (window).__sentCommands);
+    expect(sent.some((c) => c.type === 'override-exit')).toBe(false);
+
+    // 6. Fast-forward past the 3-minute minimum and push another frame.
+    await page.clock.fastForward(3 * 60_000);
+    await pushState(page, buildFrame({
+      mode: 'solar_charging',
+      flags: { collectors_drained: false, emergency_heating_active: false },
+      manual_override: { active: true, expiresAt: exp, forcedMode: 'SC' },
+    }));
+
+    // 7. Now the card should auto-send override-exit.
     await expect.poll(async () => {
-      const sent = await page.evaluate(() => /** @type {any} */ (window).__sentCommands);
-      return sent.some((c) => c.type === 'override-exit');
+      const cmds = await page.evaluate(() => /** @type {any} */ (window).__sentCommands);
+      return cmds.some((c) => c.type === 'override-exit');
     }, { timeout: 3000 }).toBe(true);
   });
 


### PR DESCRIPTION
## Summary
Modified the drainage control refill logic to hold the pump running for a minimum of 3 minutes after entering solar_charging mode, even if the controller reports the drained flag as false earlier. This ensures collectors actually fill completely by displacing trapped air before the override exits.

## Key Changes
- Added `refillSCStartedAt` timestamp tracking to record when SOLAR_CHARGING mode is first observed during a refill operation
- Introduced `MIN_REFILL_PUMP_MS` constant (3 minutes) to define the minimum pump runtime requirement
- Modified the refill completion logic to wait for both conditions:
  1. Controller reports `!drained` and `mode === 'solar_charging'`
  2. At least 3 minutes have elapsed since SOLAR_CHARGING was first observed
- Reset `refillSCStartedAt` when aborting, completing, or losing the override to maintain clean state
- Updated test to verify the 3-minute hold behavior with clock manipulation

## Implementation Details
The fix addresses a timing issue where the `drained` flag clears as soon as water flow begins (within seconds), but the collectors aren't actually full yet. By enforcing a minimum pump runtime, we ensure water is pushed up the loop long enough to displace trapped air and fully fill the collectors before exiting the manual override.

https://claude.ai/code/session_018K9fwGjuS3JrYBEV3aubHe