### PR TITLE
tests: more __initComplete gates + fix e2e MQTT cross-worker bleed

### DIFF
--- a/tests/e2e/device-config-mqtt.spec.js
+++ b/tests/e2e/device-config-mqtt.spec.js
@@ -7,13 +7,19 @@ import { test, expect } from './fixtures.js';
 //
 // If this goes red, the mqtt-bridge → broker hop is broken —
 // likely to affect sensor-config and relay-command flows too.
+
+let counter = 0;
+
 test.describe('device-config PUT → MQTT publish', () => {
   test('publishes the new config to greenhouse/config (retained)', async ({ page, mqttClient }) => {
     // Subscribing to greenhouse/config immediately delivers the
     // retained "current config" message that the server re-publishes
     // on every MQTT (re)connect (see republishDeviceConfig). We don't
-    // care about that one — filter by the unique `ea` value we're
-    // about to send.
+    // care about that one. Filter by a unique `wb.I` value so this test
+    // doesn't pick up a config published by another parallel worker —
+    // every worker subscribes to the same retained topic on a shared
+    // broker, so `find(m => m.ea === 31)` would also match a sibling
+    // worker's PUT.
     const targetEa = 31;
     const messages = [];
     mqttClient.on('message', (topic, payload) => {
@@ -23,15 +29,21 @@ test.describe('device-config PUT → MQTT publish', () => {
       mqttClient.subscribe('greenhouse/config', { qos: 1 }, (err) => err ? reject(err) : resolve());
     });
 
-    const banUntil = Math.floor(Date.now() / 1000) + 3600;
+    // Worker-unique banUntil: pid + sub-millisecond entropy so two workers
+    // that hit Date.now() in the same millisecond still pick distinct
+    // values. (Workers occupy disjoint pids, so pid alone is enough; the
+    // counter is belt-and-braces for parallel repeats inside one worker.)
+    const banUntil = Math.floor(Date.now() / 1000) + 3600
+      + (process.pid % 7919) + (++counter);
     const res = await page.request.put('/api/device-config', {
       data: { ea: targetEa, wb: { I: banUntil } },
     });
     expect(res.status()).toBe(200);
 
-    await expect.poll(() => messages.find(m => m.ea === targetEa) ?? null,
+    const matchOurs = (m) => m.ea === targetEa && m.wb && m.wb.I === banUntil;
+    await expect.poll(() => messages.find(matchOurs) ?? null,
       { timeout: 3000 }).not.toBeNull();
-    const msg = messages.find(m => m.ea === targetEa);
+    const msg = messages.find(matchOurs);
     expect(msg.wb).toEqual({ I: banUntil });
   });
 });

--- a/tests/frontend/device-config.spec.js
+++ b/tests/frontend/device-config.spec.js
@@ -106,8 +106,8 @@ async function setupDeviceView(page, initialConfig) {
   }));
 
   await page.goto('/playground/', { waitUntil: 'domcontentloaded' });
-  // Wait for live mode to activate (localhost is live-capable)
-  await expect(page.locator('#mode-toggle')).toBeVisible();
+  // Wait for init to wire click handlers + reveal mode-toggle.
+  await page.waitForFunction(() => window.__initComplete === true);
 
   // Navigate to Device view
   const deviceNav = page.locator('.sidebar-nav [data-view="device"]');
@@ -187,7 +187,8 @@ async function setupRelayView(page, stateOverrides) {
   }));
 
   await page.goto('/playground/', { waitUntil: 'domcontentloaded' });
-  await expect(page.locator('#mode-toggle')).toBeVisible();
+  // Init wires the click handlers and reveals #mode-toggle.
+  await page.waitForFunction(() => window.__initComplete === true);
   // Wait for live connection to be established (state data received)
   await expect(page.locator('#connection-dot')).toHaveClass(/connected/, { timeout: 3000 });
   await page.locator('.sidebar-nav [data-view="device"]').click();
@@ -695,7 +696,7 @@ test.describe('Device config UI', () => {
     }));
 
     await page.goto('/playground/', { waitUntil: 'domcontentloaded' });
-    await expect(page.locator('#mode-toggle')).toBeVisible();
+    await page.waitForFunction(() => window.__initComplete === true);
 
     // In live mode (default on localhost), Device nav is visible
     const deviceNav = page.locator('.sidebar-nav [data-view="device"]');

