### PR TITLE
Upgrade CodeQL Action from v3.35.2 to v4.35.2

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,12 +36,12 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@b2f9ef845756500b97acbdaf5c1dd4e9c1d15734 # v3.35.2
+        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@b2f9ef845756500b97acbdaf5c1dd4e9c1d15734 # v3.35.2
+        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary
This pull request upgrades the GitHub CodeQL Action to the latest major version (v4.35.2) in the CI/CD workflow.

## Key Changes
- Updated `github/codeql-action/init` from v3.35.2 to v4.35.2
- Updated `github/codeql-action/analyze` from v3.35.2 to v4.35.2
- Updated action commit hashes to reflect the new version references

## Details
Both CodeQL action steps in the workflow have been upgraded to v4.35.2, which includes improvements and updates from the CodeQL team. This ensures the repository benefits from the latest security analysis capabilities and bug fixes available in the CodeQL Action.

https://claude.ai/code/session_01Mcaa9L9dHz1RdQFneNNrdP