### PR TITLE
tests: fix live-logs WS-injection race (2/10 flake under load)

### DIFF
--- a/tests/frontend/live-logs.spec.js
+++ b/tests/frontend/live-logs.spec.js
@@ -228,6 +228,12 @@ test.describe('System Logs card is backed by live state events', () => {
 
     await page.goto('/playground/', { waitUntil: 'domcontentloaded' });
     await expect(page.locator('#connection-dot')).toHaveClass(/connected/, { timeout: 3000 });
+    // Wait for the initial /api/events fetch to settle before injecting
+    // the WS state. fetchLiveEvents(reset=true) clears transitionLog when
+    // its response arrives, so any in-memory entry added by
+    // detectLiveTransition() before the response comes back gets
+    // clobbered. Waiting for the seed row to render eliminates that race.
+    await expect(page.locator('#logs-list .log-item')).toHaveCount(1, { timeout: 3000 });
 
     // Fire a new state with explicit cause+temps — simulates a device
     // that reports a forced-mode transition to GREENHOUSE_HEATING.


### PR DESCRIPTION
## Summary

Ran the CI suite (`npm run test:unit`, `npm run test:frontend`, `npm run test:e2e`, plus the static-checks job) 5+ times each to surface flakes.

| Suite | Runs | Failures |
|---|---|---|
| `test:unit:ci` (788 tests) | 5/5 | 0 |
| `test:frontend` (238 tests, 4 workers) | **2/10** | `live-logs.spec.js:223` |
| `test:e2e` (4 tests) | 5/5 | 0 |
| static-checks (lint / knip / file-size / assets) | — | 0 |

After the fix: 5/5 frontend runs green.

## The flake

`live-logs.spec.js:223` — *"carries cause + temps straight through from a live WS mode change"* — fired a WS `state` frame right after the connection dot turned `connected`, **without waiting for the initial `/api/events` fetch to settle**.

The in-flight `fetchLiveEvents(reset=true)` (kicked off by `switchToLive`) clears `transitionLog` when its response arrives. So the entry that `detectLiveTransition()` unshifts from the WS frame could be clobbered seconds later, replaced by the seed `/api/events` row. That produced two failure modes depending on timing:

- `toContainText('Heating Greenhouse')` on the first item — fails when `/api/events` arrives before the WS injection (run 10).
- `toHaveText('Forced mode')` on `.log-cause` — fails when `/api/events` arrives *between* the two assertions: `toContainText` briefly passes against the in-memory row, then the row is wiped (run 1).

The sister test on line 150 (*"prepends a new log entry when the live mode changes"*) already follows the correct pattern: it waits for `toHaveCount(1)` on the seed `/api/events` row before injecting the WS frame. The fix applies the same wait at line 223. **Same scenario, deterministically ordered.**

```diff
     await page.goto('/playground/', { waitUntil: 'domcontentloaded' });
     await expect(page.locator('#connection-dot')).toHaveClass(/connected/, { timeout: 3000 });
+    // Wait for the initial /api/events fetch to settle before injecting
+    // the WS state. fetchLiveEvents(reset=true) clears transitionLog when
+    // its response arrives, so any in-memory entry added by
+    // detectLiveTransition() before the response comes back gets
+    // clobbered. Waiting for the seed row to render eliminates that race.
+    await expect(page.locator('#logs-list .log-item')).toHaveCount(1, { timeout: 3000 });
```

## Test plan

- [x] `npm run test:unit:ci` — 788 passing × 5 consecutive runs
- [x] `npm run test:frontend` — 238 passing × 5 consecutive runs (post-fix)
- [x] `npm run test:e2e` — 4 passing × 5 consecutive runs
- [x] `npm run lint` / `knip` / `check:file-size --strict` / `check:assets --strict` — all green
- [x] Confirmed flake reproduces on pre-fix code (2/10 full-suite frontend runs)
- [x] `tests/frontend/live-logs.spec.js` run in isolation 10×: 80/80 passing

https://claude.ai/code/session_01RCNKFmMEEycsxmsEnXwbQ3

---
_Generated by [Claude Code](https://claude.ai/code/session_01RCNKFmMEEycsxmsEnXwbQ3)_