### PR TITLE
tests: extend init-race fix to live-mode.spec.js manual-override tests

### DIFF
--- a/tests/frontend/live-mode.spec.js
+++ b/tests/frontend/live-mode.spec.js
@@ -235,7 +235,12 @@ test.describe('Manual override gating with unbound sensors', () => {
   test('Enter Manual Override becomes enabled when controls_enabled=true even if all sensors are null', async ({ page }) => {
     await installMockWs(page);
     await page.goto('/playground/#device');
-    await page.waitForTimeout(300);
+    // Wait for app init AND for the (mocked) WebSocket to be wired up.
+    // Fixed waitForTimeout(300) here raced under workers=8 contention
+    // and tripped the "mock ws not initialized" guard below. Mirrors
+    // the pattern already used in drainage-control.spec.js.
+    await page.waitForFunction(() => window.__initComplete === true);
+    await page.waitForFunction(() => /** @type {any} */ (window).__mockWs?.onmessage);
 
     // Push a Shelly-shaped state with all sensors unbound (null) and controls enabled
     await page.evaluate(() => {
@@ -273,7 +278,8 @@ test.describe('Manual override gating with unbound sensors', () => {
     page.on('pageerror', (err) => errors.push(String(err)));
 
     await page.goto('/playground/#device');
-    await page.waitForTimeout(300);
+    await page.waitForFunction(() => window.__initComplete === true);
+    await page.waitForFunction(() => /** @type {any} */ (window).__mockWs?.onmessage);
 
     await page.evaluate(() => {
       // @ts-ignore
@@ -339,7 +345,8 @@ test.describe('Manual override gating with unbound sensors', () => {
   test('temperature display shows placeholder for null sensors instead of crashing', async ({ page }) => {
     await installMockWs(page);
     await page.goto('/playground/#components');
-    await page.waitForTimeout(300);
+    await page.waitForFunction(() => window.__initComplete === true);
+    await page.waitForFunction(() => /** @type {any} */ (window).__mockWs?.onmessage);
 
     await page.evaluate(() => {
       // @ts-ignore


### PR DESCRIPTION
## Summary

Rebased onto current `main`. Most of the original PR turned out to be redundant: PRs #90 and #91 (`claude/fix-init-race-flakes`) had already addressed the same races in `drainage-control.spec.js` (via `__initComplete + __mockWs?.onmessage` gates) and the "Immediate overlay on load" tests in `live-mode.spec.js` (by bumping the 500 ms timeout to 2000 ms). Those redundant changes were dropped.

The remaining genuinely new work: three tests in `live-mode.spec.js`'s `Manual override gating with unbound sensors` describe still used the original `goto → waitForTimeout(300)` pattern and threw `mock ws not initialized` under workers=8 contention. This commit applies the **same gate already used in `drainage-control.spec.js`** (`__initComplete` + `__mockWs?.onmessage`) so the pattern stays consistent across both files.

### Tests touched
- `Enter Manual Override becomes enabled when controls_enabled=true even if all sensors are null` (line 235)
- `Live-update pipeline does not throw uncaught errors on null sensor data` (line 269)
- `temperature display shows placeholder for null sensors instead of crashing` (line 345)

### Verification

Reproduces pre-fix in 1/5 stress runs (`workers=8 --repeat-each=3`, isolated to `live-mode.spec.js`).

Post-fix:
- 5/5 stress runs of `live-mode.spec.js` (workers=8, repeat-each=3, 78 tests/run)
- 2/2 full frontend stress runs (workers=8, repeat-each=2, 476 tests/run)
- Standard CI gates clean (lint, knip, file-size --strict, assets --strict, test:unit, test:frontend, test:e2e)

No scenario coverage changes — same locators, same assertions.

## Test plan

- [x] Stress: `npx playwright test --project=frontend --workers=8 --repeat-each=3 tests/frontend/live-mode.spec.js` × 5
- [x] Full stress: `npx playwright test --project=frontend --workers=8 --repeat-each=2` × 2
- [x] All CI gates locally

https://claude.ai/code/session_01M8jDgLVgCBybN8zP9Rb9bh