### PR TITLE
Audit-log every wb/mo change + mirror device auto-shutdown bans

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,10 @@ Solar thermal greenhouse heating system for Southwest Finland. Shelly-controlled
 
 **Before finishing any work, review this file and update it if your changes affect project structure, conventions, commands, or workflows described here.** Stale guidance is worse than none. Add new rules here; don't re-describe files that are self-explanatory from their path and content.
 
+## Communicating with the user
+
+This codebase is dense with short codes — `wb`, `mo`, `ce`, `ea`, `we`, `wz` (deviceConfig fields), `I` / `SC` / `GH` / `AD` / `EH` (mode short codes), `sng` / `scs` / `ggr` (watchdog ids). The compact form exists because Shelly KVS values are capped at 256 bytes, so on-device JSON has to fit. **In user-facing prose, always lead with the full name** (e.g. "Solar Charging mode", "manual override", "watchdog auto-shutdown ban") and parenthesise the short code only when it adds wiring-level insight (e.g. "the Greenhouse Heating ban (`wb["GH"]`) is set until 12:32"). Bare `wb`, `mo`, `EH`, `ggr`, etc. with no expansion will lose the user — assume the user is reading the *operational* layer, not the on-device JSON. The mapping table is in `server/lib/device-config.js` (top of file) and `shelly/watchdogs-meta.js`; in code (comments, tests, identifiers) the short codes stay.
+
 ## Repository Layout
 
 - `system.yaml` — authoritative hardware spec

--- a/playground/js/main/logs.js
+++ b/playground/js/main/logs.js
@@ -9,6 +9,7 @@ import { store } from '../app-state.js';
 import {
   formatClockTime, formatFullTimeHelsinki, formatCauseLabel,
   formatReasonLabel, formatSensorsLine, escapeHtml, formatTimeOfDay,
+  formatConfigEntry,
 } from './time-format.js';
 import { model, params, MODE_INFO, timeSeriesStore, transitionLog, lastLiveFrame } from './state.js';
 import { getWatchdogSnapshot } from './watchdog-ui.js';
@@ -16,65 +17,119 @@ import { getWatchdogSnapshot } from './watchdog-ui.js';
 export { transitionLog };
 
 const EVENTS_PAGE_SIZE = 10;
-let eventsCursor = null;   // ms timestamp of oldest entry currently shown
-let eventsHasMore = false; // true if the DB has older entries to load
-let eventsLoading = false; // in-flight guard
+// Two parallel cursors so config and mode events scroll independently.
+// The transitionLog merges them by ts; "Load more" fetches another page
+// of each, taking only the half that still has older rows on the
+// server. Without separate cursors, a long quiet stretch on one feed
+// would prematurely block scrolling for the other.
+let modeCursor = null;
+let modeHasMore = false;
+let configCursor = null;
+let configHasMore = false;
+let eventsLoading = false; // in-flight guard for either side
 let lastLiveMode = null;   // last observed live mode (change detector)
 
 // Drop pagination + mode-change state. Called when the mode-switch UI
 // clears the live display; fetchLiveEvents(null) will repopulate.
 export function resetEventsState() {
-  eventsCursor = null;
-  eventsHasMore = false;
+  modeCursor = null;
+  modeHasMore = false;
+  configCursor = null;
+  configHasMore = false;
   lastLiveMode = null;
 }
 
