### PR TITLE
playground: data-sync framework for Android background→resume

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ This codebase is dense with short codes — `wb`, `mo`, `ce`, `ea`, `we`, `wz` (
 - `system.yaml` — authoritative hardware spec
 - `shelly/` — device scripts (`control.js`, `control-logic.js`, `telemetry.js`, `deploy.sh`)
 - `shelly/lint/` — Shelly platform conformance linter (standalone Node.js CLI, Acorn-based)
-- `playground/` — SPA/PWA: 5 hash-routed views (`#status`, `#components`, `#controls`, `#device`, `#settings`). Passkey-protected in cloud mode. Legacy `#schematic` → `#components` and `#sensors` → `#device` aliases live in `js/actions/navigation.js`.
+- `playground/` — SPA/PWA: 5 hash-routed views (`#status`, `#components`, `#controls`, `#device`, `#settings`). Passkey-protected in cloud mode. Legacy `#schematic` → `#components` and `#sensors` → `#device` aliases live in `js/actions/navigation.js`. Cross-cutting **data-sync framework** in `playground/js/sync/` — new full-stack features that fetch from the server should register a source there so they refresh automatically on Android resume / focus / network recovery (see `playground/js/sync/README.md`).
 - `playground/public/` — assets served without auth (login page, shared CSS/font, libraries needed by unauthenticated views). The server whitelists `/public/*`, so anything placed here is reachable without a session — do not put sensitive data here.
 - `playground/vendor/` — vendored third-party libraries for authed views (see Critical Rules)
 - `server/` — Node.js API: HTTP + WebSocket + MQTT bridge + auth + device/sensor config + history + push notifications

--- a/knip.json
+++ b/knip.json
@@ -42,6 +42,7 @@
     "js-yaml"
   ],
   "ignoreUnresolved": [
-    "/playground/js/app-state.js"
+    "/playground/js/app-state.js",
+    "/playground/js/main/display-update.js"
   ]
 }

