### PR TITLE
tests: silence pg-mem 'Unexpected kw_order' history-query noise in e2e

### DIFF
--- a/tests/e2e/_setup/silence-pgmem-noise.js
+++ b/tests/e2e/_setup/silence-pgmem-noise.js
@@ -1,0 +1,46 @@
+'use strict';
+
+// Drops server-side log lines that originate from pg-mem's known
+// inability to parse the production UNION ALL/ORDER BY history query.
+//
+// The e2e harness (tests/e2e/_setup/start.cjs) uses pg-mem in place of
+// PostgreSQL/TimescaleDB. pg-mem rejects the parenthesised
+// `(SELECT …) UNION ALL (SELECT …) ORDER BY ts` shape that
+// server/lib/db.js builds for ≤48h history ranges with
+// "💀 Syntax error … Unexpected kw_order token". The harness already
+// accepts that /api/history returns 500 in that case (see
+// tests/e2e/health-smoke.spec.js); what we don't want is the server's
+// downstream `log.error('history query failed', …)` JSON entry
+// surfacing as `[WebServer]` noise on every page render.
+//
+// The filter is intentionally narrow — only lines that match
+// component=http, msg='history query failed', AND contain pg-mem's
+// `Unexpected kw_order` signature are dropped. Unrelated errors
+// (including unrelated pg-mem failures and unrelated http errors)
+// still print.
+
+function shouldSuppress(line) {
+  return typeof line === 'string'
+    && line.indexOf('"component":"http"') !== -1
+    && line.indexOf('"msg":"history query failed"') !== -1
+    && line.indexOf('Unexpected kw_order') !== -1;
+}
+
+function install(stream) {
+  const target = stream || process.stderr;
+  const orig = target.write.bind(target);
+  target.write = function (chunk, encoding, cb) {
+    const str = typeof chunk === 'string' ? chunk : (chunk && chunk.toString());
+    if (shouldSuppress(str)) {
+      const done = typeof encoding === 'function' ? encoding
+        : typeof cb === 'function' ? cb
+        : null;
+      if (done) done();
+      return true;
+    }
+    return orig(chunk, encoding, cb);
+  };
+  return function uninstall() { target.write = orig; };
+}
+
+module.exports = { install, shouldSuppress };

--- a/tests/e2e/_setup/start.cjs
+++ b/tests/e2e/_setup/start.cjs
@@ -32,6 +32,11 @@ const fs = require('fs');
 const os = require('os');
 const net = require('net');
 
+// Drop the per-render `history query failed` log lines that pg-mem's
+// rejection of the production UNION ALL/ORDER BY history query
+// produces. See ./silence-pgmem-noise.js for scope + rationale.
+require('./silence-pgmem-noise').install();
+
 // ── 1. pg-mem with TimescaleDB-compatible schema ──────────────
 
 const { newDb } = require('pg-mem');

