### PR TITLE
tests/frontend: harden three flaky specs against parallel-load races

### DIFF
--- a/tests/frontend/live-display.spec.js
+++ b/tests/frontend/live-display.spec.js
@@ -127,16 +127,19 @@ test.describe('Status history graph uses live data', () => {
     // Wait until the live connection is up
     await expect(page.locator('#connection-dot')).toHaveClass(/connected/, { timeout: 3000 });
 
-    // The graph should have ingested the history points.  This is tested
-    // via a debug hook exposed by the page on window.
-    const count = await page.evaluate(() => {
+    // The graph should have ingested the history points. Read via the
+    // debug hook exposed on window. Poll rather than asserting once —
+    // the connection-dot transition only signals WS-open, not that the
+    // /api/history fetch has resolved and applyLiveHistory has run. Under
+    // heavy parallel load the assertion could fire after the live state
+    // frame's recordLiveHistoryPoint added a single point but before the
+    // history fetch loaded the 3 mocked points (count=1 instead of 3).
+    await expect.poll(() => page.evaluate(() => {
       // @ts-ignore
       return typeof window.__getHistoryPointCount === 'function'
         ? window.__getHistoryPointCount()
         : null;
-    });
-    expect(count).not.toBeNull();
-    expect(count).toBeGreaterThanOrEqual(3);
+    }), { timeout: 5000 }).toBeGreaterThanOrEqual(3);
   });
 
   test('graph does not stay empty after switching from simulation to live', async ({ page }) => {

--- a/tests/frontend/live-logs.spec.js
+++ b/tests/frontend/live-logs.spec.js
@@ -228,6 +228,13 @@ test.describe('System Logs card is backed by live state events', () => {
 
     await page.goto('/playground/', { waitUntil: 'domcontentloaded' });
     await expect(page.locator('#connection-dot')).toHaveClass(/connected/, { timeout: 3000 });
+    // Wait for the historical /api/events row to render before we
+    // inject the live mode change. fetchLiveEvents(reset=true) does
+    // `transitionLog.length = 0` on completion, so a live entry that
+    // landed first would be wiped under load when the historical fetch
+    // resolves late. Same gating pattern as the "prepends a new log
+    // entry" test above.
+    await expect(page.locator('#logs-list .log-item')).toHaveCount(1, { timeout: 3000 });
 
     // Fire a new state with explicit cause+temps — simulates a device
     // that reports a forced-mode transition to GREENHOUSE_HEATING.
@@ -248,7 +255,9 @@ test.describe('System Logs card is backed by live state events', () => {
       });
     }, now + 600_000);
 
-    const first = page.locator('#logs-list .log-item').first();
+    const items = page.locator('#logs-list .log-item');
+    await expect(items).toHaveCount(2, { timeout: 3000 });
+    const first = items.first();
     await expect(first).toContainText('Heating Greenhouse');
     await expect(first.locator('.log-cause')).toHaveText('Forced mode');
     await expect(first.locator('.log-sensors')).toContainText('gh 7.0°');

--- a/tests/frontend/visibility-resync.spec.js
+++ b/tests/frontend/visibility-resync.spec.js
@@ -40,11 +40,12 @@ test.describe('visibility resync', () => {
     });
     await page.goto('/playground/');
     await waitForSyncReady(page);
-    // Wait for the initial live-mode fetch (1h, 6h, …) to land
-    // before counting subsequent ones — it varies by range +
-    // balance card so we just snapshot the count and look for
-    // increases.
-    await page.waitForTimeout(200);
+    // Wait deterministically for both initial /api/history fetches
+    // (live-history range + balance-history 48h) to land before
+    // snapshotting the baseline. A fixed 200 ms timeout was racy
+    // under heavy parallel load — see PR-history "active.length was
+    // 0" failure mode for the prior incarnation of this race.
+    await expect.poll(() => historyHits, { timeout: 5000 }).toBeGreaterThanOrEqual(2);
     const baseline = historyHits;
 
     // Simulate Android resume: visibility goes hidden then visible.
@@ -57,13 +58,16 @@ test.describe('visibility resync', () => {
       document.dispatchEvent(new Event('visibilitychange'));
     });
 
-    // The coordinator's resync is async — wait for the syncing flag
-    // to flip back to false, then assert hits increased.
-    await page.waitForFunction(async () => {
-      const mod = await import('/playground/js/app-state.js');
-      return mod.store.get('syncing') === false;
-    }, undefined, { timeout: 5000 });
-    expect(historyHits).toBeGreaterThan(baseline);
+    // Poll for the resync's re-fetches to actually hit the route
+    // handler. Plain `expect(historyHits).toBeGreaterThan(baseline)`
+    // run once was racy: under load the assertion could fire in the
+    // tick after the resync triggered triggerResync but before the
+    // first source's fetch had settled (or after a previous
+    // currentController.abort() had cancelled the in-flight signal,
+    // forcing the source to re-issue on a later resync). Polling
+    // tolerates either ordering — the increment will arrive whenever
+    // the route handler runs.
+    await expect.poll(() => historyHits, { timeout: 5000 }).toBeGreaterThan(baseline);
   });
 
   test('syncing overlay uses light variant, not full blur', async ({ page }) => {


### PR DESCRIPTION
## Summary

Stress-running `npm run test:frontend` back-to-back exposed three deterministic races that surface under 4-worker parallelism + CI-style network jitter. Each fix replaces an early one-shot assertion with an explicit synchronization barrier; **the original scenarios are preserved**.

| Spec | Failure under load | Fix |
|---|---|---|
| `visibility-resync.spec.js:32` | `historyHits` snapshot raced the initial `/api/history` fetches AND the post-trigger assertion fired before the resync's `source.fetch(signal)` reached the route handler | Replace fixed `waitForTimeout(200)` with `expect.poll(historyHits).toBeGreaterThanOrEqual(2)`; replace one-shot `expect.toBeGreaterThan(baseline)` with `expect.poll(...)`. Same "active.length was 0" race the prior hardening commit `cac51de` chased. |
| `live-logs.spec.js:223` | Historical `/api/events` fetch resolved AFTER the test's WS injection, and `fetchLiveEvents`'s `transitionLog.length = 0` (isReset=true) wiped the just-prepended live entry — first item became `Collecting Solar Energy` instead of `Heating Greenhouse` | Wait for `#logs-list .log-item` count==1 between the connection-dot check and the WS injection. Mirrors line 150 in the same file. |
| `live-display.spec.js:116` | One-shot `expect(count).toBeGreaterThanOrEqual(3)` raced `applyLiveHistory`. `connection-dot=connected` only signals WS-open, not that `/api/history` has resolved; under load count was 1 (the live frame's `recordLiveHistoryPoint` only) instead of 3 | Replace one-shot `expect` with `expect.poll(...).toBeGreaterThanOrEqual(3)` |

## Validation

Each test was first reproduced 5× to confirm the flake (1-2 failures per 5 runs in 2/3 specs; the third surfaced in 1/8 of a longer 8x run). After the fixes, the **full frontend suite was run 8× back-to-back at 4 workers**: **239/239 pass on every run**. Unit tests (`npm run test:unit:ci`) and e2e tests (`npm run test:e2e`) were also each run 5× — 0 flakes in either suite.

## Test plan

- [x] `npm run lint` — 0 errors
- [x] `npm run test:unit:ci` — 5/5 clean runs
- [x] `npm run test:e2e` — 5/5 clean runs (4 tests each)
- [x] `npm run test:frontend` — 8/8 clean runs (239 tests each) with all 3 fixes applied
- [x] Each fixed test still asserts the same scenario (only the synchronization barriers changed; assertion semantics preserved)

https://claude.ai/code/session_01Tv5bB6kChhZfJAbwp5Yoa6

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tv5bB6kChhZfJAbwp5Yoa6)_