--- a/playground/js/app-state.js
+++ b/playground/js/app-state.js
@@ -49,6 +49,14 @@ export const store = createStore({
 
   // Internal: staleness tick for periodic re-evaluation
   _staleTick: 0,
+
+  // Sync coordinator (./sync/coordinator.js). `syncing` is true from
+  // the moment a resync is triggered (visibility/pageshow/online) until
+  // every active data source has settled. `syncReason` is the trigger
+  // tag — UI components that distinguish between e.g. user-initiated
+  // refresh and Android background-resume can read it.
+  syncing: false,
+  syncReason: null,
 });
 
 /**
@@ -88,6 +96,12 @@ export const derived = {
 
   get connectionDisplay() {
     if (store.get('phase') !== 'live') return 'active';
+
+    // A resync is in flight (Android resume / network recovery / user
+    // returned focus). Surface as a single 'syncing' state so the
+    // overlay + banner unify into one transition instead of the old
+    // "blur clears, then banner clears" two-step.
+    if (store.get('syncing')) return 'syncing';
 
     const ws = store.get('wsStatus');
     const mqtt = store.get('mqttStatus');

--- a/playground/js/main.js
+++ b/playground/js/main.js
@@ -171,6 +171,11 @@ async function init() {
 
   // Start polling for JS source updates
   startVersionCheck();
+
+  // Test hook — frontend specs poll this to know that init() has
+  // wired everything (initConnection + initModeToggle, in
+  // particular). Same pattern as window.__getHistoryPointCount.
+  window.__initComplete = true;
 }
 
 function buildFallbackConfig() {

--- a/playground/js/main/balance-card.js
+++ b/playground/js/main/balance-card.js
@@ -19,6 +19,7 @@ import {
   editorialNightSentence,
 } from '../energy-balance.js';
 import { helsinkiParts } from './time-format.js';
+import { registerDataSource } from '../sync/registry.js';
 
 const HELSINKI_TZ = 'Europe/Helsinki';
 const fmtWindowClock = new Intl.DateTimeFormat('en-GB', {
@@ -77,24 +78,46 @@ export function resetBalanceState() {
   liveYesterdayHigh = null;
 }
 
+// Fetcher: returns Promise<data>. AbortSignal honoured so the sync
+// coordinator can cancel an in-flight request on overlapping resyncs.
+function balanceHistoryFetch(signal) {
+  return fetch('/api/history?range=48h', { signal }).then(r => r.json());
+}
+
+// Applier: idempotent write of the 48h snapshot into module state +
+// re-render. Resets the live-tail buffers because the fresh history
+// already covers everything they were tracking.
+function applyBalanceHistory(data) {
+  if (store.get('phase') !== 'live') return;
+  balanceHistory = data;
+  balanceLivePoints = [];
+  balanceLiveEvents = [];
+  balanceLiveLastMode = null;
+  liveYesterdayHigh = computeLiveYesterdayHigh(data && data.points);
+  renderBalanceCard();
+  // Balance fetch completes independently of the WS state stream,
+  // so re-render so the peak label reflects the freshly-computed
+  // yesterdayHigh instead of waiting for the next state frame.
+  _onRerender();
+}
+
 export function fetchBalanceHistory() {
   if (store.get('phase') !== 'live') return;
-  fetch('/api/history?range=48h')
-    .then(r => r.json())
-    .then(data => {
-      if (store.get('phase') !== 'live') return;
-      balanceHistory = data;
-      balanceLivePoints = [];
-      balanceLiveEvents = [];
-      balanceLiveLastMode = null;
-      liveYesterdayHigh = computeLiveYesterdayHigh(data && data.points);
-      renderBalanceCard();
-      // Balance fetch completes independently of the WS state stream,
-      // so re-render so the peak label reflects the freshly-computed
-      // yesterdayHigh instead of waiting for the next state frame.
-      _onRerender();
-    })
+  balanceHistoryFetch()
+    .then(applyBalanceHistory)
     .catch(() => { balanceHistory = null; });
+}
+
+// Register the balance-history source with the sync coordinator so
+// Android resume / network recovery / focus events refresh the
+// 48h energy-balance card alongside the rest of the view.
+export function registerBalanceHistorySource() {
+  return registerDataSource({
+    id: 'balance-history',
+    isActive: () => store.get('phase') === 'live',
+    fetch: (signal) => balanceHistoryFetch(signal),
+    applyToStore: (data) => applyBalanceHistory(data),
+  });
 }
 
 // Peak tank average ((tank_top + tank_bottom) / 2) across points whose

--- a/playground/js/main/connection.js
+++ b/playground/js/main/connection.js
@@ -14,12 +14,15 @@
 
 import { LiveSource, SimulationSource } from '../data-source.js';
 import { store } from '../app-state.js';
+import { initSyncCoordinator } from '../sync/coordinator.js';
 import { attachScriptStatusWebSocket } from '../actions/script-monitor.js';
 import { graphRange, timeSeriesStore, running } from './state.js';
 import { attachWatchdogWebSocket } from './watchdog-ui.js';
 import { handleOverrideResponse, updateRelayBoard } from './relay-board.js';
 import { updateDrainageControl } from './drainage-control.js';
-import { updateDisplay, setLiveFrameSeen } from './display-update.js';
+import {
+  updateDisplay, setLiveFrameSeen, rerenderWithHistoryFallback,
+} from './display-update.js';
 import { drawHistoryGraph } from './history-graph.js';
 import {
   transitionLog, fetchLiveEvents, resetEventsState,
@@ -27,8 +30,12 @@ import {
 import {
   fetchBalanceHistory, renderBalanceCard,
   resetLiveYesterdayHigh, resetBalanceState,
+  registerBalanceHistorySource,
 } from './balance-card.js';
-import { fetchLiveHistory, clearLiveHistoryData } from './live-history.js';
+import {
+  fetchLiveHistory, clearLiveHistoryData,
+  registerLiveHistorySource,
+} from './live-history.js';
 
 // Detect deployment context: GitHub Pages = simulation only, deployed app = live capable
 // `window.__simulateGitHubPagesDeploy` is a test-only hatch (set via
@@ -60,6 +67,52 @@ export function getLiveSource() { return liveSource; }
 
 export function initConnection({ setRunning } = {}) {
   if (typeof setRunning === 'function') _setRunning = setRunning;
+
+  // Register the live-mode data sources with the sync registry. Both
+  // sources are gated on phase === 'live' so they're inert in
+  // simulation mode without anything having to deregister them.
+  registerLiveHistorySource(() => graphRange);
+  registerBalanceHistorySource();
+
+  // Repaint connection indicator + overlays the moment store.syncing
+  // flips. This is what collapses the old "blur clears, then banner
+  // clears" two-step into a single transition: the syncing → active
+  // edge fires one repaint, both elements update together.
+  store.subscribe('syncing', function () {
+    if (store.get('phase') !== 'live') return;
+    refreshConnectionIndicator();
+    updateConnectionOverlays();
+    updateSidebarSubtitle();
+    // Drop the staleness banner immediately on syncing=true; the
+    // unified overlay takes over.
+    const banner = document.getElementById('staleness-banner');
+    if (banner && store.get('syncing')) banner.classList.remove('visible');
+  });
+
+  // Wire visibility / pageshow / online listeners. On every resume,
+  // reset the live-frame flag so the UI falls back to the fresh
+  // history snapshot until a new WS frame lands (otherwise the
+  // pre-background `lastState` would feed stale temperatures + wrong
+  // trend arrows). On completion, re-render to pick up the freshly
+  // applied data even if no WS frame has arrived yet.
+  initSyncCoordinator({
+    onResyncStart: function () {
+      if (store.get('phase') !== 'live') return;
+      setLiveFrameSeen(false);
+      // Reset the staleness clock so the banner doesn't briefly
+      // re-flash 'stale' between syncing → active.
+      lastDataTime = Date.now();
+    },
+    onResyncComplete: function () {
+      if (store.get('phase') !== 'live') return;
+      rerenderWithHistoryFallback();
+      // Repaint the connection indicator + overlays now that
+      // store.syncing has flipped back to false.
+      refreshConnectionIndicator();
+      updateConnectionOverlays();
+      updateSidebarSubtitle();
+    },
+  });
 }
 
 function updateConnectionUI(status) {
@@ -86,6 +139,10 @@ function refreshConnectionIndicator() {
       dot.className = 'connection-dot connected';
       label.textContent = 'Live';
       break;
+    case 'syncing':
+      dot.className = 'connection-dot reconnecting';
+      label.textContent = 'Syncing…';
+      break;
     case 'connecting':
       dot.className = 'connection-dot reconnecting';
       label.textContent = 'Connecting…';
@@ -108,8 +165,16 @@ function checkStaleness() {
   if (store.get('phase') !== 'live') return;
   const banner = document.getElementById('staleness-banner');
   if (banner) {
+    // Suppress the banner while a resync is in flight — the
+    // unified syncing overlay already communicates the catch-up
+    // state. Otherwise the banner would briefly show "stale" right
+    // before fresh data arrives, repeating the old two-step UX.
+    const syncing = !!store.get('syncing');
     const elapsed = Date.now() - lastDataTime;
-    banner.classList.toggle('visible', elapsed > 60000 && lastDataTime > 0);
+    banner.classList.toggle(
+      'visible',
+      !syncing && elapsed > 60000 && lastDataTime > 0,
+    );
   }
   refreshConnectionIndicator();
   updateConnectionOverlays();
@@ -137,11 +202,23 @@ const OVERLAY_MESSAGES = {
   stale: {
     title: 'Your sanctuary has gone quiet.',
     subtitle: 'No data received for over 60 seconds.'
-  }
+  },
+  // 'syncing' deliberately renders without the heavy
+  // backdrop-blur copy block. It marks the overlays with
+  // .connection-overlay--syncing instead, so style.css can apply a
+  // light "Syncing…" pill while leaving the cards readable. This
+  // gives a graceful fallback during the Android-resume re-fetch
+  // instead of the old fully-blurred + banner combo.
+  syncing: { title: '', subtitle: '', light: true }
 };
 
 function getConnectionDisplayState() {
   if (store.get('phase') !== 'live') return 'active';
+  // A resync is in flight (Android resume / network recovery / focus).
+  // Surface as a single 'syncing' state so the overlay + banner
+  // unify into one transition. Cleared by onResyncComplete via
+  // store.syncing → false.
+  if (store.get('syncing')) return 'syncing';
   const hasData = liveSource && liveSource.hasReceivedData;
   const mqttStatus = liveSource ? liveSource.mqttStatus : 'unknown';
 
@@ -178,12 +255,17 @@ function updateConnectionOverlays() {
     if (!overlay) continue;
     if (msg) {
       overlay.classList.add('visible');
+      // Light variant: the syncing state shows last-known values
+      // through a subtle Syncing… pill instead of the full
+      // backdrop-blur copy block. Cards stay readable.
+      overlay.classList.toggle('connection-overlay--syncing', !!msg.light);
       const titleEl = document.getElementById(overlayIds[i] + '-title');
       const subtitleEl = document.getElementById(overlayIds[i] + '-subtitle');
       if (titleEl) titleEl.textContent = msg.title;
       if (subtitleEl) subtitleEl.textContent = msg.subtitle;
     } else {
       overlay.classList.remove('visible');
+      overlay.classList.remove('connection-overlay--syncing');
     }
   }
 }
@@ -413,6 +495,10 @@ export function updateSidebarSubtitle() {
     case 'active':
       el.textContent = 'Live';
       el.className = 'subtitle-live';
+      break;
+    case 'syncing':
+      el.textContent = 'Syncing…';
+      el.className = 'subtitle-connecting';
       break;
     case 'connecting':
       el.textContent = 'Connecting…';

--- a/playground/js/main/display-update.js
+++ b/playground/js/main/display-update.js
@@ -119,6 +119,10 @@ let lastDay = 0;
 export function setSchematicHandle(h) { schematicHandle = h; }
 export function getLastFrame() { return { state: lastState, result: lastResult }; }
 export function setLiveFrameSeen(v) { liveFrameSeen = v; }
+// Test hook — frontend specs use it to verify the sync coordinator's
+// onResyncStart hook actually clears the flag, which is the seam
+// that fixes the Android wrong-direction-arrow bug.
+window.__getLiveFrameSeen = function () { return liveFrameSeen; };
 export function resetYesterdayTracking() {
   yesterdayHigh = 0;
   confirmedYesterdayHigh = 0;

--- a/playground/js/main/live-history.js
+++ b/playground/js/main/live-history.js
@@ -1,9 +1,14 @@
 // Live-mode history fetch + live-frame append. Extracted from main.js.
 //
-// - fetchLiveHistory(rangeSeconds): pulls /api/history?range=<key>,
-//   loads the response into the shared timeSeriesStore, redraws the
-//   graph, and invokes onRerender so the gauge / trend arrows catch
-//   up without waiting for the next WS frame.
+// - fetchLiveHistory(rangeSeconds): user-triggered (mode-switch, range
+//   slider). Pulls /api/history?range=<key>, applies into the shared
+//   timeSeriesStore, redraws the graph, re-renders the gauge / trend
+//   arrows. Internally split into liveHistoryFetch (async fetch only)
+//   and applyLiveHistory (sync store-write + redraw) so the sync
+//   coordinator can drive the same path on Android resume.
+// - registerLiveHistorySource(getRange): registers the live-history
+//   data source with the sync registry so visibility / pageshow /
+//   online events automatically refresh the graph.
 // - recordLiveHistoryPoint(state, result): appends a single live
 //   frame (rate-limited to ~5 s) so the sliding window advances
 //   between /api/history fetches.
@@ -12,6 +17,7 @@ import { store } from '../app-state.js';
 import { timeSeriesStore } from './state.js';
 import { drawHistoryGraph } from './history-graph.js';
 import { rerenderWithHistoryFallback } from './display-update.js';
+import { registerDataSource } from '../sync/registry.js';
 
 const RANGE_MAP = {
   3600: '1h', 21600: '6h', 43200: '12h', 86400: '24h',
@@ -22,26 +28,53 @@ let liveHistoryData = null;
 
 export function clearLiveHistoryData() { liveHistoryData = null; }
 
+function rangeKeyFor(rangeSeconds) {
+  return RANGE_MAP[rangeSeconds] || '6h';
+}
+
+// Fetcher: returns Promise<data> or rejects. Honours AbortSignal so
+// the sync coordinator can cancel an in-flight request when a newer
+// resync supersedes it.
+function liveHistoryFetch(rangeSeconds, signal) {
+  return fetch('/api/history?range=' + rangeKeyFor(rangeSeconds), { signal })
+    .then(r => r.json());
+}
+
+// Applier: writes data into the shared store + redraws. Idempotent.
+function applyLiveHistory(data) {
+  // Phase guard — the user may have flipped to simulation while the
+  // fetch was in flight, in which case dumping live data into the
+  // store would clobber the simulation history.
+  if (store.get('phase') !== 'live') return;
+  liveHistoryData = data;
+  loadLiveHistoryIntoStore(data);
+  drawHistoryGraph();
+  // The history fetch is async; the first WebSocket state frame may
+  // have already rendered the UI with empty trend arrows (because the
+  // store was empty at that moment). Re-render now so trends and the
+  // tank-avg gauge reflect the freshly-loaded 15-min window instead
+  // of waiting for the next ~1 Hz WS frame to trigger a refresh.
+  rerenderWithHistoryFallback();
+}
+
 export function fetchLiveHistory(rangeSeconds) {
   if (store.get('phase') !== 'live') return;
-  const rangeKey = RANGE_MAP[rangeSeconds] || '6h';
-  fetch('/api/history?range=' + rangeKey)
-    .then(r => r.json())
-    .then(data => {
-      // Only apply to the current phase — the user may have switched
-      // back to simulation while the request was in flight.
-      if (store.get('phase') !== 'live') return;
-      liveHistoryData = data;
-      loadLiveHistoryIntoStore(data);
-      drawHistoryGraph();
-      // The history fetch is async; the first WebSocket state frame may
-      // have already rendered the UI with empty trend arrows (because the
-      // store was empty at that moment). Re-render now so trends and the
-      // tank-avg gauge reflect the freshly-loaded 15-min window instead
-      // of waiting for the next ~1 Hz WS frame to trigger a refresh.
-      rerenderWithHistoryFallback();
-    })
+  liveHistoryFetch(rangeSeconds)
+    .then(applyLiveHistory)
     .catch(() => { liveHistoryData = null; });
+}
+
+// Wires this module into the sync coordinator so visibilitychange /
+// pageshow / online trigger a re-fetch of the current range.
+// `getRange` is a thunk that returns the live graph range so the
+// registered source always picks up the user's current selection.
+export function registerLiveHistorySource(getRange) {
+  return registerDataSource({
+    id: 'live-history',
+    isActive: () => store.get('phase') === 'live',
+    fetch: (signal) => liveHistoryFetch(getRange(), signal),
+    applyToStore: (data) => applyLiveHistory(data),
+  });
 }
 
 // Convert /api/history response into timeSeriesStore format.

--- a/playground/js/sync/README.md
+++ b/playground/js/sync/README.md
@@ -1,0 +1,74 @@
+# Frontend data-sync framework
+
+Small registry + coordinator that handles the "browser was paused, now we're back" problem so individual feature modules don't each have to.
+
+## When to use
+
+Any time a feature has its own server-side data source (an HTTP endpoint, a WebSocket frame, etc.) whose data ends up in the UI. Without registering, the feature won't refresh on:
+
+- Android backgrounding / Chrome timer suspension (the WebSocket may stay open but deliver no data, so the cached state on screen drifts from reality);
+- Network drops + recovery;
+- The user switching back to the tab.
+
+## How to plug in
+
+Three steps, mirroring the registry shape (`registry.js`):
+
+### 1. Server: add the endpoint or WS message
+
+Whatever your feature needs. No coordinator changes here — the coordinator only cares about how the client refreshes.
+
+### 2. Client fetch: register a data source
+
+In your feature's init path:
+
+```js
+import { registerDataSource } from '../sync/registry.js';
+import { store } from '../app-state.js';
+
+registerDataSource({
+  id: 'my-feature',                     // unique
+  isActive: () => store.get('phase') === 'live',
+  fetch: (signal) => fetch('/api/my-feature', { signal }).then(r => r.json()),
+  applyToStore: (data) => {
+    // Atomic write into your module-local state or the central store.
+    // Idempotent — applyToStore may be called many times over an app's
+    // lifetime, once per resync the source is active for.
+    myModuleState = data;
+    rerender();
+  },
+});
+```
+
+`fetch(signal)` MUST honour the AbortSignal: when a second resync starts before the first finishes (e.g. the user resumes, then immediately the network reconnects), the coordinator aborts the first. If your fetch ignores the signal, `applyToStore` for the stale fetch will be skipped (the coordinator drops it), but the network request continues — which is wasteful and can cause out-of-order data writes if you're not careful.
+
+### 3. Display: subscribe to your store keys
+
+Your DOM components subscribe to whichever store keys (or module-local re-render hook) `applyToStore` writes into. Components do NOT touch `visibilitychange` / `online` / WebSocket lifecycle themselves — that's the coordinator's job.
+
+## Lifecycle
+
+The coordinator listens for `visibilitychange` (visible), `pageshow` (bfcache restore), and `online`. On any of those:
+
+1. Aborts any in-flight resync.
+2. Sets `store.syncing = true`. Components that want a "syncing…" affordance can subscribe to this key.
+3. Calls `onResyncStart(reason)` (set up once at app boot in `connection.js`). Used to reset stale-frame flags.
+4. Runs every active source's `fetch(signal)` in parallel.
+5. For each that resolves un-aborted, calls `applyToStore(data)`.
+6. Sets `store.syncing = false` and calls `onResyncComplete(reason)`.
+
+## What NOT to put here
+
+- WebSocket message replay. We deliberately don't do server-side "send everything since seq N" — re-fetching from `/api/history` (or your endpoint) on resume is sufficient because `sensor_readings_30s` is the source of truth for graphed data anyway. Adding replay would buy us second-resolution accuracy across the gap, at the cost of protocol complexity. Talk to a maintainer before introducing it.
+- Per-component fetch retry policies. The coordinator runs sources once per resume; if a source fails the user sees the previous data until the next resume. Don't add a hidden retry loop — it tends to mask real outages.
+
+## Tests
+
+- `tests/frontend/sync-registry.spec.js` — contract test. Future contributors who change the API need to keep this green. It exercises:
+  - `registerDataSource` rejecting malformed specs and duplicate ids
+  - `isActive()` being honoured
+  - `fetch(signal)` getting an AbortSignal that aborts on overlap
+  - `applyToStore` running exactly once per resolved fetch (and not at all if aborted)
+  - the `syncing` store flag toggling around the resync window
+  - one source failing not blocking the others
+- `tests/frontend/visibility-resync.spec.js` — behaviour test for the Android resume case.

--- a/playground/js/sync/coordinator.js
+++ b/playground/js/sync/coordinator.js
@@ -1,0 +1,150 @@
+// Sync coordinator.
+//
+// Owns the page-visibility / network-recovery seams the rest of the
+// app relies on. When the user backgrounds the tab on Android (or
+// loses network, or the browser pauses timers), the WebSocket may
+// keep its socket but not deliver fresh data; on resume we need to
+// re-fetch everything that has a registered data source so the cards,
+// graph, and trend arrows reflect reality instead of pre-background
+// values.
+//
+// Public API
+//   initSyncCoordinator({ onResyncStart, onResyncComplete })
+//     Wires the visibilitychange / pageshow / online listeners.
+//     Callbacks fire around each resync (see triggerResync below).
+//   triggerResync(reason)
+//     Public entry point — also invoked by the listeners above.
+//     Returns a Promise that resolves once every active source has
+//     settled (or aborted by a newer resync).
+//   _resetForTests()
+//     Tears down listeners + aborts in-flight work. Test-only.
+//
+// Lifecycle of a single resync
+//   1. If a resync is in flight, abort it (its sources see signal.aborted
+//      and bail out). The caller's Promise resolves with `{ aborted: true }`.
+//   2. Set store.syncing = true.
+//   3. Call onResyncStart(reason). Use this to reset stale-frame flags
+//      so the UI falls back to the synthesised "last history point"
+//      rendering until fresh data lands.
+//   4. Run every spec.isActive() source's spec.fetch(signal) in
+//      parallel. Failures and aborts are swallowed — one source falling
+//      over must not freeze the others.
+//   5. For each source whose fetch resolved un-aborted, run
+//      spec.applyToStore(data).
+//   6. Set store.syncing = false.
+//   7. Call onResyncComplete(reason).
+
+import { _registeredSources } from './registry.js';
+import { store } from '../app-state.js';
+
+let currentController = null;
+let _onResyncStart = function () {};
+let _onResyncComplete = function () {};
+let _listeners = null;
+
+export function initSyncCoordinator(opts) {
+  const { onResyncStart, onResyncComplete } = opts || {};
+  if (typeof onResyncStart === 'function') _onResyncStart = onResyncStart;
+  if (typeof onResyncComplete === 'function') _onResyncComplete = onResyncComplete;
+
+  if (_listeners) return; // idempotent — main.js init can be re-entered in tests
+
+  function onVisibility() {
+    if (typeof document !== 'undefined' && document.visibilityState === 'visible') {
+      triggerResync('visibility');
+    }
+  }
+  function onPageShow(e) {
+    // Only re-fetch on bfcache restore. A non-persisted pageshow is
+    // just the initial page load, which already kicks off its own
+    // data fetches via the live-mode init path.
+    if (e && e.persisted) triggerResync('pageshow');
+  }
+  function onOnline() { triggerResync('online'); }
+
+  document.addEventListener('visibilitychange', onVisibility);
+  window.addEventListener('pageshow', onPageShow);
+  window.addEventListener('online', onOnline);
+
+  _listeners = { onVisibility, onPageShow, onOnline };
+}
+
+function triggerResync(reason) {
+  if (currentController) currentController.abort();
+  const controller = new AbortController();
+  currentController = controller;
+
+  const all = _registeredSources();
+  const active = [];
+  for (let i = 0; i < all.length; i++) {
+    const src = all[i];
+    let alive = false;
+    try { alive = !!src.isActive(); }
+    catch (e) { console.error('[sync] isActive threw for', src.id, e); }
+    if (alive) active.push(src);
+  }
+
+  store.set('syncing', true);
+  store.set('syncReason', reason || null);
+  try { _onResyncStart(reason); }
+  catch (e) { console.error('[sync] onResyncStart threw:', e); }
+
+  if (active.length === 0) {
+    finishResync(controller);
+    return Promise.resolve({ aborted: false, ran: 0 });
+  }
+
+  const settles = active.map(function (src) {
+    return Promise.resolve()
+      .then(function () { return src.fetch(controller.signal); })
+      .then(function (data) {
+        if (controller.signal.aborted) return;
+        try { src.applyToStore(data); }
+        catch (e) { console.error('[sync] applyToStore threw for', src.id, e); }
+      })
+      .catch(function (e) {
+        if (controller.signal.aborted) return;
+        // Don't propagate — one bad source must not break the others.
+        console.warn('[sync] fetch failed for', src.id, e);
+      });
+  });
+
+  return Promise.all(settles).then(function () {
+    if (controller.signal.aborted) return { aborted: true, ran: active.length };
+    finishResync(controller);
+    return { aborted: false, ran: active.length };
+  });
+}
+
+function finishResync(controller) {
+  if (currentController === controller) {
+    currentController = null;
+    store.set('syncing', false);
+  }
+  try { _onResyncComplete(store.get('syncReason')); }
+  catch (e) { console.error('[sync] onResyncComplete threw:', e); }
+}
+
+function _resetForTests() {
+  if (currentController) currentController.abort();
+  currentController = null;
+  store.set('syncing', false);
+  store.set('syncReason', null);
+  if (_listeners) {
+    document.removeEventListener('visibilitychange', _listeners.onVisibility);
+    window.removeEventListener('pageshow', _listeners.onPageShow);
+    window.removeEventListener('online', _listeners.onOnline);
+    _listeners = null;
+  }
+  _onResyncStart = function () {};
+  _onResyncComplete = function () {};
+}
+
+// Test bridge. The frontend Playwright suite drives the coordinator
+// via window.__sync — see ./README.md. registry.js attaches its own
+// pieces; we attach ours here. Production code never reads it.
+if (typeof window !== 'undefined') {
+  window.__sync = window.__sync || {};
+  window.__sync.triggerResync = triggerResync;
+  window.__sync._resetForTests = _resetForTests;
+}

--- a/playground/js/sync/registry.js
+++ b/playground/js/sync/registry.js
@@ -1,0 +1,69 @@
+// Data-source registry for the playground UI.
+//
+// Components that fetch their own data over HTTP/WS register a small
+// spec here; the coordinator (./coordinator.js) re-runs every active
+// source on app re-focus / network recovery so the whole view catches
+// up in one round-trip instead of each component fetching on its own
+// schedule (or never, which is what happened on Android resume before
+// this module existed).
+//
+// A source spec is:
+//   {
+//     id:            string — unique. Throws on duplicate.
+//     fetch(signal): Promise<data>. Must honour the AbortSignal so
+//                    overlapping resyncs can cancel cleanly.
+//     applyToStore(data): writes data into shared state (timeSeriesStore,
+//                    component-local module state, …). Called only if
+//                    the signal is still un-aborted.
+//     isActive():    boolean. Sources whose `isActive()` is false are
+//                    skipped on a resync (e.g. live-only sources while
+//                    the user is in simulation mode).
+//   }
+//
+// The contract is exercised in tests/frontend/sync-registry.spec.js —
+// keep that suite green when changing the API.
+//
+// See ./README.md for the convention new full-stack features should
+// follow.
+
+const sources = new Map();
+
+export function registerDataSource(spec) {
+  if (!spec || typeof spec.id !== 'string' || !spec.id) {
+    throw new Error('registerDataSource: spec.id is required');
+  }
+  if (typeof spec.fetch !== 'function') {
+    throw new Error('registerDataSource: spec.fetch must be a function');
+  }
+  if (typeof spec.applyToStore !== 'function') {
+    throw new Error('registerDataSource: spec.applyToStore must be a function');
+  }
+  if (typeof spec.isActive !== 'function') {
+    throw new Error('registerDataSource: spec.isActive must be a function');
+  }
+  if (sources.has(spec.id)) {
+    throw new Error('registerDataSource: duplicate id "' + spec.id + '"');
+  }
+  sources.set(spec.id, spec);
+  return function unregister() { sources.delete(spec.id); };
+}
+
+// Internal accessor used by the coordinator. Returns a snapshot array
+// so a source unregistering mid-iteration cannot trip the loop.
+export function _registeredSources() {
+  return Array.from(sources.values());
+}
+
+function _clearAllForTests() {
+  sources.clear();
+}
+
+// Test bridge. The frontend Playwright suite drives the coordinator
+// via window.__sync (see ./README.md and tests/frontend/sync-*.spec.js).
+// Production code never reads it.
+if (typeof window !== 'undefined') {
+  window.__sync = window.__sync || {};
+  window.__sync.registerDataSource = registerDataSource;
+  window.__sync._registeredSources = _registeredSources;
+  window.__sync._clearAllForTests = _clearAllForTests;
+}

--- a/playground/public/style.css
+++ b/playground/public/style.css
@@ -1519,6 +1519,38 @@ button.primary:disabled {
   line-height: 1.5;
 }
 
+/* Light variant — used while the sync coordinator is re-fetching
+ * data after page-visibility / focus / online events. The full
+ * backdrop blur would hide the last-known values mid-resync; the
+ * light variant lets cards stay readable and shows a small Syncing…
+ * pill instead. Driven by .connection-overlay--syncing applied via
+ * connection.js.updateConnectionOverlays(). */
+.connection-overlay.connection-overlay--syncing {
+  background: transparent;
+  backdrop-filter: blur(2px);
+  -webkit-backdrop-filter: blur(2px);
+  pointer-events: none;
+  justify-content: flex-start;
+  padding-top: 12px;
+}
+.connection-overlay.connection-overlay--syncing .connection-overlay-title,
+.connection-overlay.connection-overlay--syncing .connection-overlay-subtitle {
+  display: none;
+}
+.connection-overlay.connection-overlay--syncing::before {
+  content: 'Syncing\2026';
+  font-family: 'Manrope', sans-serif;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: var(--on-surface);
+  background: rgba(17, 19, 25, 0.78);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 4px 12px;
+  border-radius: 999px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
+}
+
 /* ── Device Push Disabled State ── */
 
 button.primary.disabled {

--- a/tests/frontend/sync-registry.spec.js
+++ b/tests/frontend/sync-registry.spec.js
@@ -1,0 +1,206 @@
+// @ts-check
+//
+// Contract test for the sync registry + coordinator
+// (playground/js/sync/). This is the executable spec that future
+// full-stack features should pass when they plug into the same
+// framework — see playground/js/sync/README.md.
+//
+// Drives a fake data source through hide/show/online via
+// window.__sync, asserts:
+//   - registerDataSource() rejects bad specs
+//   - the coordinator runs only sources whose isActive() is true
+//   - fetch is called with an AbortSignal that aborts on overlap
+//   - applyToStore runs exactly once per resolved fetch (and not at
+//     all if the source's signal aborted)
+//   - the syncing store flag toggles around the resync window
+
+import { test, expect } from './fixtures.js';
+
+// Mock the API endpoints the production registered sources hit so a
+// page load doesn't spawn real network requests during these tests.
+async function mockApis(page) {
+  await page.route('**/api/history**', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({ points: [], events: [] }),
+  }));
+  await page.route('**/api/events**', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({ events: [], hasMore: false }),
+  }));
+}
+
+test.describe('sync registry + coordinator contract', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockApis(page);
+    await page.goto('/playground/');
+    // Wait for module-loaded test hook
+    await page.waitForFunction(() => typeof window.__sync === 'object');
+    // Clean slate: drop production-registered sources for the
+    // duration of this test, and abort anything in flight.
+    await page.evaluate(() => {
+      window.__sync._resetForTests();
+      window.__sync._clearAllForTests();
+    });
+  });
+
+  test('registerDataSource rejects malformed specs', async ({ page }) => {
+    const errors = await page.evaluate(() => {
+      const out = [];
+      const tries = [
+        {},
+        { id: 'x' },
+        { id: 'x', fetch: () => {} },
+        { id: 'x', fetch: () => {}, applyToStore: () => {} },
+      ];
+      for (const t of tries) {
+        try { window.__sync.registerDataSource(t); out.push(null); }
+        catch (e) { out.push(String(e.message)); }
+      }
+      // Duplicate id is also rejected.
+      window.__sync.registerDataSource({
+        id: 'dupe',
+        fetch: () => Promise.resolve(),
+        applyToStore: () => {},
+        isActive: () => true,
+      });
+      try {
+        window.__sync.registerDataSource({
+          id: 'dupe',
+          fetch: () => Promise.resolve(),
+          applyToStore: () => {},
+          isActive: () => true,
+        });
+        out.push(null);
+      } catch (e) { out.push(String(e.message)); }
+      return out;
+    });
+    expect(errors[0]).toMatch(/spec.id is required/);
+    expect(errors[1]).toMatch(/spec.fetch must be a function/);
+    expect(errors[2]).toMatch(/spec.applyToStore must be a function/);
+    expect(errors[3]).toMatch(/spec.isActive must be a function/);
+    expect(errors[4]).toMatch(/duplicate id "dupe"/);
+  });
+
+  test('coordinator runs only active sources', async ({ page }) => {
+    const result = await page.evaluate(async () => {
+      const calls = { active: 0, inactive: 0, applied: { active: 0, inactive: 0 } };
+      window.__sync.registerDataSource({
+        id: 'active-src',
+        isActive: () => true,
+        fetch: () => { calls.active++; return Promise.resolve('A'); },
+        applyToStore: () => { calls.applied.active++; },
+      });
+      window.__sync.registerDataSource({
+        id: 'inactive-src',
+        isActive: () => false,
+        fetch: () => { calls.inactive++; return Promise.resolve('B'); },
+        applyToStore: () => { calls.applied.inactive++; },
+      });
+      const summary = await window.__sync.triggerResync('test');
+      return { calls, summary };
+    });
+    expect(result.calls.active).toBe(1);
+    expect(result.calls.inactive).toBe(0);
+    expect(result.calls.applied.active).toBe(1);
+    expect(result.calls.applied.inactive).toBe(0);
+    expect(result.summary.aborted).toBe(false);
+    expect(result.summary.ran).toBe(1);
+  });
+
+  test('fetch receives an AbortSignal; overlapping resyncs abort the first', async ({ page }) => {
+    const result = await page.evaluate(async () => {
+      let release;
+      const gate = new Promise(r => { release = r; });
+      let fetchCount = 0;
+      const firstSignalAborted = { value: null };
+      let appliedCount = 0;
+
+      window.__sync.registerDataSource({
+        id: 'slow-src',
+        isActive: () => true,
+        fetch: (signal) => {
+          const idx = fetchCount++;
+          return gate.then(() => {
+            // Snapshot only the FIRST call's signal — the second
+            // call's signal is fresh and won't be aborted.
+            if (idx === 0) firstSignalAborted.value = signal.aborted;
+            return 'data-' + idx;
+          });
+        },
+        applyToStore: () => { appliedCount++; },
+      });
+
+      // Trigger first resync — fetch hangs on the gate.
+      const firstPromise = window.__sync.triggerResync('first');
+      // Trigger a second resync — aborts the first.
+      const secondPromise = window.__sync.triggerResync('second');
+      // Now release the gate so both .then callbacks fire.
+      release();
+      const firstSummary = await firstPromise;
+      const secondSummary = await secondPromise;
+      return { firstSignalAborted: firstSignalAborted.value, appliedCount, firstSummary, secondSummary };
+    });
+    // First call's signal flipped aborted by the time its .then() ran.
+    expect(result.firstSignalAborted).toBe(true);
+    // applyToStore runs once: only for the un-aborted second call.
+    expect(result.appliedCount).toBe(1);
+    expect(result.firstSummary.aborted).toBe(true);
+    expect(result.secondSummary.aborted).toBe(false);
+  });
+
+  test('store.syncing toggles around a resync window', async ({ page }) => {
+    const transitions = await page.evaluate(async () => {
+      // Hold the fetch open so we can observe `syncing === true`
+      // mid-flight before the resync resolves.
+      let release;
+      const gate = new Promise(r => { release = r; });
+      const observed = [];
+      const mod = await import('/playground/js/app-state.js');
+      mod.store.subscribe('syncing', v => observed.push(v));
+
+      window.__sync.registerDataSource({
+        id: 'gate-src',
+        isActive: () => true,
+        fetch: () => gate,
+        applyToStore: () => {},
+      });
+
+      const before = mod.store.get('syncing');
+      const p = window.__sync.triggerResync('test');
+      const during = mod.store.get('syncing');
+      release(true);
+      await p;
+      const after = mod.store.get('syncing');
+      return { before, during, after, observed };
+    });
+    expect(transitions.before).toBe(false);
+    expect(transitions.during).toBe(true);
+    expect(transitions.after).toBe(false);
+    // Subscriber observed both edges.
+    expect(transitions.observed).toEqual([true, false]);
+  });
+
+  test('one source failing does not block the others', async ({ page }) => {
+    const result = await page.evaluate(async () => {
+      const applied = { good: 0, bad: 0 };
+      window.__sync.registerDataSource({
+        id: 'bad-src',
+        isActive: () => true,
+        fetch: () => Promise.reject(new Error('boom')),
+        applyToStore: () => { applied.bad++; },
+      });
+      window.__sync.registerDataSource({
+        id: 'good-src',
+        isActive: () => true,
+        fetch: () => Promise.resolve('ok'),
+        applyToStore: () => { applied.good++; },
+      });
+      await window.__sync.triggerResync('test');
+      return applied;
+    });
+    expect(result.bad).toBe(0);
+    expect(result.good).toBe(1);
+  });
+});

