### PR TITLE
Fix flaky frontend tests racing with playground SPA async init

### DIFF
--- a/playground/js/main.js
+++ b/playground/js/main.js
@@ -165,8 +165,13 @@ async function init() {
   captureInstallPrompt();
 
   // Initialize push notifications (service worker, VAPID key, existing subscription)
+  // Ready marker fires after notification UI wiring (the only post-init async
+  // step that attaches click handlers). Tests gate nav/button clicks on it
+  // to avoid racing with init-time event-listener attachment.
   initNotifications().then(function () {
     wireNotificationUI();
+  }).finally(function () {
+    document.body.dataset.ready = '1';
   });
 
   // Start polling for JS source updates

--- a/tests/frontend/connection-status.spec.js
+++ b/tests/frontend/connection-status.spec.js
@@ -1,5 +1,5 @@
 // @ts-check
-import { test, expect } from './fixtures.js';
+import { test, expect, waitForAppReady } from './fixtures.js';
 
 test.describe('Connection status and overlays', () => {
 
@@ -61,6 +61,7 @@ test.describe('Connection status and overlays', () => {
     }));
 
     await page.goto('/playground/');
+    await waitForAppReady(page);
     // Navigate to device view
     await page.locator('.sidebar-nav [data-view="device"]').click();
     await expect(page.locator('#view-device')).toBeVisible();
@@ -88,6 +89,7 @@ test.describe('Connection status and overlays', () => {
     }));
 
     await page.goto('/playground/');
+    await waitForAppReady(page);
     await page.locator('.sidebar-nav [data-view="device"]').click();
     await expect(page.locator('#device-config-form')).toBeVisible();
     // "Try anyway" link should be visible

--- a/tests/frontend/copy-logs.spec.js
+++ b/tests/frontend/copy-logs.spec.js
@@ -6,7 +6,7 @@
  *   Simulation mode — sim parameters + sensor history + transition log
  *   Live mode       — sensor readings at 20-min resolution + transition log
  */
-import { test, expect } from './fixtures.js';
+import { test, expect, waitForAppReady } from './fixtures.js';
 
 // ── Helpers ──
 
@@ -40,7 +40,7 @@ async function getClipboardText(page) {
 test.describe('Copy System Logs — simulation mode', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/playground/?mode=sim');
-    await expect(page.locator('#fab-play')).toBeVisible();
+    await waitForAppReady(page);
     await waitForTestHook(page);
   });
 

--- a/tests/frontend/fixtures.js
+++ b/tests/frontend/fixtures.js
@@ -60,4 +60,19 @@ export const test = base.extend({
   },
 });
 
+/**
+ * Wait until the playground SPA has finished its async init pipeline
+ * (config load, control-logic load, navigation/notification wiring).
+ * Tests that click navigation links or buttons whose handlers are
+ * attached during init must call this after `page.goto('/playground/...')`
+ * to avoid racing with the wire-up — clicks dispatched before then
+ * land on inert elements and silently no-op.
+ *
+ * The signal is `document.body.dataset.ready = '1'`, set in
+ * `playground/js/main.js` after `wireNotificationUI()` resolves.
+ */
+export async function waitForAppReady(page) {
+  await expect(page.locator('body[data-ready="1"]')).toBeAttached();
+}
+
 export { expect };

--- a/tests/frontend/mobile-ui.spec.js
+++ b/tests/frontend/mobile-ui.spec.js
@@ -1,5 +1,5 @@
 // @ts-check
-import { test, expect } from './fixtures.js';
+import { test, expect, waitForAppReady } from './fixtures.js';
 
 const MOBILE = { width: 375, height: 812 };
 
