### PR TITLE
tests: gate frontend specs on __initComplete; drop pre-push retries

### DIFF
--- a/.claude/hooks/pre-push-gate.sh
+++ b/.claude/hooks/pre-push-gate.sh
@@ -195,7 +195,7 @@ else
 fi
 
 pw_start=$(date +%s)
-if npx playwright test --reporter=line --retries=1 >"$pw_log" 2>&1; then
+if npx playwright test --reporter=line >"$pw_log" 2>&1; then
   printf "  ✓ %-30s (%ds)\n" "Playwright (frontend + e2e)" "$(( $(date +%s) - pw_start ))" >&2
   echo "✅ All gates green — proceeding with push." >&2
   exit 0

--- a/tests/frontend/auth-actions.spec.js
+++ b/tests/frontend/auth-actions.spec.js
@@ -46,6 +46,10 @@ async function mockUnauthenticated(page) {
 
 // Navigate into the Settings view where the Account card lives.
 async function gotoSettings(page) {
+  // The hashchange listener is wired inside the async init() function.
+  // Setting the hash before init reaches initNavigation is silent (no
+  // listener yet), so wait for init to finish before navigating.
+  await page.waitForFunction(() => window.__initComplete === true);
   await page.evaluate(() => { window.location.hash = 'settings'; });
   await expect(page.locator('#view-settings')).toHaveClass(/active/);
 }

--- a/tests/frontend/copy-logs.spec.js
+++ b/tests/frontend/copy-logs.spec.js
@@ -40,7 +40,7 @@ async function getClipboardText(page) {
 test.describe('Copy System Logs — simulation mode', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/playground/?mode=sim');
-    await expect(page.locator('#fab-play')).toBeVisible();
+    await page.waitForFunction(() => window.__initComplete === true);
     await waitForTestHook(page);
   });
 

--- a/tests/frontend/live-mode.spec.js
+++ b/tests/frontend/live-mode.spec.js
@@ -17,6 +17,8 @@ test.describe('Live mode toggle', () => {
 
   test('switching to simulation mode shows controls view', async ({ page }) => {
     await page.goto('/playground/');
+    // The mode-toggle click handler is wired inside async init().
+    await page.waitForFunction(() => window.__initComplete === true);
     // Click toggle to switch to simulation
     const sw = page.locator('#mode-toggle-switch');
     await sw.click();
@@ -27,6 +29,7 @@ test.describe('Live mode toggle', () => {
 
   test('simulation mode still works after toggle', async ({ page }) => {
     await page.goto('/playground/');
+    await page.waitForFunction(() => window.__initComplete === true);
     // Switch to simulation
     await page.locator('#mode-toggle-switch').click();
     // Start simulation
@@ -71,7 +74,7 @@ test.describe('Connection state overlays', () => {
 
   test('switching to simulation removes all overlays', async ({ page }) => {
     await page.goto('/playground/');
-    await page.waitForTimeout(1500);
+    await page.waitForFunction(() => window.__initComplete === true);
     // Overlays should be visible in live mode
     await expect(page.locator('#overlay-modes')).toBeVisible();
     // Switch to simulation

--- a/tests/frontend/mobile-ui.spec.js
+++ b/tests/frontend/mobile-ui.spec.js
@@ -7,7 +7,10 @@ test.describe('Simulation-only mode overlays (GitHub Pages context)', () => {
   test('connection overlays are hidden in simulation-only mode', async ({ page }) => {
     // ?mode=sim forces simulation-only mode (same as GitHub Pages)
     await page.goto('/playground/?mode=sim');
-    await page.waitForTimeout(300);
+    // Overlays are toggled inside the async init() pipeline (initModeToggle
+    // → switchToSimulation → updateConnectionOverlays). Wait for init to
+    // finish so the assertion isn't racing the boot path.
+    await page.waitForFunction(() => window.__initComplete === true);
     // No connection overlay should appear — simulation mode doesn't need a server
     await expect(page.locator('#overlay-modes')).not.toBeVisible();
     await expect(page.locator('#overlay-gauge')).not.toBeVisible();
@@ -18,7 +21,10 @@ test.describe('Simulation-only mode overlays (GitHub Pages context)', () => {
 test.describe('Settings visibility on GitHub Pages', () => {
   test('Settings nav is hidden when isLiveCapable is false', async ({ page }) => {
     await page.goto('/playground/');
-    await page.waitForSelector('.sidebar-nav');
+    // The store mutation below relies on initSubscriptions having wired the
+    // phase subscriber. __initComplete fires only after init() has run end
+    // to end, so this is the safe gate.
+    await page.waitForFunction(() => window.__initComplete === true);
     // We can't fake location.hostname reliably across browsers, so stub the
     // store value after boot and re-fire the phase subscription to refresh
     // nav visibility. Setting phase to the same value is a no-op in the
@@ -30,7 +36,6 @@ test.describe('Settings visibility on GitHub Pages', () => {
       store.set('phase', '__refresh__');
       store.set('phase', phase);
     });
-    await page.waitForTimeout(200);
     // The Settings anchor stays in the DOM (HTML unchanged) but must be hidden
     await expect(page.locator('.sidebar-nav [data-view="settings"]')).toBeHidden();
     await expect(page.locator('.bottom-nav [data-view="settings"]')).toBeHidden();
@@ -42,8 +47,7 @@ test.describe('Settings visibility on GitHub Pages', () => {
 
   test('Settings nav is visible on localhost (live-capable)', async ({ page }) => {
     await page.goto('/playground/');
-    await page.waitForSelector('.sidebar-nav');
-    await page.waitForTimeout(200);
+    await page.waitForFunction(() => window.__initComplete === true);
     await expect(page.locator('.sidebar-nav [data-view="settings"]')).toBeVisible();
   });
 });
@@ -77,6 +81,8 @@ test.describe('Mobile: mode toggle visibility', () => {
   test('page content below status bar is interactable on mobile', async ({ page }) => {
     await page.setViewportSize(MOBILE);
     await page.goto('/playground/');
+    // Nav links have no href — the click handler is wired inside async init().
+    await page.waitForFunction(() => window.__initComplete === true);
     // Bottom nav links must be clickable without interception from the status bar
     await page.locator('.bottom-nav [data-view="components"]').click();
     await expect(page.locator('#view-components')).toHaveClass(/active/);
@@ -90,6 +96,7 @@ test.describe('Mobile: Device view does not overflow horizontally', () => {
   test('device config form does not cause horizontal scroll', async ({ page }) => {
     await page.setViewportSize(MOBILE);
     await page.goto('/playground/');
+    await page.waitForFunction(() => window.__initComplete === true);
     // Navigate to Device view via bottom nav (available in live mode on localhost)
     await page.locator('.bottom-nav [data-view="device"]').click();
     // Force-show the config form (normally hidden until API loads config)

--- a/tests/frontend/notifications-push.spec.js
+++ b/tests/frontend/notifications-push.spec.js
@@ -116,6 +116,8 @@ async function installPushMocks(page) {
 }
 
 async function gotoSettings(page) {
+  // Hashchange listener is wired inside async init(); see auth-actions.spec.js.
+  await page.waitForFunction(() => window.__initComplete === true);
   await page.evaluate(() => { window.location.hash = 'settings'; });
   await expect(page.locator('#view-settings')).toHaveClass(/active/);
   // Wait for initNotifications to settle — the toggle button gets its

--- a/tests/frontend/pwa-notifications.spec.js
+++ b/tests/frontend/pwa-notifications.spec.js
@@ -43,6 +43,8 @@ async function mockPushApi(page) {
 }
 
 async function gotoSettings(page) {
+  // Hashchange listener is wired inside async init(); see auth-actions.spec.js.
+  await page.waitForFunction(() => window.__initComplete === true);
   // Navigate to the Settings view (URL hash based routing)
   await page.evaluate(() => { window.location.hash = 'settings'; });
   await expect(page.locator('#view-settings')).toHaveClass(/active/);
@@ -57,7 +59,7 @@ test.describe('Settings view — desktop', () => {
   test.beforeEach(async ({ page }) => {
     await mockPushApi(page);
     await page.goto('/playground/?mode=sim');
-    await expect(page.locator('#fab-play')).toBeVisible();
+    await page.waitForFunction(() => window.__initComplete === true);
     await gotoSettings(page);
   });
 
@@ -157,7 +159,7 @@ test.describe('Install card state when running standalone', () => {
   test('idle card is shown by default (browser mode)', async ({ page }) => {
     await mockPushApi(page);
     await page.goto('/playground/?mode=sim');
-    await expect(page.locator('#fab-play')).toBeVisible();
+    await page.waitForFunction(() => window.__initComplete === true);
     await page.evaluate(() => { window.location.hash = 'settings'; });
     await expect(page.locator('#view-settings')).toHaveClass(/active/);
 
@@ -192,7 +194,7 @@ test.describe('Install card state when running standalone', () => {
 
     await mockPushApi(page);
     await page.goto('/playground/?mode=sim');
-    await expect(page.locator('#fab-play')).toBeVisible();
+    await page.waitForFunction(() => window.__initComplete === true);
     await page.evaluate(() => { window.location.hash = 'settings'; });
     await expect(page.locator('#view-settings')).toHaveClass(/active/);
 
@@ -223,7 +225,7 @@ test.describe('Install card state when running standalone', () => {
 
     await mockPushApi(page);
     await page.goto('/playground/?mode=sim');
-    await expect(page.locator('#fab-play')).toBeVisible();
+    await page.waitForFunction(() => window.__initComplete === true);
     await page.evaluate(() => { window.location.hash = 'settings'; });
 
     const desc = page.locator('#pwa-uninstall-desc');
@@ -313,7 +315,7 @@ test.describe('Settings view — mobile viewport', () => {
   test.beforeEach(async ({ page }) => {
     await mockPushApi(page);
     await page.goto('/playground/?mode=sim');
-    await expect(page.locator('#fab-play')).toBeVisible();
+    await page.waitForFunction(() => window.__initComplete === true);
   });
 
   test('Settings nav item is visible in mobile bottom nav', async ({ page }) => {

--- a/tests/frontend/thermal-sim.spec.js
+++ b/tests/frontend/thermal-sim.spec.js
@@ -17,8 +17,11 @@ async function setSlider(page, id, value) {
 test.describe('Thermal Simulation UI', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/playground/?mode=sim');
-    // Wait for app to initialize (FAB becomes clickable when ready)
-    await expect(page.locator('#fab-play')).toBeVisible();
+    // Nav links have no href — the click handler is wired inside the
+    // async init() function. __initComplete fires only when init() has
+    // run past initNavigation + initModeToggle, i.e. when phase is set
+    // to 'simulation' so 'controls' is in availableViews.
+    await page.waitForFunction(() => window.__initComplete === true);
   });
 
   test('page loads with correct title and initial state', async ({ page }) => {


### PR DESCRIPTION
## Summary

- **Root cause:** Nav links in `playground/index.html` (`<a data-view="...">`) have no `href`, so they're inert until `initNavigation()` wires the click handler inside the **async** `init()` function. Specs that did `page.goto(...)` then immediately clicked a nav link or set the URL hash could win the race against init: the click hit a handler-less link, the hashchange listener wasn't yet registered, the view never gained `.active`, and `expect(view).toBeVisible()` retried 8× and timed out. Confirmed in run [#25009488173 attempt 1](https://github.com/Wnt/greenhouse-solar-heater/actions/runs/25009488173/attempts/1?pr=87) (thermal-sim) and run #24986531333 (pwa-notifications).
- **Fix:** Replace fragile init signals (`expect('#fab-play').toBeVisible()`, `waitForTimeout(...)`, `waitForSelector('.sidebar-nav')`) with `await page.waitForFunction(() => window.__initComplete === true)` across the affected specs. The `__initComplete` hook was added at the end of `init()` in #87 but only used by the sync-framework specs.
- **Cleanup:** Drop `--retries=1` from `.claude/hooks/pre-push-gate.sh` now that the underlying race is gone.

Touched specs: `thermal-sim`, `pwa-notifications` (3 beforeEach + `gotoSettings`), `copy-logs`, `auth-actions` (`gotoSettings`), `notifications-push` (`gotoSettings`), `mobile-ui` (overlays / settings visibility / content interaction / device config), `live-mode` (toggle click → controls / sim mode after toggle / overlay removal).

## Test plan

- [x] `npx playwright test --reporter=line` — full suite, no retries, **239 passed (50.6 s)**
- [x] `npx playwright test --project=frontend --repeat-each=3` — **705 passed (2.7 min)**
- [x] `for i in 1 2 3; do npx playwright test --project=frontend; done` — **235 / 235 / 235 passed** (3 cold runs)
- [x] **1,888 total test executions across stress runs, zero flakes**
- [x] Local pre-push gate (the one in this PR, without `--retries=1`) — passes end to end

🤖 Generated with [Claude Code](https://claude.com/claude-code)