### PR TITLE
Add audit trail support for enabled-actuator (ea) bitmask changes

### DIFF
--- a/playground/js/main/logs.js
+++ b/playground/js/main/logs.js
@@ -9,7 +9,7 @@ import { store } from '../app-state.js';
 import {
   formatClockTime, formatFullTimeHelsinki, formatCauseLabel,
   formatReasonLabel, formatSensorsLine, escapeHtml, formatTimeOfDay,
-  formatConfigEntry,
+  formatConfigEntry, formatConfigSourceLabel,
 } from './time-format.js';
 import { model, params, MODE_INFO, timeSeriesStore, transitionLog, lastLiveFrame } from './state.js';
 import { getWatchdogSnapshot } from './watchdog-ui.js';
@@ -376,10 +376,26 @@ function buildLogsClipboardText() {
   } else {
     for (let i = 0; i < transitionLog.length; i++) {
       const t = transitionLog[i];
-      const mi = MODE_INFO[t.mode] || MODE_INFO.idle;
       const timeLabel = t.kind === 'live'
         ? formatFullTimeHelsinki(t.ts)
         : formatTimeOfDay(t.time);
+
+      // Config events (wb / ea / mo) get a one-line "Config: <title>"
+      // entry tagged with the source/actor. Without this branch they
+      // fell through the mode-row formatter and rendered as bare
+      // "Idle" rows because t.mode is undefined for config events.
+      if (t.eventType === 'config') {
+        const fmt = formatConfigEntry(t);
+        const tag = '[config: ' + (t.source || 'unknown') + ']';
+        lines.push(timeLabel + '  Config  ' + fmt.title + '  ' + tag);
+        const subtitle = t.actor
+          ? formatConfigSourceLabel(t.source) + ' by ' + t.actor
+          : formatConfigSourceLabel(t.source);
+        lines.push('    source: ' + subtitle);
+        continue;
+      }
+
+      const mi = MODE_INFO[t.mode] || MODE_INFO.idle;
       // Header row carries cause and, when present, the evaluator's
       // decision code in the form `[cause: reason]` so `grep` on a
       // single bracketed pair still matches the cause.

--- a/playground/js/main/time-format.js
+++ b/playground/js/main/time-format.js
@@ -104,6 +104,16 @@ const MODE_CODE_LABELS = {
   EH: 'Emergency Heating',
 };
 
+// ea (enabled-actuator bitmask) per-bit names → human label. Bit names
+// originate in server/lib/config-events.js EA_BITS — keep in sync.
+const EA_BIT_LABELS = {
+  valves: 'Valves',
+  pump: 'Pump',
+  fan: 'Fan',
+  space_heater: 'Space Heater',
+  immersion_heater: 'Immersion Heater',
+};
+
 // Source attribution for config_events. Combined with actor for the
 // per-row description in the System Logs view.
 const CONFIG_SOURCE_LABELS = {
@@ -118,10 +128,12 @@ export function formatConfigSourceLabel(s) {
 }
 
 // Render a config_events row to a { title, desc } pair for the log
-// list. Three flavors:
+// list. Flavors:
 //   wb add (e.g. SC=9999999999)  — "Disabled mode: Solar Charging"
 //   wb remove (e.g. SC=null)     — "Re-enabled mode: Solar Charging"
 //   wb change (timestamp swap)   — "Updated ban: Solar Charging"
+//   ea bit on  (0 → 1)           — "Enabled actuator: Fan"
+//   ea bit off (1 → 0)           — "Disabled actuator: Fan"
 //   mo enter (null → object)     — "Manual override: Solar Charging (until 14:30)"
 //   mo exit (object → null)      — "Manual override exited"
 //   mo change (object → object)  — "Manual override updated: Active Drain"
@@ -142,6 +154,12 @@ export function formatConfigEntry(t) {
       return { title: 'Re-enabled mode: ' + modeLabel, desc: subtitle };
     }
     return { title: 'Updated ban: ' + modeLabel, desc: subtitle };
+  }
+
+  if (t.configKind === 'ea') {
+    const bitLabel = EA_BIT_LABELS[t.configKey] || t.configKey || 'unknown actuator';
+    const verb = t.to === '1' ? 'Enabled actuator' : 'Disabled actuator';
+    return { title: verb + ': ' + bitLabel, desc: subtitle };
   }
 
   if (t.configKind === 'mo') {

--- a/playground/js/main/time-format.js
+++ b/playground/js/main/time-format.js
@@ -87,6 +87,22 @@ const REASON_LABELS = {
   emergency_enter: 'greenhouse critical — emergency heat',
   sensor_stale: 'sensor reading stale',
   watchdog_ban: 'mode blocked by watchdog',
+  // Watchdog auto-shutdown reasons. The id (sng / scs / ggr) is
+  // appended by buildIdleTransitionResult() in shelly/control.js so
+  // the log row distinguishes which watchdog tripped, instead of a
+  // bare "watchdog_auto" cause with no decision detail.
+  sng_shutdown: 'tank not gaining heat — auto-shutdown',
+  scs_shutdown: 'collector cooling during charging — auto-shutdown',
+  ggr_shutdown: 'greenhouse not gaining heat — auto-shutdown',
+  // Forced-mode transitions originating from the playground "Force
+  // mode" UI carry the picked mode in the reason so the log row
+  // shows the user's intent, not just the bare cause "forced".
+  forced_I: 'user forced Idle',
+  forced_SC: 'user forced Solar Charging',
+  forced_GH: 'user forced Greenhouse Heating',
+  forced_AD: 'user forced Active Drain',
+  forced_EH: 'user forced Emergency Heating',
+  override_cleared: 'manual override cleared',
   min_duration: 'holding minimum run time',
   idle: 'no trigger active',
 };

--- a/server/lib/config-events.js
+++ b/server/lib/config-events.js
@@ -2,17 +2,35 @@
  * Config-events diff helper. Pure: given (prev, next) deviceConfig
  * snapshots plus a source tag and actor, returns the array of
  * config_events rows that should be inserted to capture the wb (mode
- * bans) and mo (manual override) deltas. Used by every code path that
- * mutates deviceConfig so the System Logs view sees a consistent
- * audit trail.
+ * bans), mo (manual override), and ea (enabled-actuator bitmask)
+ * deltas. Used by every code path that mutates deviceConfig so the
+ * System Logs view sees a consistent audit trail.
  *
- * Unhandled fields (ce, ea, we, wz, v) are intentionally ignored —
- * they're either operational toggles (ce, ea), watchdog config that
- * the watchdog UI tracks separately (we, wz), or bookkeeping (v).
- * If/when one of those needs an audit row, add it here.
+ * ea is emitted per-bit: a single PUT that flips two bits produces
+ * two rows, mirroring how wb emits one row per mode. Each row's `key`
+ * is the bit name (valves / pump / fan / space_heater / immersion_heater)
+ * and old_value/new_value are '0' / '1'. This is what makes a Fan-only
+ * toggle by the user show up as a single "Enabled actuator: Fan" entry
+ * instead of an opaque "ea: 3 → 7".
+ *
+ * Unhandled fields (ce, we, wz, v) are intentionally ignored —
+ * watchdog config has its own UI surface (we, wz), and ce / v are
+ * coarse-grained toggles / bookkeeping. If/when one of those needs an
+ * audit row, add it here.
  */
 
 const WB_KEYS = ['I', 'SC', 'GH', 'AD', 'EH'];
+
+// Mirrors device-config.js: ea = valves|pump|fan|space_heater|immersion_heater
+// at bits 1, 2, 4, 8, 16. Order is bit order so multi-bit diffs come
+// out in a stable sequence.
+const EA_BITS = [
+  { bit: 1,  name: 'valves' },
+  { bit: 2,  name: 'pump' },
+  { bit: 4,  name: 'fan' },
+  { bit: 8,  name: 'space_heater' },
+  { bit: 16, name: 'immersion_heater' },
+];
 
 function getWb(cfg) {
   return (cfg && cfg.wb) || {};
@@ -28,6 +46,11 @@ function moEqual(a, b) {
   const sa = a ? JSON.stringify(a) : null;
   const sb = b ? JSON.stringify(b) : null;
   return sa === sb;
+}
+
+function getEa(cfg) {
+  const v = cfg && cfg.ea;
+  return typeof v === 'number' ? v : 0;
 }
 
 function diffConfig(prev, next, source, actor) {
@@ -48,6 +71,25 @@ function diffConfig(prev, next, source, actor) {
       source,
       actor: actor || null,
     });
+  }
+
+  const eaPrev = getEa(prev);
+  const eaNext = getEa(next);
+  if (eaPrev !== eaNext) {
+    for (let i = 0; i < EA_BITS.length; i++) {
+      const b = EA_BITS[i];
+      const wasOn = (eaPrev & b.bit) !== 0;
+      const nowOn = (eaNext & b.bit) !== 0;
+      if (wasOn === nowOn) continue;
+      out.push({
+        kind: 'ea',
+        key: b.name,
+        old_value: wasOn ? '1' : '0',
+        new_value: nowOn ? '1' : '0',
+        source,
+        actor: actor || null,
+      });
+    }
   }
 
   const moPrev = getMo(prev);

--- a/shelly/control.js
+++ b/shelly/control.js
@@ -220,6 +220,16 @@ function setValves(pairs, idx, cb) {
       setPump(false);
       state.mode = MODES.IDLE;
       state.mode_start = Date.now();
+      // Mode just flipped to IDLE outside the staged-transition flow
+      // (no transitionTo() update). Refresh cause + reason in lock-step
+      // so the published snapshot can't carry a stale reason from the
+      // last successful transition. Without this guard, an idle row
+      // emitted right after a valve hiccup would inherit the prior
+      // entry's reason (e.g. "greenhouse_enter") and mislead operators
+      // into thinking the device decided to heat when it actually
+      // bailed on a hardware error.
+      state.lastTransitionCause = "failed";
+      state.lastTransitionReason = null;
       captureWatchdogBaseline();
       state.transitioning = false;
       if (cb) cb(false);
@@ -380,8 +390,12 @@ function publishWatchdogEvent(payload) {
 
 // Build an IDLE result for transitionTo() — used when a watchdog
 // fires the auto-shutdown path or the user-initiated shutdown via
-// config push.
-function buildIdleTransitionResult() {
+// config push. `reason` flows straight into result.reason and
+// becomes the published `reason` on the IDLE-state row, so the
+// System Logs UI can tell apart "greenhouse stalled" (`ggr_shutdown`)
+// from "no solar gain" (`sng_shutdown`) — without it every watchdog
+// trip would render as a bare `watchdog_auto` with no decision code.
+function buildIdleTransitionResult(reason) {
   return {
     nextMode: MODES.IDLE,
     valves: MODE_VALVES[MODES.IDLE],
@@ -394,15 +408,24 @@ function buildIdleTransitionResult() {
       solarChargePeakTankAvgAt: 0
     },
     suppressed: false,
-    safetyOverride: false
+    safetyOverride: false,
+    reason: reason || null
   };
 }
 
-// Forced-mode transitionTo-shaped result (bypasses evaluate()).
+// Forced-mode transitionTo-shaped result (bypasses evaluate()). The
+// reason is "forced_<code>" so the System Logs UI can show *which*
+// mode the user picked instead of the bare cause "forced".
 function makeModeResult(code) {
   var m = MODE_CODE[code];
   if (!m || !MODES[m]) return null;
-  return { nextMode: MODES[m], valves: MODE_VALVES[MODES[m]], actuators: MODE_ACTUATORS[MODES[m]], flags: {} };
+  return {
+    nextMode: MODES[m],
+    valves: MODE_VALVES[MODES[m]],
+    actuators: MODE_ACTUATORS[MODES[m]],
+    flags: {},
+    reason: "forced_" + code
+  };
 }
 
 // Auto-shutdown path: called from watchdogTick() after the 5-minute
@@ -431,9 +454,13 @@ function applyBanAndShutdown(id, how) {
   state.watchdogPending = null;
   // how is "shutdown_auto" from autoShutdown() or "shutdown_user" from
   // handleConfigDrivenResolution(). Matches the published "resolved"
-  // event so UI logs line up.
-  transitionTo(buildIdleTransitionResult(),
-    how === "shutdown_user" ? "user_shutdown" : "watchdog_auto");
+  // event so UI logs line up. Carry the watchdog id into the reason so
+  // the System Logs UI can show *which* watchdog tripped — operators
+  // need to tell "greenhouse not gaining heat" (ggr) from "tank not
+  // gaining heat during charging" (sng) at a glance.
+  var cause = (how === "shutdown_user") ? "user_shutdown" : "watchdog_auto";
+  var reason = id + "_shutdown";
+  transitionTo(buildIdleTransitionResult(reason), cause);
   publishWatchdogEvent({ t: "resolved", id: id, how: how, ts: nowSec });
 }
 
@@ -493,7 +520,7 @@ function handleConfigDrivenResolution(prevCfg, newCfg) {
     var oldWb = prevCfg && prevCfg.wb && prevCfg.wb[modeCode];
     if (newWb && newWb > nowSec && newWb !== oldWb) {
       state.watchdogPending = null;
-      transitionTo(buildIdleTransitionResult(), "user_shutdown");
+      transitionTo(buildIdleTransitionResult(pid + "_shutdown"), "user_shutdown");
       publishWatchdogEvent({
         t: "resolved", id: pid, how: "shutdown_user", ts: nowSec
       });
@@ -510,7 +537,7 @@ function handleForcedModeChange(prev, next) {
   var pFm = (pMo && pMo.fm) || null, nFm = (nMo && nMo.fm) || null;
   var t = null;
   if (nMo && nMo.a && nFm && nFm !== pFm) t = makeModeResult(nFm);
-  else if (pMo && pMo.a && (!nMo || !nMo.a)) t = buildIdleTransitionResult();
+  else if (pMo && pMo.a && (!nMo || !nMo.a)) t = buildIdleTransitionResult("override_cleared");
   if (t) Timer.set(1000, false, function() { transitionTo(t, "forced"); });
 }
 

--- a/tests/config-events-diff.test.js
+++ b/tests/config-events-diff.test.js
@@ -130,7 +130,47 @@ describe('config-events diff — mo (manual override)', () => {
   });
 });
 
-describe('config-events diff — combined wb + mo deltas', () => {
+describe('config-events diff — ea (enabled-actuator bitmask)', () => {
+  it('emits one row per flipped bit (off → on)', () => {
+    // ea=3 (valves|pump) → ea=7 (valves|pump|fan) — only fan flips.
+    const rows = diffConfig({ ea: 3 }, { ea: 7 }, 'api', 'alice');
+    assert.deepStrictEqual(rows, [
+      { kind: 'ea', key: 'fan', old_value: '0', new_value: '1', source: 'api', actor: 'alice' },
+    ]);
+  });
+
+  it('emits one row per flipped bit (on → off)', () => {
+    // ea=7 → ea=3 — fan disabled.
+    const rows = diffConfig({ ea: 7 }, { ea: 3 }, 'api', 'alice');
+    assert.deepStrictEqual(rows, [
+      { kind: 'ea', key: 'fan', old_value: '1', new_value: '0', source: 'api', actor: 'alice' },
+    ]);
+  });
+
+  it('emits multiple rows when several bits flip in one update', () => {
+    // ea=0 → ea=14 (pump|fan|space_heater): three bits flip.
+    const rows = diffConfig({ ea: 0 }, { ea: 14 }, 'api', 'alice');
+    rows.sort((a, b) => a.key.localeCompare(b.key));
+    assert.deepStrictEqual(rows, [
+      { kind: 'ea', key: 'fan',          old_value: '0', new_value: '1', source: 'api', actor: 'alice' },
+      { kind: 'ea', key: 'pump',         old_value: '0', new_value: '1', source: 'api', actor: 'alice' },
+      { kind: 'ea', key: 'space_heater', old_value: '0', new_value: '1', source: 'api', actor: 'alice' },
+    ]);
+  });
+
+  it('returns no rows when ea unchanged', () => {
+    assert.deepStrictEqual(diffConfig({ ea: 7 }, { ea: 7 }, 'api', 'alice'), []);
+  });
+
+  it('treats missing ea on either side as 0', () => {
+    const rows = diffConfig({}, { ea: 4 }, 'api', 'alice');
+    assert.deepStrictEqual(rows, [
+      { kind: 'ea', key: 'fan', old_value: '0', new_value: '1', source: 'api', actor: 'alice' },
+    ]);
+  });
+});
+
+describe('config-events diff — combined wb + mo + ea deltas', () => {
   it('emits rows for both fields when both change in one update', () => {
     const rows = diffConfig(
       { wb: {}, mo: null },
@@ -143,10 +183,21 @@ describe('config-events diff — combined wb + mo deltas', () => {
     assert.deepStrictEqual(kinds, ['mo', 'wb']);
   });
 
-  it('ignores changes to non-tracked fields (ce, ea, we, wz, v)', () => {
+  it('emits ea rows alongside wb / mo when all three change at once', () => {
+    const rows = diffConfig(
+      { ea: 3, wb: {}, mo: null },
+      { ea: 7, wb: { SC: 9999999999 }, mo: { a: true, ex: 1840000000, fm: 'SC' } },
+      'api',
+      'alice'
+    );
+    const kinds = rows.map(r => r.kind).sort();
+    assert.deepStrictEqual(kinds, ['ea', 'mo', 'wb']);
+  });
+
+  it('ignores changes to non-tracked fields (ce, we, wz, v)', () => {
     const rows = diffConfig(
       { ce: false, ea: 0, we: {}, wz: {}, wb: {}, mo: null, v: 1 },
-      { ce: true, ea: 31, we: { ggr: 1 }, wz: { ggr: 1840003600 }, wb: {}, mo: null, v: 2 },
+      { ce: true, ea: 0, we: { ggr: 1 }, wz: { ggr: 1840003600 }, wb: {}, mo: null, v: 2 },
       'api',
       'alice'
     );

--- a/tests/frontend/copy-logs.spec.js
+++ b/tests/frontend/copy-logs.spec.js
@@ -351,6 +351,50 @@ test.describe('Copy System Logs — live mode', () => {
     expect(text).toContain('Config version:     42');
   });
 
+  test('clipboard export renders config events (ea / wb) with friendly labels', async ({ page }) => {
+    // Regression: config_events used to fall through the mode-row
+    // formatter in the clipboard export (because t.mode is undefined
+    // for config rows) and rendered as empty "Idle" lines. Each
+    // config row should now render as a "Config" line with a friendly
+    // title plus a "source:" subtitle.
+    const now = Date.now();
+    const rows = [
+      makeEvent(now - 30_000, 'idle', 'solar_charging'),
+      {
+        ts: now - 60_000, type: 'config', kind: 'ea', key: 'fan',
+        from: '0', to: '1', source: 'api', actor: 'alice',
+      },
+      {
+        ts: now - 90_000, type: 'config', kind: 'wb', key: 'GH',
+        from: null, to: '9999999999', source: 'api', actor: 'alice',
+      },
+    ];
+
+    await installMockWs(page);
+    await mockHistoryApi(page);
+    await mockEventsApi(page, rows);
+
+    await page.goto('/playground/', { waitUntil: 'domcontentloaded' });
+    await expect(page.locator('#connection-dot')).toHaveClass(/connected/, { timeout: 5000 });
+    await expect(page.locator('#logs-list .log-item')).toHaveCount(3, { timeout: 5000 });
+    await waitForTestHook(page);
+
+    const text = await getClipboardText(page);
+    expect(text).toContain('Enabled actuator: Fan');
+    expect(text).toContain('Disabled mode: Greenhouse Heating');
+    expect(text).toContain('source: mode-enablement UI by alice');
+    expect(text).toContain('[config: api]');
+
+    // Guard the original bug: config rows must not be rendered as bare "Idle"
+    // lines (no payload, no description). Pull out only the lines under
+    // the Transition Log section to scope the assertion.
+    const tlIdx = text.indexOf('--- Transition Log ---');
+    expect(tlIdx).toBeGreaterThan(-1);
+    const transitionLogLines = text.slice(tlIdx).split('\n');
+    const bareIdle = transitionLogLines.filter(line => /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\s+Idle\s*$/.test(line));
+    expect(bareIdle).toHaveLength(0);
+  });
+
   test('controller state shows manual-override forced mode + permanent SC ban', async ({ page }) => {
     const nowSec = Math.floor(Date.now() / 1000);
 

--- a/tests/frontend/live-logs.spec.js
+++ b/tests/frontend/live-logs.spec.js
@@ -307,4 +307,35 @@ test.describe('System Logs card is backed by live state events', () => {
     await expect(items.nth(2)).toContainText('device view by alice');
     await expect(items.nth(3)).toContainText('Idle');
   });
+
+  test('ea bit-flip renders as "Enabled actuator: <name>"', async ({ page }) => {
+    // A user toggling Fan on via Controller settings should appear in
+    // the System Logs card as a config_events row with the friendly
+    // bit label, not as an opaque ea-bitmask number.
+    const now = Date.now();
+    const rows = [
+      {
+        ts: now - 30_000, type: 'config', kind: 'ea', key: 'fan',
+        from: '0', to: '1', source: 'api', actor: 'alice',
+      },
+      {
+        ts: now - 60_000, type: 'config', kind: 'ea', key: 'pump',
+        from: '1', to: '0', source: 'api', actor: 'alice',
+      },
+    ];
+
+    await installMockWs(page);
+    await mockHistoryApi(page);
+    await mockEventsApi(page, rows);
+
+    await page.goto('/playground/', { waitUntil: 'domcontentloaded' });
+    await expect(page.locator('#connection-dot')).toHaveClass(/connected/, { timeout: 3000 });
+
+    const items = page.locator('#logs-list .log-item');
+    await expect(items).toHaveCount(2, { timeout: 3000 });
+
+    await expect(items.nth(0)).toContainText('Enabled actuator: Fan');
+    await expect(items.nth(0)).toContainText('mode-enablement UI by alice');
+    await expect(items.nth(1)).toContainText('Disabled actuator: Pump');
+  });
 });

--- a/tests/shelly-watchdog-path.test.js
+++ b/tests/shelly-watchdog-path.test.js
@@ -173,4 +173,19 @@ describe('Shelly watchdog: scs fire → auto-shutdown', () => {
     assert.strictEqual(lastMode, 'idle',
       'expected final mode idle after auto-shutdown; got ' + lastMode);
   });
+
+  it('published IDLE state carries cause=watchdog_auto and reason=scs_shutdown', () => {
+    // Without this propagation the System Logs UI sees a bare
+    // "watchdog_auto" cause with no decision code — operators can't
+    // tell which watchdog tripped. The reason must identify *which*
+    // watchdog (scs/sng/ggr) so the friendly label in REASON_LABELS
+    // tells the right story.
+    const idleEvents = stateEvents.filter(e => e.mode === 'idle');
+    assert.ok(idleEvents.length >= 1, 'expected at least one idle state event');
+    const post = idleEvents[idleEvents.length - 1];
+    assert.strictEqual(post.cause, 'watchdog_auto',
+      'expected cause=watchdog_auto on post-shutdown idle row; got ' + post.cause);
+    assert.strictEqual(post.reason, 'scs_shutdown',
+      'expected reason=scs_shutdown on post-shutdown idle row; got ' + post.reason);
+  });
 });


### PR DESCRIPTION
## Summary
Extended the config-events audit trail system to track changes to the enabled-actuator (ea) bitmask, complementing existing support for mode bans (wb) and manual overrides (mo). Each bit flip in the ea bitmask now generates a separate audit row with friendly actuator names, improving System Logs visibility into hardware configuration changes.

## Key Changes

- **Config-events diff logic** (`server/lib/config-events.js`):
  - Added `EA_BITS` mapping to decode ea bitmask bits into human-readable actuator names (valves, pump, fan, space_heater, immersion_heater)
  - Implemented per-bit diffing: when ea changes, each flipped bit generates a separate audit row with `kind: 'ea'`, `key: <actuator_name>`, and `old_value`/`new_value` as '0'/'1'
  - Updated module documentation to reflect ea tracking alongside wb and mo

- **Watchdog and forced-mode transitions** (`shelly/control.js`):
  - Enhanced `buildIdleTransitionResult()` to accept and propagate a `reason` parameter, enabling distinction between different shutdown causes (e.g., `sng_shutdown` vs `ggr_shutdown`)
  - Updated `makeModeResult()` to include `reason: "forced_<code>"` so forced-mode transitions show which mode was selected
  - Modified `applyBanAndShutdown()` to pass watchdog ID into the reason, allowing System Logs to show which watchdog triggered
  - Updated `handleConfigDrivenResolution()` and `handleForcedModeChange()` to provide appropriate reason values

- **Frontend display** (`playground/js/main/time-format.js`):
  - Added `EA_BIT_LABELS` mapping for friendly actuator display
  - Extended `formatConfigEntry()` to handle ea config events with "Enabled/Disabled actuator: <name>" titles
  - Added reason labels for watchdog shutdowns (`sng_shutdown`, `scs_shutdown`, `ggr_shutdown`) and forced modes (`forced_I`, `forced_SC`, etc.)
  - Added `override_cleared` reason label

- **Clipboard export** (`playground/js/main/logs.js`):
  - Added dedicated handling for config event rows in clipboard export to prevent them from falling through as bare "Idle" lines
  - Config events now render as "Config: <title>" with source/actor attribution

- **Tests**:
  - Added comprehensive test suite for ea bit-flip detection (single bit, multiple bits, no change, missing ea)
  - Updated combined-delta tests to verify ea works alongside wb and mo
  - Added frontend tests for ea rendering in live logs and clipboard export
  - Added watchdog test verifying reason propagation to published state

## Implementation Details

The ea bitmask is decoded bit-by-bit during diff, mirroring how wb emits one row per mode. This ensures a single config update that enables multiple actuators produces multiple audit rows, each with clear semantics. The bit order (1, 2, 4, 8, 16) ensures stable output ordering across multi-bit changes.

Watchdog and forced-mode transitions now carry decision context in the `reason` field, allowing the System Logs UI to distinguish between different shutdown triggers and user-selected modes without requiring additional state lookups.

https://claude.ai/code/session_014gW6jjfoChVw3kVjwx7d4K