--- a/tests/frontend/mobile-ui.spec.js
+++ b/tests/frontend/mobile-ui.spec.js
@@ -56,6 +56,7 @@ test.describe('Mobile: mode toggle visibility', () => {
   test('mode toggle is visible at mobile viewport width', async ({ page }) => {
     await page.setViewportSize(MOBILE);
     await page.goto('/playground/');
+    await page.waitForFunction(() => window.__initComplete === true);
     // Mode toggle must be accessible on mobile, not hidden inside the sidebar
     await expect(page.locator('#mode-toggle')).toBeVisible();
   });

--- a/tests/frontend/script-crash-banner.spec.js
+++ b/tests/frontend/script-crash-banner.spec.js
@@ -71,7 +71,7 @@ test.describe('script-crash banner', () => {
   test('banner is hidden when the script is running', async ({ page }) => {
     await mockLiveConnectionWithScriptStatus(page, { running: true, reachable: true });
     await page.goto('/playground/', { waitUntil: 'domcontentloaded' });
-    await expect(page.locator('#mode-toggle')).toBeVisible();
+    await page.waitForFunction(() => window.__initComplete === true);
     // Banner stays hidden for a healthy script.
     await expect(page.locator('#script-crash-banner')).toBeHidden();
   });
@@ -79,7 +79,7 @@ test.describe('script-crash banner', () => {
   test('banner appears when a crash broadcast arrives', async ({ page }) => {
     await mockLiveConnectionWithScriptStatus(page, { running: true, reachable: true });
     await page.goto('/playground/', { waitUntil: 'domcontentloaded' });
-    await expect(page.locator('#mode-toggle')).toBeVisible();
+    await page.waitForFunction(() => window.__initComplete === true);
     await expect(page.locator('#script-crash-banner')).toBeHidden();
 
     // Inject crash broadcast
@@ -115,6 +115,7 @@ test.describe('script-crash banner', () => {
     });
 
     await page.goto('/playground/', { waitUntil: 'domcontentloaded' });
+    await page.waitForFunction(() => window.__initComplete === true);
     await expect(page.locator('#script-crash-banner')).toBeVisible();
     await page.click('#script-crash-banner-restart');
     await expect.poll(() => posted.length).toBeGreaterThan(0);

--- a/tests/frontend/watchdog-flow.spec.js
+++ b/tests/frontend/watchdog-flow.spec.js
@@ -138,7 +138,7 @@ test.describe('watchdog flow', () => {
     const calls = await setupWatchdogRoutes(page);
 
     await page.goto('/playground/', { waitUntil: 'domcontentloaded' });
-    await expect(page.locator('#mode-toggle')).toBeVisible();
+    await page.waitForFunction(() => window.__initComplete === true);
 
     // The banner should be hidden initially (no pending)
     await expect(page.locator('#watchdog-banner')).toBeHidden();
@@ -191,7 +191,7 @@ test.describe('watchdog flow', () => {
     const calls = await setupWatchdogRoutes(page);
 
     await page.goto('/playground/', { waitUntil: 'domcontentloaded' });
-    await expect(page.locator('#mode-toggle')).toBeVisible();
+    await page.waitForFunction(() => window.__initComplete === true);
 
     await page.evaluate(({ watchdogs }) => {
       window.__wdInject({
@@ -260,7 +260,7 @@ test.describe('watchdog flow', () => {
     }));
 
     await page.goto('/playground/', { waitUntil: 'domcontentloaded' });
-    await expect(page.locator('#mode-toggle')).toBeVisible();
+    await page.waitForFunction(() => window.__initComplete === true);
 
     // GET is still pending — inject a WS broadcast that should set the banner
     await page.evaluate(({ watchdogs }) => {


### PR DESCRIPTION
## Summary

Round 2 of flake hardening, surfaced by lowering the Playwright `expect.timeout` from the default 5000 ms to 200 ms and watching what broke. Two real bugs fell out:

1. **`#mode-toggle.toBeVisible()` was being used as an init-complete proxy in 6 places** — but the toggle's `.visible` class is set inside the async \`init()\` flow (initModeToggle), so under load the assertion can lapse before init reaches that point. Same root cause as the existing __initComplete fixes; just a different surface. Replaced with \`waitForFunction(() => __initComplete)\` in \`device-config.spec.js\` (3×), \`watchdog-flow.spec.js\` (3×), \`script-crash-banner.spec.js\` (3×), and \`mobile-ui.spec.js\`.

2. **Real cross-worker bleed in `tests/e2e/device-config-mqtt.spec.js`.** Every worker subscribes to \`greenhouse/config\` on the shared broker and PUTs \`ea: 31\`. \`messages.find(m => m.ea === 31)\` matches the *first* \`ea=31\` message — frequently a sibling worker's publish, with a different \`banUntil\` second. Caught by running the spec with \`--repeat-each=10\` (6/10 failed). Fixed by computing a worker-unique \`banUntil\` (pid + per-test counter) and filtering \`messages\` on the exact \`wb.I\` value we sent.

## Test plan

- [x] Full suite (frontend + e2e) at default 5 s expect timeout — 239 passed
- [x] Full suite × `repeat-each=2` — **478 passed (2.1 min)**
- [x] `device-config-mqtt.spec.js` × `repeat-each=10` (parallel) — 10 / 10 (was 4 / 10 before fix)
- [x] Aggregate across all sweeps in this PR + #90: ~2,400 test executions, zero flakes

🤖 Generated with [Claude Code](https://claude.com/claude-code)