--- a/tests/silence-pgmem-noise.test.js
+++ b/tests/silence-pgmem-noise.test.js
@@ -1,0 +1,117 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+
+const { install, shouldSuppress } = require('./e2e/_setup/silence-pgmem-noise');
+
+// A representative line emitted by server/lib/logger.js when
+// server/lib/http-handlers.js:handleHistoryApi catches pg-mem's
+// "Unexpected kw_order" parse failure on the production UNION ALL
+// history query.
+const NOISE_LINE = JSON.stringify({
+  ts: '2026-04-27T18:39:40.998Z',
+  level: 'error',
+  component: 'http',
+  msg: 'history query failed',
+  error: '💔 Your query failed to parse.\n... Unexpected kw_order token: "order". ...',
+}) + '\n';
+
+describe('silence-pgmem-noise', () => {
+  describe('shouldSuppress', () => {
+    it('matches the pg-mem history-query parse-failure log line', () => {
+      assert.strictEqual(shouldSuppress(NOISE_LINE), true);
+    });
+
+    it('does not match unrelated http error lines', () => {
+      const line = JSON.stringify({
+        level: 'error', component: 'http', msg: 'events query failed',
+        error: 'connection refused',
+      }) + '\n';
+      assert.strictEqual(shouldSuppress(line), false);
+    });
+
+    it('does not match unrelated pg-mem failures (different msg)', () => {
+      const line = JSON.stringify({
+        level: 'error', component: 'db', msg: 'maintenance failed',
+        error: 'Unexpected kw_order token',
+      }) + '\n';
+      assert.strictEqual(shouldSuppress(line), false);
+    });
+
+    it('does not match history failures from other parsers', () => {
+      const line = JSON.stringify({
+        level: 'error', component: 'http', msg: 'history query failed',
+        error: 'connection terminated unexpectedly',
+      }) + '\n';
+      assert.strictEqual(shouldSuppress(line), false);
+    });
+
+    it('handles non-string input safely', () => {
+      assert.strictEqual(shouldSuppress(null), false);
+      assert.strictEqual(shouldSuppress(undefined), false);
+      assert.strictEqual(shouldSuppress(123), false);
+    });
+  });
+
+  describe('install', () => {
+    function fakeStream() {
+      const captured = [];
+      return {
+        captured,
+        write(chunk, _encoding, cb) {
+          captured.push(typeof chunk === 'string' ? chunk : chunk.toString());
+          if (typeof _encoding === 'function') _encoding();
+          else if (typeof cb === 'function') cb();
+          return true;
+        },
+      };
+    }
+
+    it('drops matching lines from the stream', () => {
+      const stream = fakeStream();
+      install(stream);
+      stream.write(NOISE_LINE);
+      assert.deepStrictEqual(stream.captured, []);
+    });
+
+    it('passes through unrelated lines untouched', () => {
+      const stream = fakeStream();
+      install(stream);
+      const passthrough = '{"level":"info","msg":"booted"}\n';
+      stream.write(passthrough);
+      assert.deepStrictEqual(stream.captured, [passthrough]);
+    });
+
+    it('invokes the write callback even when suppressing', () => {
+      const stream = fakeStream();
+      install(stream);
+      let called = false;
+      stream.write(NOISE_LINE, 'utf8', () => { called = true; });
+      assert.strictEqual(called, true);
+    });
+
+    it('invokes the write callback when callback is the second arg', () => {
+      const stream = fakeStream();
+      install(stream);
+      let called = false;
+      stream.write(NOISE_LINE, () => { called = true; });
+      assert.strictEqual(called, true);
+    });
+
+    it('returns an uninstall fn that restores the original write', () => {
+      const stream = fakeStream();
+      const uninstall = install(stream);
+      uninstall();
+      stream.write(NOISE_LINE);
+      assert.deepStrictEqual(stream.captured, [NOISE_LINE]);
+    });
+
+    it('handles Buffer chunks', () => {
+      const stream = fakeStream();
+      install(stream);
+      stream.write(Buffer.from(NOISE_LINE));
+      assert.deepStrictEqual(stream.captured, []);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- The e2e harness uses pg-mem in place of TimescaleDB, but pg-mem can't parse the parenthesised `(SELECT …) UNION ALL (SELECT …) ORDER BY ts` shape that `server/lib/db.js` builds for ≤48h history ranges. Every page render therefore dumped a verbose `history query failed` JSON log line into Playwright's `[WebServer]` output.
- The existing `health-smoke.spec.js` already accepts that `/api/history` returns 500 under the harness — only the log noise was unwanted.
- Adds a narrow stderr filter that drops only lines matching `component=http` + `msg='history query failed'` + `Unexpected kw_order`. Wired in from the e2e harness setup. Unrelated errors still print.

## Test plan
- [x] New unit tests (`tests/silence-pgmem-noise.test.js`) cover match/no-match, callback semantics, install/uninstall, and Buffer chunks (11 tests, all pass).
- [x] `npm run lint` / `knip` / `check:file-size --strict` / `check:assets --strict` all pass.
- [x] `npm run test:unit` — 900 tests pass.
- [x] Full Playwright suite (frontend + e2e) — 239 tests pass; e2e output no longer contains the `Unexpected kw_order` lines.

https://claude.ai/code/session_01XYrE1NJxX64rQPvftyF5R6

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYrE1NJxX64rQPvftyF5R6)_