### PR TITLE
Distinguish permanent mode disables from watchdog bans in logs

### DIFF
--- a/playground/js/main/time-format.js
+++ b/playground/js/main/time-format.js
@@ -104,6 +104,7 @@ const REASON_LABELS = {
   forced_AD: 'user forced Active Drain',
   forced_EH: 'user forced Emergency Heating',
   override_cleared: 'manual override cleared',
+  override_expired: 'manual override timed out',
   min_duration: 'holding minimum run time',
   idle: 'no trigger active',
 };

--- a/playground/js/main/time-format.js
+++ b/playground/js/main/time-format.js
@@ -86,7 +86,8 @@ const REASON_LABELS = {
   greenhouse_tank_depleted: 'tank too cool to heat greenhouse',
   emergency_enter: 'greenhouse critical — emergency heat',
   sensor_stale: 'sensor reading stale',
-  watchdog_ban: 'mode blocked by watchdog',
+  watchdog_ban: 'mode in watchdog cool-off',
+  mode_disabled: 'mode disabled by user',
   // Watchdog auto-shutdown reasons. The id (sng / scs / ggr) is
   // appended by buildIdleTransitionResult() in shelly/control.js so
   // the log row distinguishes which watchdog tripped, instead of a

--- a/shelly/control-logic.js
+++ b/shelly/control-logic.js
@@ -160,6 +160,13 @@ var DEFAULT_CONFIG = {
   watchdogBanSeconds: 14400
 };
 
+// Sentinel value stored in wb[mode] when the user has permanently
+// disabled a mode via the device-config UI. Distinct from the 4-hour
+// cool-off written by applyBanAndShutdown() (a unix timestamp ~now+4h).
+// Mirrored from server/lib/device-config.js — keep them in sync if
+// you ever change the magic number.
+var WB_PERMANENT_SENTINEL = 9999999999;
+
 function applyDefaults(config) {
   var result = {};
   var key;
@@ -519,13 +526,20 @@ function evaluate(state, config, deviceConfig) {
   }
 
   // ── Combine pump mode + emergency overlay ──
-  if (flags.emergencyHeatingActive && pumpMode === MODES.IDLE) {
-    // Emergency heating is also subject to wb
+  // EH ban gates the overlay. Two ban shapes share `wb.EH`:
+  //   - permanent sentinel (user disabled emergency heating in the UI), or
+  //   - 4-hour cool-off (watchdog auto-shutdown).
+  // Either way, suppress the overlay AND fall through — do not return
+  // IDLE with reason "watchdog_ban", which would clobber the natural
+  // pumpMode reason (e.g. "greenhouse_tank_depleted") and falsely tell
+  // the user a watchdog tripped when they had simply disabled emergency
+  // heating. See 2026-04-28 04:54 field log for the original symptom.
+  if (flags.emergencyHeatingActive) {
     if (dc && dc.wb && dc.wb.EH && dc.wb.EH > state.now) {
       flags.emergencyHeatingActive = false;
-      return makeResult(MODES.IDLE, flags, dc, false, "watchdog_ban");
+    } else if (pumpMode === MODES.IDLE) {
+      return makeResult(MODES.EMERGENCY_HEATING, flags, dc, false, "emergency_enter");
     }
-    return makeResult(MODES.EMERGENCY_HEATING, flags, dc, false, "emergency_enter");
   }
 
   var result = makeResult(pumpMode, flags, dc, false, reason);
@@ -535,13 +549,17 @@ function evaluate(state, config, deviceConfig) {
 
   // ── Natural-mode ban check (post-evaluation) ──
   // Blocks the mode that the physics evaluation chose if its wb entry
-  // is still active. Returns IDLE instead.
+  // is still active. Distinguishes a user-set permanent disable
+  // (sentinel → "mode_disabled") from a watchdog cool-off
+  // ("watchdog_ban") so the System Logs UI tells the operator which
+  // one they are looking at.
   if (dc && dc.wb && result.nextMode !== MODES.IDLE) {
     var natCode = shortCodeOf(result.nextMode);
     if (natCode && dc.wb[natCode] && dc.wb[natCode] > state.now) {
       flags.solarChargePeakTankAvg = null;
       flags.solarChargePeakTankAvgAt = 0;
-      return makeResult(MODES.IDLE, flags, dc, false, "watchdog_ban");
+      var banReason = (dc.wb[natCode] >= WB_PERMANENT_SENTINEL) ? "mode_disabled" : "watchdog_ban";
+      return makeResult(MODES.IDLE, flags, dc, false, banReason);
     }
   }
 

--- a/shelly/control.js
+++ b/shelly/control.js
@@ -908,9 +908,18 @@ function isManualOverrideActive() {
     // TTL expired: clear mo, persist, force IDLE inside the KVS.Set cb
     // so HTTP.GETs don't overlap with the KVS.Set (stays under cap).
     // AD→IDLE auto-uses valves-first via state.transitionFromMode.
+    //
+    // Pass cause "forced" (matches handleForcedModeChange's user-clear
+    // path) plus a dedicated reason "override_expired" so the System
+    // Logs row can distinguish a TTL self-clear from a user-issued
+    // exit. Without an explicit reason, transitionTo() would set
+    // lastTransitionReason=null and lastTransitionCause would inherit
+    // whatever the prior transition set (e.g. "automation" from the
+    // pre-override mode), making the row look unrelated to the
+    // override.
     deviceConfig.mo = null;
     Shelly.call("KVS.Set", {key: "config", value: JSON.stringify(deviceConfig)}, function() {
-      if (!state.transitioning) transitionTo(buildIdleTransitionResult());
+      if (!state.transitioning) transitionTo(buildIdleTransitionResult("override_expired"), "forced");
     });
     return false;
   }

--- a/tests/control-logic-valves.test.js
+++ b/tests/control-logic-valves.test.js
@@ -916,13 +916,60 @@ describe('evaluate() emits a decision reason for each path', () => {
     assert.strictEqual(r.reason, 'drain_running');
   });
 
-  it('watchdog_ban when evaluator chose a mode that is banned', () => {
+  it('mode_disabled when evaluator chose a mode the user has permanently banned', () => {
+    // Sentinel 9999999999 — set by the user via the device-config UI to
+    // permanently disable a mode. Distinct from a watchdog cool-off.
     const dc = { ce: true, wb: { SC: 9999999999 } };
     const r = evaluate(makeState({
       temps: { collector: 50, tank_top: 40, tank_bottom: 30, greenhouse: 15, outdoor: 10 }
     }), null, dc);
     assert.strictEqual(r.nextMode, MODES.IDLE);
+    assert.strictEqual(r.reason, 'mode_disabled');
+  });
+
+  it('watchdog_ban when evaluator chose a mode under a watchdog cool-off', () => {
+    // wb entry that is not the permanent sentinel — the 4-hour cool-off
+    // applied after a watchdog firing.
+    const dc = { ce: true, wb: { SC: 1000000 + 3600 } };
+    const r = evaluate(makeState({
+      temps: { collector: 50, tank_top: 40, tank_bottom: 30, greenhouse: 15, outdoor: 10 },
+      now: 1000000
+    }), null, dc);
+    assert.strictEqual(r.nextMode, MODES.IDLE);
     assert.strictEqual(r.reason, 'watchdog_ban');
+  });
+
+  it('emergency-disabled with depleted tank reports the natural reason, not watchdog_ban', () => {
+    // Reproduces the 2026-04-28 04:54 field log: in GH, greenhouse drops
+    // below the emergency-enter threshold (so emergencyHeatingActive
+    // would flip on), tank is too cool to heat the greenhouse, and EH
+    // is permanently disabled by the user. The transition to IDLE is
+    // correct — but the reason must surface the actual cause
+    // (greenhouse_tank_depleted), not "mode blocked by watchdog".
+    const dc = { ce: true, wb: { EH: 9999999999 } };
+    const r = evaluate(makeState({
+      temps: { collector: -3.9, tank_top: 10.2, tank_bottom: 9.5, greenhouse: 8.3, outdoor: 0.8 },
+      currentMode: MODES.GREENHOUSE_HEATING,
+      modeEnteredAt: 0,
+      now: 100000,
+      collectorsDrained: true
+    }), null, dc);
+    assert.strictEqual(r.nextMode, MODES.IDLE);
+    assert.strictEqual(r.reason, 'greenhouse_tank_depleted');
+  });
+
+  it('emergency-disabled with no other trigger falls through to idle reason', () => {
+    // Greenhouse cold (would activate emergency) but tank can't heat it
+    // and we are not currently in GH. Without the EH disable the
+    // evaluator would return EMERGENCY_HEATING. With it, the natural
+    // result is IDLE with reason "idle" — not "watchdog_ban".
+    const dc = { ce: true, wb: { EH: 9999999999 } };
+    const r = evaluate(makeState({
+      temps: { collector: 5, tank_top: 10, tank_bottom: 9, greenhouse: 8, outdoor: 5 },
+      collectorsDrained: true
+    }), null, dc);
+    assert.strictEqual(r.nextMode, MODES.IDLE);
+    assert.strictEqual(r.reason, 'idle');
   });
 
   it('idle when no trigger is active', () => {

--- a/tests/override-forced-mode.test.js
+++ b/tests/override-forced-mode.test.js
@@ -420,6 +420,60 @@ describe('override-forced-mode :: mo.fm drives transitionTo', function() {
     });
   });
 
+  it('TTL expiry tags the published state with cause=forced reason=override_expired', function(t, done) {
+    // Regression for the audit finding adjacent to the wb.EH bug fix:
+    // isManualOverrideActive() previously called transitionTo(buildIdleTransitionResult())
+    // with no cause/reason args. The IDLE row in the System Logs then
+    // inherited the prior transition's lastTransitionCause (whatever
+    // ran before the override — typically "automation") and a null
+    // reason, falsely suggesting the device autonomously decided to
+    // idle. The fix passes an explicit cause "forced" + reason
+    // "override_expired" so operators can tell the row apart from
+    // user-cleared override (cause "forced", reason "override_cleared")
+    // and from any unrelated automation tick.
+    const rt = createOrderingRuntime();
+    bootScript(rt, function() {
+      // Capture greenhouse/state publishes after boot.
+      const stateMsgs = [];
+      rt.globals.MQTT.publish = function(topic, payload) {
+        if (topic === 'greenhouse/state') {
+          try { stateMsgs.push(JSON.parse(payload)); } catch (e) {}
+        }
+      };
+      const sysUnix = rt.globals.Shelly.getComponentStatus('sys').unixtime;
+      const shortTtl = sysUnix + 5;
+      // Override forcing IDLE with a 5-s TTL.
+      rt.setConfig(Object.assign({}, BASE_CONFIG, {
+        mo: { a: true, ex: shortTtl, fm: 'I' }
+      }));
+      // Walk past the expiry, then drive the control loop so
+      // isManualOverrideActive() detects now >= mo.ex.
+      rt.advance(6000, function() {
+        stateMsgs.length = 0;
+        rt.tick(function() {
+          // Let the staged IDLE transition run to completion.
+          rt.advance(35000, function() {
+            // Walk the publishes for the dedicated TTL-expiry tag.
+            // Several idle broadcasts can come through during the
+            // controlLoop tick + staged transition; the override-
+            // expired transition is the one we care about.
+            const expiredMsg = stateMsgs.find(function(m) {
+              return m.mode === 'idle' && m.reason === 'override_expired';
+            });
+            assert.ok(expiredMsg,
+              'expected a mode=idle publish with reason=override_expired; got: ' +
+              JSON.stringify(stateMsgs.map(function(m) {
+                return { mode: m.mode, cause: m.cause, reason: m.reason };
+              })));
+            assert.strictEqual(expiredMsg.cause, 'forced',
+              'TTL expiry must tag cause=forced (matches user-clear path)');
+            done();
+          });
+        });
+      });
+    });
+  });
+
   it('triggers IDLE transition on TTL expiry without a user command', function(t, done) {
     // TTL-expiry path: isManualOverrideActive() detects now >= mo.ex, clears
     // mo, and (our new code) calls transitionTo(buildIdleTransitionResult()).


### PR DESCRIPTION
## Summary
This PR improves observability in the System Logs by distinguishing between two different reasons a mode might be blocked: permanent user-configured disables versus temporary watchdog cool-off periods. It also fixes a regression where TTL-expired manual overrides were incorrectly attributed to prior automation runs.

## Key Changes

- **Mode disable reasons**: Split the generic "watchdog_ban" reason into two distinct cases:
  - `mode_disabled`: When a user permanently disables a mode via the device-config UI (sentinel value 9999999999)
  - `watchdog_ban`: When a mode is under a temporary 4-hour watchdog cool-off
  - This prevents confusion in logs where a disabled mode might be misattributed to a watchdog firing

- **Emergency heating disable handling**: Fixed a logic bug where emergency heating disabled by the user would incorrectly return "watchdog_ban" instead of the natural reason (e.g., "greenhouse_tank_depleted"). The fix ensures the actual cause surfaces in logs rather than masking it with a watchdog message.

- **Manual override TTL expiry**: Fixed a regression where TTL-expired manual overrides were tagged with the prior transition's cause/reason instead of explicit `cause="forced"` and `reason="override_expired"`. This allows operators to distinguish:
  - User-cleared overrides: `cause="forced"`, `reason="override_cleared"`
  - TTL-expired overrides: `cause="forced"`, `reason="override_expired"`
  - Unrelated automation: other causes

- **UI labels**: Updated System Logs reason labels to clarify the distinction between watchdog cool-offs and permanent disables.

## Implementation Details

- Added `WB_PERMANENT_SENTINEL` constant (9999999999) to distinguish permanent disables from timestamp-based cool-offs
- Modified `evaluate()` to check ban type and return appropriate reason
- Updated `isManualOverrideActive()` to pass explicit cause/reason when TTL expires
- Added comprehensive test coverage for all three scenarios (permanent disable, watchdog ban, emergency-disabled edge cases)

https://claude.ai/code/session_01EAwejduzRWEMHuetoVUjYN