-// Fetch the next page of mode-transition events from the DB. When `before`
-// is null this is a fresh load (replaces the log); otherwise appended.
-export function fetchLiveEvents(before) {
+function fetchEventPage(type, before) {
+  let url = '/api/events?type=' + type + '&limit=' + EVENTS_PAGE_SIZE;
+  if (before !== null && before !== undefined) url += '&before=' + before;
+  return fetch(url)
+    .then(r => r.ok ? r.json() : { events: [], hasMore: false })
+    .catch(() => ({ events: [], hasMore: false }));
+}
+
+function modeRowToLogEntry(e) {
+  return {
+    kind: 'live',
+    eventType: 'mode',
+    ts: e.ts,
+    mode: e.to,
+    from: e.from,
+    text: formatLiveTransitionText(e.from, e.to),
+    // cause/sensors may be null for pre-2026-04-20 rows or for
+    // firmware that doesn't yet carry the transition cause.
+    // reason (added 2026-04-21) is the evaluator's decision code;
+    // null when the transition did not come from evaluate().
+    cause: e.cause || null,
+    reason: e.reason || null,
+    sensors: e.sensors || null,
+  };
+}
+
+function configRowToLogEntry(e) {
+  return {
+    kind: 'live',
+    eventType: 'config',
+    ts: e.ts,
+    configKind: e.kind,    // 'wb' | 'mo'
+    configKey: e.key,      // mode short code for wb; null for mo
+    from: e.from,
+    to: e.to,
+    source: e.source,      // 'api' | 'ws_override' | 'watchdog_auto'
+    actor: e.actor,
+  };
+}
+
+// Fetch the next page of events. `reset` true clears the log and
+// fetches both feeds afresh; otherwise advances each feed's cursor
+// independently and appends to the existing list. Sorting by ts DESC
+// happens once after both fetches return.
+export function fetchLiveEvents(reset) {
   if (store.get('phase') !== 'live') return;
   if (eventsLoading) return;
   eventsLoading = true;
 
-  let url = '/api/events?type=mode&limit=' + EVENTS_PAGE_SIZE;
-  if (before !== null && before !== undefined) url += '&before=' + before;
+  const isReset = reset === null || reset === undefined || reset === true;
+  const modeBefore = isReset ? null : (modeHasMore ? modeCursor : null);
+  const configBefore = isReset ? null : (configHasMore ? configCursor : null);
 
-  fetch(url)
-    .then(r => r.json())
-    .then(data => {
+  // Skip a side that has no more rows AND it isn't a reset, to avoid
+  // re-fetching identical pages.
+  const modePromise = (isReset || modeHasMore)
+    ? fetchEventPage('mode', modeBefore)
+    : Promise.resolve({ events: [], hasMore: false, _skipped: true });
+  const configPromise = (isReset || configHasMore)
+    ? fetchEventPage('config', configBefore)
+    : Promise.resolve({ events: [], hasMore: false, _skipped: true });
+
+  Promise.all([modePromise, configPromise])
+    .then(function ([modeData, configData]) {
       // Only apply to the current phase — the user may have switched back
-      // to simulation while the request was in flight.
+      // to simulation while the requests were in flight.
       if (store.get('phase') !== 'live') return;
-      const events = (data && Array.isArray(data.events)) ? data.events : [];
-      if (before === null) {
-        // First load: replace everything
-        transitionLog.length = 0;
+      const modeEvents = (modeData && Array.isArray(modeData.events)) ? modeData.events : [];
+      const configEvents = (configData && Array.isArray(configData.events)) ? configData.events : [];
+
+      if (isReset) transitionLog.length = 0;
+
+      for (let i = 0; i < modeEvents.length; i++) {
+        transitionLog.push(modeRowToLogEntry(modeEvents[i]));
       }
-      for (let i = 0; i < events.length; i++) {
-        const e = events[i];
-        transitionLog.push({
-          kind: 'live',
-          ts: e.ts,
-          mode: e.to,
-          from: e.from,
-          text: formatLiveTransitionText(e.from, e.to),
-          // cause/sensors may be null for pre-2026-04-20 rows or for
-          // firmware that doesn't yet carry the transition cause.
-          // reason (added 2026-04-21) is the evaluator's decision code;
-          // null when the transition did not come from evaluate().
-          cause: e.cause || null,
-          reason: e.reason || null,
-          sensors: e.sensors || null,
-        });
+      for (let i = 0; i < configEvents.length; i++) {
+        transitionLog.push(configRowToLogEntry(configEvents[i]));
       }
-      if (events.length > 0) {
-        eventsCursor = events[events.length - 1].ts;
+      // Re-sort the merged list newest-first. Stable enough for our N (~20).
+      transitionLog.sort((a, b) => (b.ts || 0) - (a.ts || 0));
+
+      if (!modeData._skipped) {
+        if (modeEvents.length > 0) modeCursor = modeEvents[modeEvents.length - 1].ts;
+        modeHasMore = !!(modeData && modeData.hasMore);
       }
-      eventsHasMore = !!(data && data.hasMore);
+      if (!configData._skipped) {
+        if (configEvents.length > 0) configCursor = configEvents[configEvents.length - 1].ts;
+        configHasMore = !!(configData && configData.hasMore);
+      }
+
       renderLogsList();
-    })
-    .catch(() => {
-      // Silent fail — leave whatever is already rendered
     })
     .then(() => { eventsLoading = false; });
 }
@@ -83,6 +138,21 @@ function formatLiveTransitionText(from, to) {
   const fromLabel = (from && MODE_INFO[from]) ? MODE_INFO[from].label : (from || '—');
   const toLabel = (to && MODE_INFO[to]) ? MODE_INFO[to].label : (to || '—');
   return fromLabel + ' → ' + toLabel;
+}
+
+function renderConfigEntry(t, timeLabel) {
+  const fmt = formatConfigEntry(t);
+  // Use a neutral muted dot for config edits — they aren't mode
+  // transitions, so the green/orange/red mode-color palette would be
+  // misleading.
+  return '<div class="log-item">' +
+    '<div class="log-dot log-dot-muted"></div>' +
+    '<div class="log-content">' +
+      '<div class="log-title">' + escapeHtml(fmt.title) + '</div>' +
+      '<div class="log-desc">' + escapeHtml(fmt.desc) + '</div>' +
+    '</div>' +
+    '<div class="log-time">' + timeLabel + '</div>' +
+  '</div>';
 }
 
 // Detect client-side mode changes from incoming live state frames and
@@ -99,6 +169,7 @@ export function detectLiveTransition(result) {
   if (lastLiveMode === mode) return;
   transitionLog.unshift({
     kind: 'live',
+    eventType: 'mode',
     ts: Date.now(),
     mode,
     from: lastLiveMode,
@@ -138,11 +209,17 @@ export function renderLogsList() {
   let html = '';
   for (let i = 0; i < visible.length; i++) {
     const t = visible[i];
+    const timeLabel = t.kind === 'live' ? formatClockTime(t.ts) : formatTimeOfDay(t.time);
+
+    if (t.eventType === 'config') {
+      html += renderConfigEntry(t, timeLabel);
+      continue;
+    }
+
     const mi = MODE_INFO[t.mode] || MODE_INFO.idle;
     const dotClass = t.mode === 'solar_charging' || t.mode === 'active_drain' ? 'log-dot-charging'
       : t.mode === 'greenhouse_heating' ? 'log-dot-heating'
       : t.mode === 'emergency_heating' ? 'log-dot-emergency' : 'log-dot-muted';
-    const timeLabel = t.kind === 'live' ? formatClockTime(t.ts) : formatTimeOfDay(t.time);
     const causeChip = t.cause ? ' <span class="log-cause">' + escapeHtml(formatCauseLabel(t.cause)) + '</span>' : '';
     // reason sits on its own line so operators can skim the cause chip
     // row and dive into the decision code only when needed.
@@ -162,7 +239,7 @@ export function renderLogsList() {
     '</div>';
   }
 
-  if (isLive && eventsHasMore) {
+  if (isLive && (modeHasMore || configHasMore)) {
     html += '<div class="log-loading" data-log-loading="true" style="color:var(--on-surface-variant);font-size:12px;text-align:center;padding:8px 0;">' +
       (eventsLoading ? 'Loading older transitions…' : 'Scroll to load older transitions') +
     '</div>';
@@ -179,11 +256,12 @@ export function setupLogsScrollLoader() {
   container._scrollHandlerAttached = true;
   container.addEventListener('scroll', function () {
     if (store.get('phase') !== 'live') return;
-    if (!eventsHasMore || eventsLoading || eventsCursor === null) return;
+    if (eventsLoading) return;
+    if (!modeHasMore && !configHasMore) return;
     // Trigger when the scroll reaches within 40px of the bottom
     const remaining = container.scrollHeight - container.scrollTop - container.clientHeight;
     if (remaining < 40) {
-      fetchLiveEvents(eventsCursor);
+      fetchLiveEvents(false);
     }
   });
 }

--- a/playground/js/main/time-format.js
+++ b/playground/js/main/time-format.js
@@ -95,6 +95,78 @@ export function formatReasonLabel(r) {
   return REASON_LABELS[r] || r;
 }
 
+// Mode short codes (matching `wb` keys / `mo.fm` values) → human label.
+const MODE_CODE_LABELS = {
+  I: 'Idle',
+  SC: 'Solar Charging',
+  GH: 'Greenhouse Heating',
+  AD: 'Active Drain',
+  EH: 'Emergency Heating',
+};
+
+// Source attribution for config_events. Combined with actor for the
+// per-row description in the System Logs view.
+const CONFIG_SOURCE_LABELS = {
+  api: 'mode-enablement UI',
+  ws_override: 'device view',
+  watchdog_auto: 'watchdog auto-shutdown',
+  watchdog_user: 'watchdog banner',
+};
+
+export function formatConfigSourceLabel(s) {
+  return CONFIG_SOURCE_LABELS[s] || s || 'unknown source';
+}
+
+// Render a config_events row to a { title, desc } pair for the log
+// list. Three flavors:
+//   wb add (e.g. SC=9999999999)  — "Disabled mode: Solar Charging"
+//   wb remove (e.g. SC=null)     — "Re-enabled mode: Solar Charging"
+//   wb change (timestamp swap)   — "Updated ban: Solar Charging"
+//   mo enter (null → object)     — "Manual override: Solar Charging (until 14:30)"
+//   mo exit (object → null)      — "Manual override exited"
+//   mo change (object → object)  — "Manual override updated: Active Drain"
+export function formatConfigEntry(t) {
+  const PERMANENT = 9999999999;
+  const sourceLabel = formatConfigSourceLabel(t.source);
+  const actorLabel = t.actor ? ' by ' + t.actor : '';
+  const subtitle = sourceLabel + actorLabel;
+
+  if (t.configKind === 'wb') {
+    const modeLabel = MODE_CODE_LABELS[t.configKey] || t.configKey || 'unknown mode';
+    if (t.from === null && t.to !== null) {
+      const isPermanent = parseInt(t.to, 10) === PERMANENT;
+      const verb = isPermanent ? 'Disabled mode' : 'Banned mode (cool-off)';
+      return { title: verb + ': ' + modeLabel, desc: subtitle };
+    }
+    if (t.from !== null && t.to === null) {
+      return { title: 'Re-enabled mode: ' + modeLabel, desc: subtitle };
+    }
+    return { title: 'Updated ban: ' + modeLabel, desc: subtitle };
+  }
+
+  if (t.configKind === 'mo') {
+    const fromMo = t.from ? safeParseJson(t.from) : null;
+    const toMo = t.to ? safeParseJson(t.to) : null;
+    if (!fromMo && toMo) {
+      const fmLabel = MODE_CODE_LABELS[toMo.fm] || toMo.fm || 'unknown';
+      return { title: 'Manual override: ' + fmLabel, desc: subtitle };
+    }
+    if (fromMo && !toMo) {
+      return { title: 'Manual override exited', desc: subtitle };
+    }
+    if (toMo) {
+      const fmLabel = MODE_CODE_LABELS[toMo.fm] || toMo.fm || 'unknown';
+      return { title: 'Manual override updated: ' + fmLabel, desc: subtitle };
+    }
+  }
+
+  return { title: 'Config change', desc: subtitle };
+}
+
+function safeParseJson(s) {
+  try { return JSON.parse(s); } catch (e) { return null; }
+}
+
 // Render the temp snapshot as "coll 62.3° · tank 41/29° · gh 12° · out 8°"
 export function formatSensorsLine(sensors) {
   if (!sensors) return '';

--- a/server/lib/anomaly-manager.js
+++ b/server/lib/anomaly-manager.js
@@ -14,7 +14,7 @@ const {
 } = require('../../shelly/watchdogs-meta.js');
 
 // Module-scoped state — set by init()
-let _deps = null;         // { deviceConfig, mqttBridge, push, wsBroadcast, history, log }
+let _deps = null;         // { deviceConfig, mqttBridge, push, wsBroadcast, history, db, log }
 let _pending = null;      // { id, firedAt, mode, triggerReason, dbEventId } | null
 // Mirror of deviceConfig fields that the playground needs to render
 // the watchdog UI and the System Logs export. Broadcast over WS as
@@ -67,6 +67,7 @@ function bootstrap(opts) {
     wsBroadcast: opts.wsBroadcast,
     mqttBridge: opts.mqttBridge,
     deviceConfig: opts.deviceConfig,
+    db,
     log,
   });
   log.info('anomaly-manager initialized', { backend: wdHistoryDb ? 'postgres' : 'ring-buffer' });
@@ -160,6 +161,37 @@ async function _handleFired(msg) {
 async function _handleResolved(msg) {
   const resolvedAt = new Date((msg.ts || Math.floor(Date.now() / 1000)) * 1000);
   const matches = !!(_pending && _pending.id === msg.id);
+
+  // Audit-log device-driven auto-shutdowns. shutdown_auto means the
+  // 5-minute pending grace expired without user action; the device
+  // wrote wb[modeCode] = now + WATCHDOG_BAN_SECONDS and transitioned
+  // to IDLE. The server's deviceConfig mirror does NOT see this write
+  // (no device → server config feedback), so without an explicit
+  // event row the auto-shutdown is invisible in the System Logs.
+  // shutdown_user goes through the regular config-PUT path so it's
+  // already covered by the http-handlers diff.
+  if (msg.how === 'shutdown_auto') {
+    const meta = getWatchdog(msg.id);
+    if (meta && meta.modeCode && _deps && _deps.db &&
+        typeof _deps.db.insertConfigEvent === 'function') {
+      const tsSec = msg.ts || Math.floor(Date.now() / 1000);
+      _deps.db.insertConfigEvent({
+        ts: new Date(tsSec * 1000),
+        kind: 'wb',
+        key: meta.modeCode,
+        old_value: null,
+        new_value: String(tsSec + WATCHDOG_BAN_SECONDS),
+        source: 'watchdog_auto',
+        actor: 'device',
+      }, function (err) {
+        if (err && _deps.log) {
+          _deps.log.error('config_event insert failed (watchdog_auto)', {
+            error: err.message, watchdog: msg.id, mode: meta.modeCode,
+          });
+        }
+      });
+    }
+  }
 
   if (matches) {
     await _deps.history.update(_pending.dbEventId, {

--- a/server/lib/anomaly-manager.js
+++ b/server/lib/anomaly-manager.js
@@ -162,35 +162,15 @@ async function _handleResolved(msg) {
   const resolvedAt = new Date((msg.ts || Math.floor(Date.now() / 1000)) * 1000);
   const matches = !!(_pending && _pending.id === msg.id);
 
-  // Audit-log device-driven auto-shutdowns. shutdown_auto means the
-  // 5-minute pending grace expired without user action; the device
-  // wrote wb[modeCode] = now + WATCHDOG_BAN_SECONDS and transitioned
-  // to IDLE. The server's deviceConfig mirror does NOT see this write
-  // (no device → server config feedback), so without an explicit
-  // event row the auto-shutdown is invisible in the System Logs.
-  // shutdown_user goes through the regular config-PUT path so it's
-  // already covered by the http-handlers diff.
+  // Device-driven auto-shutdown: the 5-minute pending grace expired
+  // without user action; the device wrote wb[modeCode] = now +
+  // WATCHDOG_BAN_SECONDS to its own KVS and transitioned to IDLE.
+  // There is no device → server config feedback, so we mirror the
+  // ban into the server's deviceConfig + audit-log it. shutdown_user
+  // takes the normal config-PUT path so both halves are already
+  // handled by http-handlers.
   if (msg.how === 'shutdown_auto') {
-    const meta = getWatchdog(msg.id);
-    if (meta && meta.modeCode && _deps && _deps.db &&
-        typeof _deps.db.insertConfigEvent === 'function') {
-      const tsSec = msg.ts || Math.floor(Date.now() / 1000);
-      _deps.db.insertConfigEvent({
-        ts: new Date(tsSec * 1000),
-        kind: 'wb',
-        key: meta.modeCode,
-        old_value: null,
-        new_value: String(tsSec + WATCHDOG_BAN_SECONDS),
-        source: 'watchdog_auto',
-        actor: 'device',
-      }, function (err) {
-        if (err && _deps.log) {
-          _deps.log.error('config_event insert failed (watchdog_auto)', {
-            error: err.message, watchdog: msg.id, mode: meta.modeCode,
-          });
-        }
-      });
-    }
+    await _handleAutoShutdownBan(msg);
   }
 
   if (matches) {
@@ -297,6 +277,57 @@ function _buildNotificationPayload(pending) {
 // snooze, wb[modeCode] for shutdown) and reacts. This avoids needing
 // a second MQTT subscription on the Shelly device, which has a
 // limited subscription budget.
+// Mirror a device-driven mode-ban into the server's deviceConfig and
+// audit-log it. The device wrote wb[modeCode] = ts + 14400 to its own
+// KVS when its watchdog auto-shutdown grace expired. There is no
+// device → server config feedback channel, so without this mirror:
+//   - the next config republish (server → MQTT → device) would
+//     clobber the device's auto-set ban back to nothing (the server's
+//     wb mirror would be empty);
+//   - the Mode Enablement panel's cool-off TTL line would not show
+//     because watchdog-state broadcasts carry the server mirror, not
+//     the device's actual KVS.
+async function _handleAutoShutdownBan(msg) {
+  const meta = getWatchdog(msg.id);
+  if (!meta || !meta.modeCode) return;
+  const tsSec = msg.ts || Math.floor(Date.now() / 1000);
+  const banUntil = tsSec + WATCHDOG_BAN_SECONDS;
+
+  // Audit row first — even if mirroring the wb fails, we want the
+  // event in the System Logs so the user can see what happened.
+  if (_deps && _deps.db && typeof _deps.db.insertConfigEvent === 'function') {
+    _deps.db.insertConfigEvent({
+      ts: new Date(tsSec * 1000),
+      kind: 'wb',
+      key: meta.modeCode,
+      old_value: null,
+      new_value: String(banUntil),
+      source: 'watchdog_auto',
+      actor: 'device',
+    }, function (err) {
+      if (err && _deps.log) {
+        _deps.log.error('config_event insert failed (watchdog_auto)', {
+          error: err.message, watchdog: msg.id, mode: meta.modeCode,
+        });
+      }
+    });
+  }
+
+  // Mirror into the server's deviceConfig + republish + updateSnapshot.
+  // _updateConfigAndPublish handles the persistence + broadcast plumbing.
+  const patch = { wb: {} };
+  patch.wb[meta.modeCode] = banUntil;
+  try {
+    await _updateConfigAndPublish(patch);
+  } catch (err) {
+    if (_deps && _deps.log) {
+      _deps.log.error('failed to mirror watchdog auto-shutdown ban', {
+        error: err.message, watchdog: msg.id, mode: meta.modeCode,
+      });
+    }
+  }
+}
+
 function _updateConfigAndPublish(patch) {
   return new Promise((resolve, reject) => {
     _deps.deviceConfig.updateConfig(patch, (err, updated) => {

--- a/server/lib/config-events.js
+++ b/server/lib/config-events.js
@@ -1,0 +1,92 @@
+/**
+ * Config-events diff helper. Pure: given (prev, next) deviceConfig
+ * snapshots plus a source tag and actor, returns the array of
+ * config_events rows that should be inserted to capture the wb (mode
+ * bans) and mo (manual override) deltas. Used by every code path that
+ * mutates deviceConfig so the System Logs view sees a consistent
+ * audit trail.
+ *
+ * Unhandled fields (ce, ea, we, wz, v) are intentionally ignored —
+ * they're either operational toggles (ce, ea), watchdog config that
+ * the watchdog UI tracks separately (we, wz), or bookkeeping (v).
+ * If/when one of those needs an audit row, add it here.
+ */
+
+const WB_KEYS = ['I', 'SC', 'GH', 'AD', 'EH'];
+
+function getWb(cfg) {
+  return (cfg && cfg.wb) || {};
+}
+
+function getMo(cfg) {
+  return (cfg && cfg.mo !== undefined) ? cfg.mo : null;
+}
+
+function moEqual(a, b) {
+  // mo is either null or { a, ex, fm? }. Compare by JSON since the
+  // shape is small and field set is fixed.
+  const sa = a ? JSON.stringify(a) : null;
+  const sb = b ? JSON.stringify(b) : null;
+  return sa === sb;
+}
+
+function diffConfig(prev, next, source, actor) {
+  const out = [];
+  const wbPrev = getWb(prev);
+  const wbNext = getWb(next);
+
+  for (let i = 0; i < WB_KEYS.length; i++) {
+    const k = WB_KEYS[i];
+    const pv = wbPrev[k];
+    const nv = wbNext[k];
+    if (pv === nv) continue;
+    out.push({
+      kind: 'wb',
+      key: k,
+      old_value: (pv === undefined || pv === null) ? null : String(pv),
+      new_value: (nv === undefined || nv === null) ? null : String(nv),
+      source,
+      actor: actor || null,
+    });
+  }
+
+  const moPrev = getMo(prev);
+  const moNext = getMo(next);
+  if (!moEqual(moPrev, moNext)) {
+    out.push({
+      kind: 'mo',
+      key: null,
+      old_value: moPrev ? JSON.stringify(moPrev) : null,
+      new_value: moNext ? JSON.stringify(moNext) : null,
+      source,
+      actor: actor || null,
+    });
+  }
+
+  return out;
+}
+
+// Higher-level convenience: diff prev/next, write each row through
+// the supplied db.insertConfigEvent. Failure of one insert doesn't
+// short-circuit subsequent inserts — they're independent rows and
+// dropping one is preferable to dropping all. Errors are logged via
+// the supplied logger so the caller can rely on best-effort writes.
+function emitConfigEvents(db, log, prev, next, source, actor) {
+  if (!db || typeof db.insertConfigEvent !== 'function') return;
+  const rows = diffConfig(prev, next, source, actor);
+  for (let i = 0; i < rows.length; i++) {
+    const row = rows[i];
+    db.insertConfigEvent(row, function (err) {
+      if (err && log && typeof log.error === 'function') {
+        log.error('config_event insert failed', {
+          error: err.message,
+          kind: row.kind,
+          key: row.key,
+          source,
+        });
+      }
+    });
+  }
+}
+
+module.exports = { diffConfig, emitConfigEvents };

--- a/server/lib/db-schema.js
+++ b/server/lib/db-schema.js
@@ -57,6 +57,33 @@ const SCHEMA_SQL = [
   ")",
 
   "CREATE INDEX IF NOT EXISTS script_crashes_ts ON script_crashes (ts DESC)",
+
+  // Config-mutation events. Captures every wb (mode-ban) and mo (manual-
+  // override) change so the System Logs view can render an audit trail
+  // alongside mode transitions. Sources:
+  //   'api'           — PUT /api/device-config (mode-enablement UI, etc.)
+  //   'ws_override'   — WS override-enter/exit/update (refill, drain)
+  //   'watchdog_auto' — device-side auto-shutdown after watchdog fired,
+  //                     surfaced via the watchdog "resolved" MQTT event
+  //   'watchdog_user' — user-acknowledged watchdog shutdown via banner
+  // For wb events, `key` is the mode short code (SC/GH/AD/EH/I); for mo
+  // events `key` is null (the mo field has only one slot per device).
+  // old_value / new_value carry the raw value as a string: unix-sec
+  // timestamp for wb, JSON for mo, null = absent. `actor` is the
+  // username for human actions or 'device' for watchdog_auto.
+  "CREATE TABLE IF NOT EXISTS config_events (\n" +
+  "  ts        TIMESTAMPTZ NOT NULL,\n" +
+  "  kind      TEXT        NOT NULL,\n" +
+  "  key       TEXT,\n" +
+  "  old_value TEXT,\n" +
+  "  new_value TEXT,\n" +
+  "  source    TEXT        NOT NULL,\n" +
+  "  actor     TEXT\n" +
+  ")",
+
+  "SELECT create_hypertable('config_events', 'ts', if_not_exists => true)",
+
+  "CREATE INDEX IF NOT EXISTS config_events_ts ON config_events (ts DESC)",
 ];
 
 // Pre-aggregated 30-second buckets, used by getHistory for ranges ≥ 24 h.

--- a/server/lib/db.js
+++ b/server/lib/db.js
@@ -172,6 +172,71 @@ function insertStateEvent(ts, entityType, entityId, oldValue, newValue, optsOrCa
   });
 }
 
+// ── Config events ──
+//
+// Every wb / mo mutation is logged here as one row per delta, sourced
+// from PUT /api/device-config (mode-enablement UI), WS override
+// commands (refill / drain), or the device's auto-shutdown path. The
+// System Logs view interleaves these with mode transitions to give a
+// single audit trail. Source / actor / key / value semantics are
+// documented on the table definition in db-schema.js.
+function insertConfigEvent(row, callback) {
+  const p = getPool();
+  const sql = 'INSERT INTO config_events (ts, kind, key, old_value, new_value, source, actor) ' +
+              'VALUES ($1, $2, $3, $4, $5, $6, $7)';
+  const params = [
+    row.ts || new Date(),
+    row.kind,
+    row.key || null,
+    row.old_value === undefined ? null : row.old_value,
+    row.new_value === undefined ? null : row.new_value,
+    row.source,
+    row.actor || null,
+  ];
+  p.query(sql, params, function (err) {
+    if (callback) callback(err || null);
+  });
+}
+
+// Newest-first paginated query mirroring getEventsPaginated for state_events.
+//   limit  — capped at 100
+//   before — optional Unix ms cursor; returns rows with ts < before
+function getConfigEventsPaginated(limit, before, callback) {
+  const p = getPool();
+  const cap = 100;
+  const effLimit = Math.max(1, Math.min(cap, parseInt(limit, 10) || 10));
+  const fetchLimit = effLimit + 1;
+
+  const params = [];
+  let sql = 'SELECT ts, kind, key, old_value, new_value, source, actor FROM config_events';
+  if (before !== null && before !== undefined) {
+    params.push(new Date(before));
+    sql += ' WHERE ts < $' + params.length;
+  }
+  params.push(fetchLimit);
+  sql += ' ORDER BY ts DESC LIMIT $' + params.length;
+
+  p.query(sql, params, function (err, result) {
+    if (err) { callback(err); return; }
+    let rows = result.rows;
+    const hasMore = rows.length > effLimit;
+    if (hasMore) rows = rows.slice(0, effLimit);
+    const events = rows.map(function (row) {
+      return {
+        ts: new Date(row.ts).getTime(),
+        type: 'config',
+        kind: row.kind,
+        key: row.key,
+        from: row.old_value,
+        to: row.new_value,
+        source: row.source,
+        actor: row.actor,
+      };
+    });
+    callback(null, { events, hasMore });
+  });
+}
+
 // ── History queries ──
 
 const RANGE_INTERVALS = {
@@ -517,6 +582,8 @@ module.exports = {
   stopMaintenance: maintenance.stop,
   insertSensorReadings,
   insertStateEvent,
+  insertConfigEvent,
+  getConfigEventsPaginated,
   insertScriptCrash,
   listScriptCrashes,
   getScriptCrash,

--- a/server/lib/device-config.js
+++ b/server/lib/device-config.js
@@ -184,6 +184,12 @@ function validationError(message) {
 
 function updateConfig(newConfig, callback) {
   const config = getConfig();
+  // Deep-copy of the prior state — passed through the success callback
+  // as the third arg so callers can diff (prev → updated) for audit
+  // logging without re-fetching after the mutation. `config` is
+  // mutated in place by the field-by-field assignments below, so a
+  // shallow alias would silently track post-update values.
+  const prevConfig = deepCopy(config);
   // Snapshot for no-op detection (compare BEFORE mutating)
   const beforeSnapshot = JSON.stringify(stripVersion(config));
 
@@ -289,14 +295,14 @@ function updateConfig(newConfig, callback) {
   // version. Saves S3 writes and MQTT republishes for repeated identical PUTs.
   const afterSnapshot = JSON.stringify(stripVersion(config));
   if (afterSnapshot === beforeSnapshot) {
-    callback(null, config);
+    callback(null, config, prevConfig);
     return;
   }
 
   config.v = (config.v || 0) + 1;
   save(config, function (err) {
     if (err) { callback(err); return; }
-    callback(null, config);
+    callback(null, config, prevConfig);
   });
 }
 
@@ -326,7 +332,7 @@ function handlePut(req, res, body, onUpdate) {
     return;
   }
 
-  updateConfig(parsed, function (err, config) {
+  updateConfig(parsed, function (err, config, prevConfig) {
     if (err) {
       // Validation errors are user-correctable — surface them as 400 with the
       // exact message so the UI can show it to the user.
@@ -345,7 +351,7 @@ function handlePut(req, res, body, onUpdate) {
     res.writeHead(200, { 'Content-Type': 'application/json' });
     res.end(JSON.stringify(config));
 
-    if (onUpdate) onUpdate(config);
+    if (onUpdate) onUpdate(config, prevConfig);
   });
 }
 

--- a/server/lib/http-handlers.js
+++ b/server/lib/http-handlers.js
@@ -17,6 +17,7 @@ const deviceConfig = require('./device-config');
 const sensorDiscovery = require('./sensor-discovery');
 const push = require('./push');
 const anomalyManager = require('./anomaly-manager');
+const { emitConfigEvents } = require('./config-events');
 const createLogger = require('./logger');
 
 const log = createLogger('http');
@@ -116,6 +117,23 @@ function createHandlers(deps) {
       return;
     }
 
+    // type=config queries the separate config_events table (wb/mo
+     // mutations: mode-enablement edits, manual override enter/exit,
+     // device auto-shutdowns). Same { events, hasMore } shape as the
+     // mode-events feed; the System Logs view fetches both and
+     // interleaves by ts.
+    if (type === 'config') {
+      db.getConfigEventsPaginated(limit, before, function (err, result) {
+        if (err) {
+          log.error('config events query failed', { error: err.message });
+          jsonResponse(res, 500, { error: 'Query failed' });
+          return;
+        }
+        jsonResponse(res, 200, result);
+      });
+      return;
+    }
+
     db.getEventsPaginated(type, limit, before, function (err, result) {
       if (err) {
         log.error('events query failed', { error: err.message });
@@ -135,7 +153,15 @@ function createHandlers(deps) {
     if (req.method === 'PUT') {
       // PUT requires admin role
       if (AUTH_ENABLED && !authMiddleware.requireAdmin(req, res)) return;
-      deviceConfig.handlePut(req, res, body, function (config) {
+      // Capture user identity at request time — needed for the config-
+      // events audit row written below. Falls back to 'admin' when auth
+      // is disabled (local LAN dev mode) so single-user setups still
+      // get a non-null actor in the log.
+      const user = authMiddleware && authMiddleware.getCurrentUser
+        ? authMiddleware.getCurrentUser(req)
+        : null;
+      const actor = (user && user.name) || 'admin';
+      deviceConfig.handlePut(req, res, body, function (config, prevConfig) {
         // Publish to MQTT for instant push to device
         mqttBridge.publishConfig(config);
         // Mirror the latest snapshot into anomaly-manager so wb-clear
@@ -150,6 +176,9 @@ function createHandlers(deps) {
           watchdogs: require('../../shelly/watchdogs-meta.js').WATCHDOGS,
           snapshot: { we: config.we || {}, wz: config.wz || {}, wb: config.wb || {} }
         });
+        // Audit-log wb / mo deltas. Best-effort — emitConfigEvents
+        // logs and swallows individual insert failures.
+        emitConfigEvents(db, log, prevConfig, config, 'api', actor);
       });
       return;
     }

--- a/server/lib/ws-command-handlers.js
+++ b/server/lib/ws-command-handlers.js
@@ -8,9 +8,20 @@
 
 const mqttBridge = require('./mqtt-bridge');
 const deviceConfig = require('./device-config');
+const { emitConfigEvents } = require('./config-events');
+const createLogger = require('./logger');
+
+const log = createLogger('ws-command');
 
 const VALID_RELAYS = ['vi_btm', 'vi_top', 'vi_coll', 'vo_coll', 'vo_rad', 'vo_tank', 'v_air', 'pump', 'fan'];
 let overrideTtlTimer = null;
+
+// Database handle for config_events audit writes. Injected after db
+// init from server.js so we don't carry a circular require. Optional —
+// when null (e.g. tests that don't init the DB), audit writes are
+// silently skipped.
+let _db = null;
+function setDb(db) { _db = db; }
 
 function wsSend(ws, msg) {
   if (ws.readyState === 1) ws.send(JSON.stringify(msg));
@@ -65,13 +76,14 @@ function handleOverrideEnter(ws, msg) {
   const ttl = Math.max(60, Math.min(3600, parseInt(msg.ttl, 10) || 300));
   const ex = Math.floor(Date.now() / 1000) + ttl;
 
-  deviceConfig.updateConfig({ mo: { a: true, ex, fm } }, function (err, updated) {
+  deviceConfig.updateConfig({ mo: { a: true, ex, fm } }, function (err, updated, prev) {
     if (err) {
       wsSend(ws, { type: 'override-error', message: err.message });
       return;
     }
     mqttBridge.publishConfig(updated);
     wsSend(ws, { type: 'override-ack', active: true, expiresAt: ex, forcedMode: fm });
+    emitConfigEvents(_db, log, prev, updated, 'ws_override', ws._userName || 'admin');
 
     // Secondary server-side TTL tracking
     clearOverrideTtlTimer();
@@ -79,8 +91,10 @@ function handleOverrideEnter(ws, msg) {
       overrideTtlTimer = null;
       const current = deviceConfig.getConfig();
       if (current.mo && current.mo.a) {
-        deviceConfig.updateConfig({ mo: null }, function (err2, cleared) {
-          if (!err2) mqttBridge.publishConfig(cleared);
+        deviceConfig.updateConfig({ mo: null }, function (err2, cleared, prevTtl) {
+          if (err2) return;
+          mqttBridge.publishConfig(cleared);
+          emitConfigEvents(_db, log, prevTtl, cleared, 'ws_override', 'ttl_expiry');
         });
       }
     }, ttl * 1000);
@@ -89,13 +103,14 @@ function handleOverrideEnter(ws, msg) {
 
 function handleOverrideExit(ws) {
   clearOverrideTtlTimer();
-  deviceConfig.updateConfig({ mo: null }, function (err, updated) {
+  deviceConfig.updateConfig({ mo: null }, function (err, updated, prev) {
     if (err) {
       wsSend(ws, { type: 'override-error', message: err.message });
       return;
     }
     mqttBridge.publishConfig(updated);
     wsSend(ws, { type: 'override-ack', active: false, forcedMode: null });
+    emitConfigEvents(_db, log, prev, updated, 'ws_override', ws._userName || 'admin');
   });
 }
 
@@ -110,13 +125,14 @@ function handleOverrideUpdate(ws, msg) {
   const ex = Math.floor(Date.now() / 1000) + ttl;
 
   const newMo = { a: cfg.mo.a, ex, fm: cfg.mo.fm };
-  deviceConfig.updateConfig({ mo: newMo }, function (err, updated) {
+  deviceConfig.updateConfig({ mo: newMo }, function (err, updated, prev) {
     if (err) {
       wsSend(ws, { type: 'override-error', message: err.message });
       return;
     }
     mqttBridge.publishConfig(updated);
     wsSend(ws, { type: 'override-ack', active: true, expiresAt: ex, forcedMode: (updated.mo && updated.mo.fm) || null });
+    emitConfigEvents(_db, log, prev, updated, 'ws_override', ws._userName || 'admin');
 
     // Reset secondary TTL timer
     clearOverrideTtlTimer();
@@ -124,8 +140,10 @@ function handleOverrideUpdate(ws, msg) {
       overrideTtlTimer = null;
       const current = deviceConfig.getConfig();
       if (current.mo && current.mo.a) {
-        deviceConfig.updateConfig({ mo: null }, function (err2, cleared) {
-          if (!err2) mqttBridge.publishConfig(cleared);
+        deviceConfig.updateConfig({ mo: null }, function (err2, cleared, prevTtl) {
+          if (err2) return;
+          mqttBridge.publishConfig(cleared);
+          emitConfigEvents(_db, log, prevTtl, cleared, 'ws_override', 'ttl_expiry');
         });
       }
     }, ttl * 1000);
@@ -195,4 +213,4 @@ function clearOverrideTtlTimer() {
   }
 }
 
-module.exports = { handleWsCommand };
+module.exports = { handleWsCommand, setDb };

--- a/server/server.js
+++ b/server/server.js
@@ -21,7 +21,7 @@ const sensorDiscovery = require('./lib/sensor-discovery');
 const push = require('./lib/push');
 const anomalyManager = require('./lib/anomaly-manager');
 const { createScriptMonitor } = require('./lib/script-monitor');
-const { handleWsCommand } = require('./lib/ws-command-handlers');
+const { handleWsCommand, setDb: setWsCommandHandlersDb } = require('./lib/ws-command-handlers');
 const { createHandlers, readBody, jsonResponse } = require('./lib/http-handlers');
 const { getNetworkAddress, printBanner } = require('./lib/banner');
 
@@ -424,8 +424,8 @@ function initWebSocket() {
     }
 
     wsServer.handleUpgrade(req, socket, head, function (ws) {
-      // Stamp the role on the socket so command handlers can gate writes.
       ws._role = wsUser ? wsUser.role : 'admin';
+      ws._userName = (wsUser && wsUser.name) || 'admin';
       wsServer.emit('connection', ws, req);
       // Send current MQTT connection status on connect
       ws.send(JSON.stringify({
@@ -478,6 +478,7 @@ function initServices(callback) {
           log.info('database initialized');
           db.startMaintenance();
         }
+        setWsCommandHandlersDb(db);
         initAnomalyManager();
         finish();
       });

--- a/tests/anomaly-manager.test.js
+++ b/tests/anomaly-manager.test.js
@@ -196,6 +196,77 @@ describe('anomaly-manager handleDeviceEvent fired', () => {
     const ackPushes = mocks.calls.push.filter(p => p.payload.data.kind === 'watchdog_ack');
     assert.strictEqual(ackPushes.length, 0);
   });
+
+  it('mirrors the device-set mode-ban into server deviceConfig on shutdown_auto', async () => {
+    // The device writes wb[modeCode] = now + 14400 to its own KVS when
+    // a watchdog auto-shutdown fires. The server has no device→server
+    // config feedback channel, so without explicit mirroring, the
+    // server's deviceConfig stays empty, the watchdog-state broadcast
+    // tells the UI "no ban", and the next config republish clobbers
+    // the device's auto-set ban back to nothing.
+    const mocks = makeMocks();
+    anomalyManager.init(mocks);
+
+    const firedTs = 1700000000;
+    const resolvedTs = firedTs + 305; // device's 5 min grace expired
+    await anomalyManager.handleDeviceEvent({
+      t: 'fired', id: 'ggr', mode: 'GREENHOUSE_HEATING',
+      el: 905, dT: 0.3, dC: 0, dG: 0.2, ts: firedTs
+    });
+    mocks.calls.deviceConfigPut.length = 0;
+    mocks.calls.publishedConfigs.length = 0;
+    mocks.calls.ws.length = 0;
+
+    await anomalyManager.handleDeviceEvent({
+      t: 'resolved', id: 'ggr', how: 'shutdown_auto', ts: resolvedTs
+    });
+
+    // The server's mirror should now carry the Greenhouse Heating cool-off
+    // ban (key "GH" in the deviceConfig wb map), with the same TTL the
+    // device just applied: resolvedTs + WATCHDOG_BAN_SECONDS (14400 = 4 h).
+    const expectedUntil = resolvedTs + 14400;
+    const wbPuts = mocks.calls.deviceConfigPut.filter(p => p.wb && p.wb.GH !== undefined);
+    assert.strictEqual(wbPuts.length, 1, 'expected one wb update on shutdown_auto');
+    assert.strictEqual(wbPuts[0].wb.GH, expectedUntil);
+
+    // The server should publish the updated config back to MQTT so the
+    // device sees a matching v+1 (no behaviour change on the device, but
+    // prevents a future republish from clobbering the ban) and so other
+    // observers see the new state.
+    assert.strictEqual(mocks.calls.publishedConfigs.length, 1);
+    assert.strictEqual(mocks.calls.publishedConfigs[0].wb.GH, expectedUntil);
+
+    // The watchdog-state broadcast that re-renders the Mode Enablement
+    // panel should now include the Greenhouse Heating cool-off entry —
+    // that's what makes the panel show "⏸ cool-off — Xh Ym" instead of
+    // "+ allowed".
+    const stateBroadcasts = mocks.calls.ws.filter(m => m.type === 'watchdog-state');
+    assert.ok(stateBroadcasts.length >= 1, 'expected at least one watchdog-state broadcast');
+    const last = stateBroadcasts[stateBroadcasts.length - 1];
+    assert.strictEqual(last.snapshot.wb.GH, expectedUntil);
+  });
+
+  it('does not write a wb mirror update on shutdown_user (config PUT already covered it)', async () => {
+    // shutdown_user arrives when the user pressed "Shutdown now" on the
+    // watchdog banner. That path is driven by the server: it PUTs
+    // wb[modeCode] = now + 14400, the device sees the new wb, transitions
+    // to IDLE, and replies with how=shutdown_user. The wb is already in
+    // the server's mirror — re-mirroring would be a redundant write.
+    const mocks = makeMocks();
+    anomalyManager.init(mocks);
+    await anomalyManager.handleDeviceEvent({
+      t: 'fired', id: 'ggr', mode: 'GREENHOUSE_HEATING',
+      el: 905, dT: 0.3, dC: 0, dG: 0.2, ts: 1700000000
+    });
+    mocks.calls.deviceConfigPut.length = 0;
+
+    await anomalyManager.handleDeviceEvent({
+      t: 'resolved', id: 'ggr', how: 'shutdown_user', ts: 1700000400
+    });
+
+    const wbPuts = mocks.calls.deviceConfigPut.filter(p => p.wb && p.wb.GH !== undefined);
+    assert.strictEqual(wbPuts.length, 0);
+  });
 });
 
 describe('anomaly-manager ack', () => {

--- a/tests/config-events-diff.test.js
+++ b/tests/config-events-diff.test.js
@@ -1,0 +1,155 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const { diffConfig } = require('../server/lib/config-events.js');
+
+// diffConfig is pure: takes (prev, next, source, actor) and returns
+// the array of config_events rows that should be inserted to capture
+// the wb / mo deltas. State_events table-shaped, used by every call
+// site that writes config events.
+
+describe('config-events diff — wb (mode bans)', () => {
+  it('returns one row per added wb entry', () => {
+    const rows = diffConfig(
+      { wb: {} },
+      { wb: { SC: 1840000000, GH: 1840014400 } },
+      'api',
+      'alice'
+    );
+    rows.sort((a, b) => a.key.localeCompare(b.key));
+    assert.deepStrictEqual(rows, [
+      { kind: 'wb', key: 'GH', old_value: null, new_value: '1840014400', source: 'api', actor: 'alice' },
+      { kind: 'wb', key: 'SC', old_value: null, new_value: '1840000000', source: 'api', actor: 'alice' },
+    ]);
+  });
+
+  it('returns one row per removed wb entry (clearing a cool-off)', () => {
+    const rows = diffConfig(
+      { wb: { SC: 1840000000 } },
+      { wb: {} },
+      'api',
+      'alice'
+    );
+    assert.deepStrictEqual(rows, [
+      { kind: 'wb', key: 'SC', old_value: '1840000000', new_value: null, source: 'api', actor: 'alice' },
+    ]);
+  });
+
+  it('returns one row per changed wb entry', () => {
+    const rows = diffConfig(
+      { wb: { GH: 1840000000 } },
+      { wb: { GH: 1840014400 } },
+      'api',
+      'alice'
+    );
+    assert.deepStrictEqual(rows, [
+      { kind: 'wb', key: 'GH', old_value: '1840000000', new_value: '1840014400', source: 'api', actor: 'alice' },
+    ]);
+  });
+
+  it('returns no rows when wb unchanged', () => {
+    const rows = diffConfig(
+      { wb: { GH: 1840000000 } },
+      { wb: { GH: 1840000000 } },
+      'api',
+      'alice'
+    );
+    assert.deepStrictEqual(rows, []);
+  });
+
+  it('treats undefined wb on either side as empty', () => {
+    const rows = diffConfig(
+      {},
+      { wb: { SC: 9999999999 } },
+      'api',
+      'alice'
+    );
+    assert.deepStrictEqual(rows, [
+      { kind: 'wb', key: 'SC', old_value: null, new_value: '9999999999', source: 'api', actor: 'alice' },
+    ]);
+  });
+});
+
+describe('config-events diff — mo (manual override)', () => {
+  it('null → active records the entry as one row', () => {
+    const rows = diffConfig(
+      { mo: null },
+      { mo: { a: true, ex: 1840000000, fm: 'SC' } },
+      'ws_override',
+      'alice'
+    );
+    assert.deepStrictEqual(rows, [
+      {
+        kind: 'mo',
+        key: null,
+        old_value: null,
+        new_value: JSON.stringify({ a: true, ex: 1840000000, fm: 'SC' }),
+        source: 'ws_override',
+        actor: 'alice',
+      },
+    ]);
+  });
+
+  it('active → null records the exit', () => {
+    const rows = diffConfig(
+      { mo: { a: true, ex: 1840000000, fm: 'AD' } },
+      { mo: null },
+      'ws_override',
+      'alice'
+    );
+    assert.deepStrictEqual(rows, [
+      {
+        kind: 'mo',
+        key: null,
+        old_value: JSON.stringify({ a: true, ex: 1840000000, fm: 'AD' }),
+        new_value: null,
+        source: 'ws_override',
+        actor: 'alice',
+      },
+    ]);
+  });
+
+  it('forced-mode change records the new override', () => {
+    const rows = diffConfig(
+      { mo: { a: true, ex: 1840000000, fm: 'SC' } },
+      { mo: { a: true, ex: 1840003600, fm: 'AD' } },
+      'ws_override',
+      'alice'
+    );
+    assert.strictEqual(rows.length, 1);
+    assert.strictEqual(rows[0].kind, 'mo');
+  });
+
+  it('null → null returns nothing', () => {
+    const rows = diffConfig({ mo: null }, { mo: null }, 'api', 'alice');
+    assert.deepStrictEqual(rows, []);
+  });
+
+  it('treats missing mo on either side as null', () => {
+    const rows = diffConfig({}, {}, 'api', 'alice');
+    assert.deepStrictEqual(rows, []);
+  });
+});
+
+describe('config-events diff — combined wb + mo deltas', () => {
+  it('emits rows for both fields when both change in one update', () => {
+    const rows = diffConfig(
+      { wb: {}, mo: null },
+      { wb: { SC: 9999999999 }, mo: { a: true, ex: 1840000000, fm: 'SC' } },
+      'api',
+      'alice'
+    );
+    assert.strictEqual(rows.length, 2);
+    const kinds = rows.map(r => r.kind).sort();
+    assert.deepStrictEqual(kinds, ['mo', 'wb']);
+  });
+
+  it('ignores changes to non-tracked fields (ce, ea, we, wz, v)', () => {
+    const rows = diffConfig(
+      { ce: false, ea: 0, we: {}, wz: {}, wb: {}, mo: null, v: 1 },
+      { ce: true, ea: 31, we: { ggr: 1 }, wz: { ggr: 1840003600 }, wb: {}, mo: null, v: 2 },
+      'api',
+      'alice'
+    );
+    assert.deepStrictEqual(rows, []);
+  });
+});

--- a/tests/e2e/_setup/start.cjs
+++ b/tests/e2e/_setup/start.cjs
@@ -51,6 +51,8 @@ require.cache[schemaPath] = {
       'CREATE INDEX IF NOT EXISTS state_events_type_ts ON state_events (entity_type, ts DESC)',
       'CREATE TABLE IF NOT EXISTS script_crashes (id BIGSERIAL PRIMARY KEY, ts TIMESTAMPTZ NOT NULL DEFAULT NOW(), error_msg TEXT, error_trace TEXT, sys_status JSONB, recent_states JSONB, resolved_at TIMESTAMPTZ)',
       'CREATE INDEX IF NOT EXISTS script_crashes_ts ON script_crashes (ts DESC)',
+      'CREATE TABLE IF NOT EXISTS config_events (ts TIMESTAMPTZ NOT NULL, kind TEXT NOT NULL, key TEXT, old_value TEXT, new_value TEXT, source TEXT NOT NULL, actor TEXT)',
+      'CREATE INDEX IF NOT EXISTS config_events_ts ON config_events (ts DESC)',
       // pg-mem has no materialized views + no time_bucket. Stand in
       // with a plain view so queries that target the aggregate (range
       // = '7d'/'30d'/'1y'/'all') resolve. Values are passed through

--- a/tests/format-config-entry.test.mjs
+++ b/tests/format-config-entry.test.mjs
@@ -1,0 +1,108 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { formatConfigEntry, formatConfigSourceLabel } from '../playground/js/main/time-format.js';
+
+describe('formatConfigEntry — wb (mode bans)', () => {
+  it('cool-off ban set (timestamp, not the permanent sentinel)', () => {
+    const out = formatConfigEntry({
+      eventType: 'config', configKind: 'wb', configKey: 'GH',
+      from: null, to: '1840014400',
+      source: 'watchdog_auto', actor: 'device',
+    });
+    assert.equal(out.title, 'Banned mode (cool-off): Greenhouse Heating');
+    assert.match(out.desc, /watchdog auto-shutdown by device/);
+  });
+
+  it('permanent disable (sentinel 9999999999) — set via mode-enablement UI', () => {
+    const out = formatConfigEntry({
+      eventType: 'config', configKind: 'wb', configKey: 'SC',
+      from: null, to: '9999999999',
+      source: 'api', actor: 'alice',
+    });
+    assert.equal(out.title, 'Disabled mode: Solar Charging');
+    assert.match(out.desc, /mode-enablement UI by alice/);
+  });
+
+  it('re-enable (entry removed) — clearing the cool-off / re-enabling the mode', () => {
+    const out = formatConfigEntry({
+      eventType: 'config', configKind: 'wb', configKey: 'GH',
+      from: '9999999999', to: null,
+      source: 'api', actor: 'alice',
+    });
+    assert.equal(out.title, 'Re-enabled mode: Greenhouse Heating');
+  });
+
+  it('updated ban (timestamp swap)', () => {
+    const out = formatConfigEntry({
+      eventType: 'config', configKind: 'wb', configKey: 'GH',
+      from: '1840000000', to: '1840014400',
+      source: 'watchdog_auto', actor: 'device',
+    });
+    assert.equal(out.title, 'Updated ban: Greenhouse Heating');
+  });
+
+  it('falls back gracefully on an unknown mode code', () => {
+    const out = formatConfigEntry({
+      eventType: 'config', configKind: 'wb', configKey: 'ZZ',
+      from: null, to: '9999999999', source: 'api', actor: 'alice',
+    });
+    assert.equal(out.title, 'Disabled mode: ZZ');
+  });
+});
+
+describe('formatConfigEntry — mo (manual override)', () => {
+  it('override entered (null → object)', () => {
+    const out = formatConfigEntry({
+      eventType: 'config', configKind: 'mo', configKey: null,
+      from: null,
+      to: JSON.stringify({ a: true, ex: 1840003600, fm: 'SC' }),
+      source: 'ws_override', actor: 'alice',
+    });
+    assert.equal(out.title, 'Manual override: Solar Charging');
+    assert.match(out.desc, /device view by alice/);
+  });
+
+  it('override exited (object → null)', () => {
+    const out = formatConfigEntry({
+      eventType: 'config', configKind: 'mo', configKey: null,
+      from: JSON.stringify({ a: true, ex: 1840003600, fm: 'AD' }),
+      to: null,
+      source: 'ws_override', actor: 'alice',
+    });
+    assert.equal(out.title, 'Manual override exited');
+  });
+
+  it('TTL expiry path attributes the actor as ttl_expiry', () => {
+    const out = formatConfigEntry({
+      eventType: 'config', configKind: 'mo', configKey: null,
+      from: JSON.stringify({ a: true, ex: 1840003600, fm: 'AD' }),
+      to: null,
+      source: 'ws_override', actor: 'ttl_expiry',
+    });
+    assert.match(out.desc, /by ttl_expiry/);
+  });
+
+  it('forced mode swap (object → object) shows the new fm', () => {
+    const out = formatConfigEntry({
+      eventType: 'config', configKind: 'mo', configKey: null,
+      from: JSON.stringify({ a: true, ex: 1840000000, fm: 'SC' }),
+      to: JSON.stringify({ a: true, ex: 1840003600, fm: 'AD' }),
+      source: 'ws_override', actor: 'alice',
+    });
+    assert.equal(out.title, 'Manual override updated: Active Drain');
+  });
+});
+
+describe('formatConfigSourceLabel', () => {
+  it('maps every known source', () => {
+    assert.equal(formatConfigSourceLabel('api'), 'mode-enablement UI');
+    assert.equal(formatConfigSourceLabel('ws_override'), 'device view');
+    assert.equal(formatConfigSourceLabel('watchdog_auto'), 'watchdog auto-shutdown');
+    assert.equal(formatConfigSourceLabel('watchdog_user'), 'watchdog banner');
+  });
+
+  it('falls back to the raw value (or "unknown source") for unmapped inputs', () => {
+    assert.equal(formatConfigSourceLabel('something_new'), 'something_new');
+    assert.equal(formatConfigSourceLabel(null), 'unknown source');
+  });
+});

--- a/tests/frontend/live-logs.spec.js
+++ b/tests/frontend/live-logs.spec.js
@@ -270,4 +270,41 @@ test.describe('System Logs card is backed by live state events', () => {
     await expect(first.locator('.log-cause')).toHaveCount(0);
     await expect(first.locator('.log-sensors')).toHaveCount(0);
   });
+
+  test('config_events rows render alongside mode transitions, interleaved by ts', async ({ page }) => {
+    const now = Date.now();
+    // mode row at now-30s; config rows at now-60s and now-90s; mode row at now-120s.
+    // Expected newest-first order: mode(-30s) → config(-60s) → config(-90s) → mode(-120s)
+    const rows = [
+      // newest → oldest
+      makeEvent(now - 30_000, 'idle', 'solar_charging'),
+      {
+        ts: now - 60_000, type: 'config', kind: 'wb', key: 'GH',
+        from: null, to: '9999999999', source: 'api', actor: 'alice',
+      },
+      {
+        ts: now - 90_000, type: 'config', kind: 'mo', key: null,
+        from: null, to: JSON.stringify({ a: true, ex: 1840003600, fm: 'SC' }),
+        source: 'ws_override', actor: 'alice',
+      },
+      makeEvent(now - 120_000, 'solar_charging', 'idle'),
+    ];
+
+    await installMockWs(page);
+    await mockHistoryApi(page);
+    await mockEventsApi(page, rows);
+
+    await page.goto('/playground/', { waitUntil: 'domcontentloaded' });
+    await expect(page.locator('#connection-dot')).toHaveClass(/connected/, { timeout: 3000 });
+
+    const items = page.locator('#logs-list .log-item');
+    await expect(items).toHaveCount(4, { timeout: 3000 });
+
+    await expect(items.nth(0)).toContainText('Collecting Solar Energy');
+    await expect(items.nth(1)).toContainText('Disabled mode: Greenhouse Heating');
+    await expect(items.nth(1)).toContainText('mode-enablement UI by alice');
+    await expect(items.nth(2)).toContainText('Manual override: Solar Charging');
+    await expect(items.nth(2)).toContainText('device view by alice');
+    await expect(items.nth(3)).toContainText('Idle');
+  });
 });


### PR DESCRIPTION
## Summary

Two related changes that close the audit + sync gap around watchdog auto-shutdown bans and manual override / mode-enablement edits.

### `04e276f` — audit-log every config mutation to `config_events`

Adds a new `config_events` hypertable that captures every mode-ban (`wb`) and manual-override (`mo`) change, then surfaces them in the System Logs view alongside mode transitions so the audit trail sits next to the transitions it caused.

Sources:
- **`api`** — `PUT /api/device-config` (Mode Enablement panel: Disable / Re-enable / Clear cool-off)
- **`ws_override`** — WebSocket `override-enter` / `-exit` / `-update` (Refill via solar, Drain, manual mode forcing)
- **`watchdog_auto`** — device-side auto-shutdown after the 5 min pending grace expires; surfaced via the existing `resolved shutdown_auto` MQTT event

Plumbing:
- Pure diff helper in `server/lib/config-events.js` (12 unit tests)
- `updateConfig()` now passes the prior config back through its callback so each call site can diff against it
- HTTP layer pulls user identity via `getCurrentUser`; WebSocket layer stamps `ws._userName` on connection upgrade so override commands carry an actor
- Frontend extends the System Logs feed: separate cursors per type so a quiet feed doesn't block the other; new `formatConfigEntry` maps each row to a human-readable label (e.g. *"Disabled mode: Solar Charging"* / *"Manual override: Solar Charging"* / *"Banned mode (cool-off): Greenhouse Heating"*)

### `24c3a2a` — mirror device-set auto-shutdown bans into the server's config

When the controller's watchdog auto-shutdown fires, the device writes the cool-off ban to its own KVS — but there's no device → server config feedback channel. Two visible consequences before this fix:

1. **Mode Enablement panel showed the affected mode as "allowed"** instead of "⏸ cool-off — Xh Ym" (the cool-off TTL display already exists in `renderModeEnablement`, but the `watchdog-state` broadcast it reads from is sourced from the server's empty mirror).
2. **The next config republish silently clobbered the device's auto-set ban** back to nothing — the ban was effectively lost.

`_handleResolved` now intercepts `how=shutdown_auto`, mirrors the same `wb` entry into the server's deviceConfig via the existing `_updateConfigAndPublish`, and lets the existing `_broadcastState()` push the corrected snapshot to UIs. The audit row that the previous commit added is still written first, so even a mirror-update failure leaves a System Logs entry behind.

Also adds a `CLAUDE.md` section about expanding short codes (`wb` → "mode-ban map", `EH` → "Emergency Heating mode", `ggr` → "Greenhouse growth-rate watchdog", etc.) when communicating with users — the compact form exists for the Shelly KVS 256-byte budget, not for prose.

## Test plan

- [x] `tests/config-events-diff.test.js` — pure diff helper (12 cases)
- [x] `tests/format-config-entry.test.mjs` — label rendering (11 cases)
- [x] `tests/anomaly-manager.test.js` — `shutdown_auto` mirror + `shutdown_user` skip (2 new cases)
- [x] `tests/frontend/live-logs.spec.js` — config-events rows render alongside mode transitions, interleaved by ts
- [x] Existing copy-logs + anomaly-manager suites pass
- [x] `npm run test:unit` 876/876 pass
- [x] `npm run test:e2e` 4/4 pass
- [x] `npm run lint`, `knip`, `check:file-size --strict`, `check:assets --strict` all clean

https://claude.ai/code/session_01YP3StmkbK6FmTxECfRTv59

---
_Generated by [Claude Code](https://claude.ai/code/session_01YP3StmkbK6FmTxECfRTv59)_