--- a/tests/frontend/sync-registry.spec.js
+++ b/tests/frontend/sync-registry.spec.js
@@ -35,8 +35,12 @@ test.describe('sync registry + coordinator contract', () => {
   test.beforeEach(async ({ page }) => {
     await mockApis(page);
     await page.goto('/playground/');
-    // Wait for module-loaded test hook
-    await page.waitForFunction(() => typeof window.__sync === 'object');
+    // Wait for init() to FULLY complete (window.__initComplete set
+    // at the last line of main.js init). Without this, production
+    // sources registered inside initConnection sneak into the
+    // registry mid-test and get fetched alongside the fake source,
+    // blowing source-count assertions.
+    await page.waitForFunction(() => window.__initComplete === true);
     // Clean slate: drop production-registered sources for the
     // duration of this test, and abort anything in flight.
     await page.evaluate(() => {

--- a/tests/frontend/visibility-resync.spec.js
+++ b/tests/frontend/visibility-resync.spec.js
@@ -9,6 +9,18 @@
 
 import { test, expect } from './fixtures.js';
 
+// Wait for init() to have wired up the sync framework end-to-end.
+// `window.__sync` exists at module-load time (registry attaches its
+// bridge eagerly), so polling for it isn't strong enough — under CI
+// parallelism the test can race past it before initConnection has
+// registered the production sources or initSyncCoordinator has
+// captured the onResyncStart hook. We wait on `window.__initComplete`,
+// set at the very last line of main.js init(), which guarantees every
+// subsequent wiring step has already run.
+async function waitForSyncReady(page) {
+  await page.waitForFunction(() => window.__initComplete === true);
+}
+
 test.describe('visibility resync', () => {
   test.beforeEach(async ({ page }) => {
     await page.route('**/api/events**', route => route.fulfill({
@@ -27,7 +39,7 @@ test.describe('visibility resync', () => {
       });
     });
     await page.goto('/playground/');
-    await page.waitForFunction(() => typeof window.__sync === 'object');
+    await waitForSyncReady(page);
     // Wait for the initial live-mode fetch (1h, 6h, …) to land
     // before counting subsequent ones — it varies by range +
     // balance card so we just snapshot the count and look for
@@ -67,16 +79,7 @@ test.describe('visibility resync', () => {
       });
     });
     await page.goto('/playground/');
-    await page.waitForFunction(() => typeof window.__sync === 'object');
-
-    // Wait for init() to complete so the connection.js syncing
-    // subscribe is wired before we flip the flag. The signal is
-    // phase === 'live' (set by initModeToggle, which runs after
-    // initConnection registers the subscribe).
-    await page.waitForFunction(async () => {
-      const mod = await import('/playground/js/app-state.js');
-      return mod.store.get('phase') === 'live';
-    });
+    await waitForSyncReady(page);
 
     // Trigger a resync directly (production path is the visibility
     // listener; we use the coordinator API to keep the test focused
@@ -124,7 +127,7 @@ test.describe('visibility resync', () => {
       });
     });
     await page.goto('/playground/');
-    await page.waitForFunction(() => typeof window.__sync === 'object');
+    await waitForSyncReady(page);
 
     // Pretend a live frame has already arrived so we have something
     // to observe getting reset. setLiveFrameSeen lives in

--- a/tests/frontend/visibility-resync.spec.js
+++ b/tests/frontend/visibility-resync.spec.js
@@ -1,0 +1,151 @@
+// @ts-check
+//
+// Behaviour test for the Android "background → resume" data-sync
+// path. Asserts the user-visible repair: when the page is backgrounded
+// and brought back, /api/history is re-fetched, the unified syncing
+// overlay (no heavy blur, no separate banner) shows during the catch-
+// up, and the live-frame flag is reset so the trend arrows draw off
+// fresh data instead of pre-background lastState.
+
+import { test, expect } from './fixtures.js';
+
+test.describe('visibility resync', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/api/events**', route => route.fulfill({
+      status: 200, contentType: 'application/json',
+      body: JSON.stringify({ events: [], hasMore: false }),
+    }));
+  });
+
+  test('hide → show triggers a /api/history re-fetch', async ({ page }) => {
+    let historyHits = 0;
+    await page.route('**/api/history**', route => {
+      historyHits++;
+      route.fulfill({
+        status: 200, contentType: 'application/json',
+        body: JSON.stringify({ points: [], events: [] }),
+      });
+    });
+    await page.goto('/playground/');
+    await page.waitForFunction(() => typeof window.__sync === 'object');
+    // Wait for the initial live-mode fetch (1h, 6h, …) to land
+    // before counting subsequent ones — it varies by range +
+    // balance card so we just snapshot the count and look for
+    // increases.
+    await page.waitForTimeout(200);
+    const baseline = historyHits;
+
+    // Simulate Android resume: visibility goes hidden then visible.
+    // Playwright doesn't expose visibilitychange directly, but
+    // dispatching the event manually is what the coordinator listens
+    // for, and the handler reads document.visibilityState — we
+    // override it for the test window.
+    await page.evaluate(() => {
+      Object.defineProperty(document, 'visibilityState', { configurable: true, get: () => 'visible' });
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    // The coordinator's resync is async — wait for the syncing flag
+    // to flip back to false, then assert hits increased.
+    await page.waitForFunction(async () => {
+      const mod = await import('/playground/js/app-state.js');
+      return mod.store.get('syncing') === false;
+    }, undefined, { timeout: 5000 });
+    expect(historyHits).toBeGreaterThan(baseline);
+  });
+
+  test('syncing overlay uses light variant, not full blur', async ({ page }) => {
+    // Hold history fetches open so we can observe the overlay
+    // mid-resync. We resolve them at the end of the test.
+    let releaseHistory;
+    const historyGate = new Promise(r => { releaseHistory = r; });
+    await page.route('**/api/history**', async route => {
+      await historyGate;
+      route.fulfill({
+        status: 200, contentType: 'application/json',
+        body: JSON.stringify({ points: [], events: [] }),
+      });
+    });
+    await page.goto('/playground/');
+    await page.waitForFunction(() => typeof window.__sync === 'object');
+
+    // Wait for init() to complete so the connection.js syncing
+    // subscribe is wired before we flip the flag. The signal is
+    // phase === 'live' (set by initModeToggle, which runs after
+    // initConnection registers the subscribe).
+    await page.waitForFunction(async () => {
+      const mod = await import('/playground/js/app-state.js');
+      return mod.store.get('phase') === 'live';
+    });
+
+    // Trigger a resync directly (production path is the visibility
+    // listener; we use the coordinator API to keep the test focused
+    // on the overlay state machine). Fire-and-forget: page.evaluate
+    // would otherwise await the returned Promise, which won't resolve
+    // until the gated fetch settles.
+    await page.evaluate(() => { window.__sync.triggerResync('test'); });
+    await page.waitForFunction(async () => {
+      const mod = await import('/playground/js/app-state.js');
+      return mod.store.get('syncing') === true;
+    }, undefined, { timeout: 5000 });
+
+    // The overlay element must be visible AND carry the syncing
+    // class — that's what swaps the heavy blur for the light pill.
+    const overlay = page.locator('#overlay-modes');
+    await expect(overlay).toHaveClass(/visible/);
+    await expect(overlay).toHaveClass(/connection-overlay--syncing/);
+    // Staleness banner must NOT be visible during sync — old UX
+    // showed it transiently between syncing → active.
+    const banner = page.locator('#staleness-banner');
+    await expect(banner).not.toHaveClass(/visible/);
+
+    // Close out: release the gated fetches.
+    releaseHistory();
+    await page.waitForFunction(async () => {
+      const mod = await import('/playground/js/app-state.js');
+      return mod.store.get('syncing') === false;
+    });
+    await expect(overlay).not.toHaveClass(/connection-overlay--syncing/);
+  });
+
+  test('liveFrameSeen is reset on resync start so trends fall back to fresh history', async ({ page }) => {
+    // Background: the original Android bug had `liveFrameSeen` stay
+    // true across the backgrounding, so on resume the UI used the
+    // stale lastState (wrong-direction arrows) instead of the fresh
+    // history. The coordinator resets the flag in onResyncStart;
+    // this asserts the seam is wired.
+    let releaseHistory;
+    const historyGate = new Promise(r => { releaseHistory = r; });
+    await page.route('**/api/history**', async route => {
+      await historyGate;
+      route.fulfill({
+        status: 200, contentType: 'application/json',
+        body: JSON.stringify({ points: [], events: [] }),
+      });
+    });
+    await page.goto('/playground/');
+    await page.waitForFunction(() => typeof window.__sync === 'object');
+
+    // Pretend a live frame has already arrived so we have something
+    // to observe getting reset. setLiveFrameSeen lives in
+    // display-update.js, exposed for tests via the dynamic import
+    // below — same pattern as window.__getHistoryPointCount.
+    await page.evaluate(async () => {
+      const mod = await import('/playground/js/main/display-update.js');
+      mod.setLiveFrameSeen(true);
+    });
+    const before = await page.evaluate(() => window.__getLiveFrameSeen());
+    expect(before).toBe(true);
+
+    // Trigger a resync. onResyncStart runs synchronously inside
+    // triggerResync, so the flag flips false before the fetch even
+    // resolves. We hold the fetch open via historyGate so the flag
+    // can be observed mid-resync. Fire-and-forget — see the other
+    // test for why we don't await the returned Promise.
+    await page.evaluate(() => { window.__sync.triggerResync('visibility'); });
+    const during = await page.evaluate(() => window.__getLiveFrameSeen());
+    expect(during).toBe(false);
+
+    releaseHistory();
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes the Android background→resume UX bugs: stale cards, graph showing interpolation across the gap (or empty), missing/wrong-direction trend arrows, and the staggered blur-then-banner clearing.
- Adds `playground/js/sync/` — a small registry + coordinator that listens for `visibilitychange` / `pageshow` / `online`, runs every active data source in parallel with shared `AbortSignal`, and toggles a `store.syncing` flag around the window. Convention documented in `playground/js/sync/README.md` so new full-stack features plug in the same way.
- First registered sources: `live-history` and `balance-history`. Collapses the old blur+banner two-step into a single `'syncing'` connection-display state with a light overlay variant (last-known values stay readable, no heavy backdrop blur). Resets `liveFrameSeen` on resync start so the UI falls back to fresh history instead of pre-background `lastState` (the wrong-direction-arrow fix).

## Test plan
- [x] `npm run lint` — 0 errors
- [x] `npm run knip` — 0 issues
- [x] `npm run check:file-size -- --strict` — 0 over hard cap
- [x] `npm run check:assets -- --strict` — clean
- [x] `npm run test:unit` — 876/876 pass
- [x] `npx playwright test --project=frontend` — 234/234 pass (one transient flake in `thermal-sim.spec.js` under full-suite load, passes in isolation; unrelated to this change)
- [x] `npx playwright test --project=e2e` — 4/4 pass
- [x] New `tests/frontend/sync-registry.spec.js` (contract: rejected specs, AbortSignal honoured on overlap, `isActive` gating, `applyToStore` exactly-once, `syncing` flag toggling, isolation between failing sources)
- [x] New `tests/frontend/visibility-resync.spec.js` (behaviour: hide→show re-fetches `/api/history`, light overlay variant during sync, `liveFrameSeen` reset on resync start)
- [ ] Manual smoke on Android: background the tab for ≥1 min, return — confirm graph fills the gap, trend arrows render correctly, single Syncing… transition (no separate blur and banner)

https://claude.ai/code/session_01Xu265q4JsFNEzh56mQ9JPK

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xu265q4JsFNEzh56mQ9JPK)_