@@ -77,6 +77,7 @@ test.describe('Mobile: mode toggle visibility', () => {
   test('page content below status bar is interactable on mobile', async ({ page }) => {
     await page.setViewportSize(MOBILE);
     await page.goto('/playground/');
+    await waitForAppReady(page);
     // Bottom nav links must be clickable without interception from the status bar
     await page.locator('.bottom-nav [data-view="components"]').click();
     await expect(page.locator('#view-components')).toHaveClass(/active/);
@@ -90,6 +91,7 @@ test.describe('Mobile: Device view does not overflow horizontally', () => {
   test('device config form does not cause horizontal scroll', async ({ page }) => {
     await page.setViewportSize(MOBILE);
     await page.goto('/playground/');
+    await waitForAppReady(page);
     // Navigate to Device view via bottom nav (available in live mode on localhost)
     await page.locator('.bottom-nav [data-view="device"]').click();
     // Force-show the config form (normally hidden until API loads config)

--- a/tests/frontend/pwa-notifications.spec.js
+++ b/tests/frontend/pwa-notifications.spec.js
@@ -18,7 +18,7 @@
  *     main content on other views
  */
 
-import { test, expect } from './fixtures.js';
+import { test, expect, waitForAppReady } from './fixtures.js';
 
 // The Playwright test server serves static files via `npx serve` and has
 // no /api/push/vapid-key endpoint, so we mock it with a valid-looking key.
@@ -57,7 +57,7 @@ test.describe('Settings view — desktop', () => {
   test.beforeEach(async ({ page }) => {
     await mockPushApi(page);
     await page.goto('/playground/?mode=sim');
-    await expect(page.locator('#fab-play')).toBeVisible();
+    await waitForAppReady(page);
     await gotoSettings(page);
   });
 
@@ -161,7 +161,7 @@ test.describe('Install card state when running standalone', () => {
   test('idle card is shown by default (browser mode)', async ({ page }) => {
     await mockPushApi(page);
     await page.goto('/playground/?mode=sim');
-    await expect(page.locator('#fab-play')).toBeVisible();
+    await waitForAppReady(page);
     await page.evaluate(() => { window.location.hash = 'settings'; });
     await expect(page.locator('#view-settings')).toHaveClass(/active/);
 
@@ -196,7 +196,7 @@ test.describe('Install card state when running standalone', () => {
 
     await mockPushApi(page);
     await page.goto('/playground/?mode=sim');
-    await expect(page.locator('#fab-play')).toBeVisible();
+    await waitForAppReady(page);
     await page.evaluate(() => { window.location.hash = 'settings'; });
     await expect(page.locator('#view-settings')).toHaveClass(/active/);
 
@@ -227,7 +227,7 @@ test.describe('Install card state when running standalone', () => {
 
     await mockPushApi(page);
     await page.goto('/playground/?mode=sim');
-    await expect(page.locator('#fab-play')).toBeVisible();
+    await waitForAppReady(page);
     await page.evaluate(() => { window.location.hash = 'settings'; });
 
     const desc = page.locator('#pwa-uninstall-desc');
@@ -332,7 +332,7 @@ test.describe('Settings view — mobile viewport', () => {
   test.beforeEach(async ({ page }) => {
     await mockPushApi(page);
     await page.goto('/playground/?mode=sim');
-    await expect(page.locator('#fab-play')).toBeVisible();
+    await waitForAppReady(page);
   });
 
   test('Settings nav item is visible in mobile bottom nav', async ({ page }) => {

--- a/tests/frontend/thermal-sim.spec.js
+++ b/tests/frontend/thermal-sim.spec.js
@@ -1,4 +1,4 @@
-import { test, expect } from './fixtures.js';
+import { test, expect, waitForAppReady } from './fixtures.js';
 
 // Helper: navigate to a view via sidebar (desktop) or bottom nav
 async function goToView(page, viewName) {
@@ -17,8 +17,10 @@ async function setSlider(page, id, value) {
 test.describe('Thermal Simulation UI', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/playground/?mode=sim');
-    // Wait for app to initialize (FAB becomes clickable when ready)
-    await expect(page.locator('#fab-play')).toBeVisible();
+    // Wait for the SPA's async init pipeline (config load, control-logic
+    // load, navigation/notification wiring) to finish before tests click
+    // nav links — otherwise clicks land before listeners are attached.
+    await waitForAppReady(page);
   });
 
   test('page loads with correct title and initial state', async ({ page }) => {


### PR DESCRIPTION
## Summary

Running each CI test suite 5× surfaced flakes in the Playwright **frontend** project. Across 5 baseline runs (228 tests each) the failures were:

| Run | Failed test | Root cause |
|---|---|---|
| 1 | `thermal-sim.spec.js:135` "sim speed slider controls simulation rate" | `#view-controls` never got `.active` class after sidebar click |
| 2 | `thermal-sim.spec.js:107` "schematic is visible" | Same — `#view-components` stayed `class="view"` |
| 3 | `thermal-sim.spec.js:119` + `pwa-notifications.spec.js:104` "install modal closes via close button" | Same / `#install-modal` stayed hidden after `#pwa-install-btn` click |
| 4 | `mobile-ui.spec.js:77` "page content below status bar is interactable on mobile" | `#view-components` never got `.active` after bottom-nav click |
| 5 | `thermal-sim.spec.js:80` "simulation produces mode transitions and logs" | Same — view stayed inactive |

Unit tests (5/5 × 900 tests) and e2e (5/5 × 4 tests) were already clean.

## Root cause

The flaky tests all do `page.goto('/playground/...')` and then click a nav link / button whose listener is attached *during* the SPA's async `init()` pipeline (`loadSystemYaml` → `initControlLogic` → `initSubscriptions` → `initNavigation` → `setupFAB` → … → `initNotifications().then(wireNotificationUI)`). The existing "wait for app ready" sentinel —

```js
await expect(page.locator('#fab-play')).toBeVisible();
```

— was effectively a no-op. The FAB is in the static HTML and visible from initial render, so the wait resolved before any JS ran. When init was slow enough that the click landed before listeners were attached, the click hit an inert `<a data-view="…">` (no `href`, no handler) and silently no-oped — the view never transitioned to `.active`, and the subsequent `toBeVisible()` / `toHaveClass(/active/)` timed out at 5 s.

## Fix

1. **`playground/js/main.js`**: set `document.body.dataset.ready = '1'` once the post-init wiring chain settles. The marker fires from a `.finally()` on the `initNotifications().then(wireNotificationUI)` chain, so an `initNotifications()` rejection (no service worker, blocked VAPID fetch) still releases waiters instead of hanging tests.

2. **`tests/frontend/fixtures.js`**: export `waitForAppReady(page)` — a single-line helper that asserts `body[data-ready="1"]` is attached.

3. **Specs that race**: replace the bogus FAB sentinel / add `waitForAppReady` before nav clicks in:
   - `thermal-sim.spec.js` (beforeEach)
   - `pwa-notifications.spec.js` (5 sites, replacing the same FAB pattern)
   - `mobile-ui.spec.js` (2 inline-nav tests)
   - `copy-logs.spec.js` (beforeEach)
   - `connection-status.spec.js` (2 inline-nav tests, defensive)

Test scenarios are unchanged — only the readiness gate is corrected.

## Verification

After the fix, 5 consecutive runs of each CI test suite are clean:

| Suite | Runs | Result |
|---|---|---|
| `npm run test:unit` | 5/5 | 900 / 900 pass each |
| `npm run test:frontend` | 5/5 | 228 / 228 pass each |
| `npm run test:e2e` | 5/5 | 4 / 4 pass each |
| `npm run lint` | 1 | 0 errors |
| `npm run knip` | 1 | exit 0 |
| `npm run check:file-size -- --strict` | 1 | 0 over hard cap |
| `npm run check:assets -- --strict` | 1 | exit 0 |
| `npm run coverage:frontend` + `coverage-check.mjs` | 1 | gate green (39 / 39 ≥ 50 %) |

## Test plan

- [ ] CI passes on this PR (frontend + e2e + lint + knip + coverage gate).
- [ ] No regressions visible on `#status` / `#components` / `#controls` / `#device` / `#settings` views.

https://claude.ai/code/session_01UMApaowsUNfNV2aeuEYyZG

---
_Generated by [Claude Code](https://claude.ai/code/session_01UMApaowsUNfNV2aeuEYyZG)_