### PR TITLE
ci: enable CodeQL via advanced setup workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,47 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '32 5 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+          - language: python
+            build-mode: none
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@b2f9ef845756500b97acbdaf5c1dd4e9c1d15734 # v3.35.2
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@b2f9ef845756500b97acbdaf5c1dd4e9c1d15734 # v3.35.2
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/codeql.yml` analyzing `javascript-typescript`, `python`, and `actions` — the three CodeQL-supported languages in this repo.
- Replaces the just-disabled default setup, which fixes the intermittent "Default setup / language:javascript-typescript — 1 configuration not found" warning that was appearing on PR builds.
- Action SHAs pinned to match the existing `ci.yml` style (codeql-action v3.35.2, checkout v6.0.2).

## Test plan
- [ ] CodeQL job runs on this PR and produces three analyses (one per language)
- [ ] Existing CI (`test`, `lint-shelly`, `pages-build`) stays green
- [ ] After merge, the "1 configuration not found" warning no longer appears on subsequent PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)