### PR TITLE
Make mode-events store the single source of truth for mode

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -128,13 +128,14 @@ jobs:
       - name: Render preview manifests
         env:
           PR_NUMBER: ${{ needs.preflight.outputs.pr_number }}
+          BRANCH_NAME: ${{ needs.preflight.outputs.ref }}
           IMAGE_TAG: ${{ needs.build.outputs.image_tag }}
         run: |
           set -euo pipefail
           # 4-hour TTL refreshed on every deploy. ISO-8601 UTC; the GC
           # CronJob parses this with `date -u -d`.
           EXPIRES_AT=$(date -u -d "+${TTL_HOURS} hours" +%Y-%m-%dT%H:%M:%SZ)
-          export PR_NUMBER IMAGE_TAG EXPIRES_AT
+          export PR_NUMBER BRANCH_NAME IMAGE_TAG EXPIRES_AT
           mkdir -p rendered
           for f in deploy/k8s/preview/*.yaml; do
             envsubst < "$f" > "rendered/$(basename "$f")"

--- a/deploy/k8s/preview/deployment.yaml
+++ b/deploy/k8s/preview/deployment.yaml
@@ -11,7 +11,10 @@
 #     mosquitto via the in-cluster Service (see env below) so they
 #     observe live MQTT traffic without spinning up an isolated broker.
 #
-# Substituted at deploy time: ${PR_NUMBER}, ${IMAGE_TAG}, ${EXPIRES_AT}.
+# Substituted at deploy time: ${PR_NUMBER}, ${BRANCH_NAME}, ${IMAGE_TAG},
+# ${EXPIRES_AT}. PR_NUMBER + BRANCH_NAME are surfaced through /api/runtime
+# so the playground UI and the pre-auth login page can show a "Preview ·
+# #<PR> · <branch>" label instead of the prod "Live" / "Solar sanctuary".
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -55,6 +58,10 @@ spec:
           env:
             - name: PREVIEW_MODE
               value: "true"
+            - name: PR_NUMBER
+              value: "${PR_NUMBER}"
+            - name: BRANCH_NAME
+              value: "${BRANCH_NAME}"
             - name: ORIGIN
               value: "https://pr-${PR_NUMBER}.greenhouse.madekivi.fi"
             - name: DOMAIN

--- a/playground/js/actions/script-monitor.js
+++ b/playground/js/actions/script-monitor.js
@@ -40,7 +40,7 @@ function wireRestartButton() {
   });
 }
 
-export function renderScriptCrashBanner() {
+function renderScriptCrashBanner() {
   const banner = document.getElementById('script-crash-banner');
   if (!banner) return;
   const status = store.get('scriptStatus');

--- a/playground/js/app-state.js
+++ b/playground/js/app-state.js
@@ -12,6 +12,12 @@ export const store = createStore({
   phase: 'init',             // 'init' | 'simulation' | 'live'
   isLiveCapable: false,
 
+  // Runtime metadata from /api/runtime. null on prod / local dev;
+  // { pr, branch } on PR previews — drives the sidebar / toggle / login
+  // rebrand. Preview deploys share the prod database, so this is the
+  // only signal the frontend has that it's a preview.
+  runtimePreview: null,
+
   // Auth
   userRole: 'admin',         // 'admin' | 'readonly'
 

--- a/playground/js/main.js
+++ b/playground/js/main.js
@@ -1,48 +1,33 @@
 import { loadSystemYaml } from './yaml-loader.js';
-import { ThermalModel, tankStoredEnergyKwh } from './physics.js';
+import { ThermalModel } from './physics.js';
 import { ControlStateMachine, initControlLogic } from './control.js';
-import { load as loadControlLogic } from './control-logic-loader.js';
-import { createSlider, formatTime, pickTickStep, formatTick, pickBucketSize } from './ui.js';
-import { LiveSource, SimulationSource } from './data-source.js';
+import { createSlider } from './ui.js';
 import { startVersionCheck, triggerVersionCheck } from './version-check.js';
 import { initSensorsView, destroySensorsView } from './sensors.js';
-import { store, derived } from './app-state.js';
+import { store } from './app-state.js';
 import { initSubscriptions, setViewLifecycle } from './subscriptions.js';
 import { initNavigation } from './actions/navigation.js';
-import { attachScriptStatusWebSocket, renderScriptCrashBanner } from './actions/script-monitor.js';
 import { mountCrashesView } from './crashes-view.js';
 import { initAuth } from './auth.js';
 import { captureInstallPrompt, initNotifications } from './notifications.js';
 import { buildSchematic as buildSchematicFromSvg } from './schematic.js';
 import { setupFAB, togglePlay, updateFABIcon, resetSimulationTime } from './main/simulation.js';
 import { resetModeEvents, appendModeEvent } from './main/mode-events.js';
-import {
-  formatClockTime, formatCauseLabel, formatReasonLabel,
-  formatSensorsLine, formatFullTimeHelsinki, escapeHtml,
-} from './main/time-format.js';
-import {
-  initWatchdogUI, attachWatchdogWebSocket,
-  renderModeEnablement, getWatchdogSnapshot,
-} from './main/watchdog-ui.js';
-import { initRelayBoard, updateRelayBoard } from './main/relay-board.js';
+import { initWatchdogUI } from './main/watchdog-ui.js';
+import { initRelayBoard } from './main/relay-board.js';
 import { initDrainageControl } from './main/drainage-control.js';
 import { initDeviceConfig } from './main/device-config.js';
 import { wireNotificationUI } from './main/notifications-ui.js';
-import { drawHistoryGraph, tankAvgOf, toSchematicState } from './main/history-graph.js';
+import { drawHistoryGraph, toSchematicState } from './main/history-graph.js';
 import {
-  transitionLog, fetchLiveEvents, detectLiveTransition, renderLogsList,
-  setupLogsScrollLoader, setupCopyLogsButton, resetEventsState,
+  transitionLog, setupLogsScrollLoader, setupCopyLogsButton,
 } from './main/logs.js';
-import {
-  initBalanceCard, fetchBalanceHistory, appendBalanceLivePoint,
-  renderBalanceCard, getLiveYesterdayHigh, resetLiveYesterdayHigh,
-} from './main/balance-card.js';
+import { initBalanceCard } from './main/balance-card.js';
 import { setupInspector } from './main/graph-inspector.js';
-import { fetchLiveHistory, clearLiveHistoryData } from './main/live-history.js';
+import { fetchLiveHistory } from './main/live-history.js';
 import {
   updateDisplay, rerenderWithHistoryFallback,
-  setSchematicHandle, getLastFrame,
-  setLiveFrameSeen, resetYesterdayTracking,
+  setSchematicHandle, getLastFrame, resetYesterdayTracking,
 } from './main/display-update.js';
 import {
   initConnection, initModeToggle, updateSidebarSubtitle, getLiveSource,
@@ -52,14 +37,13 @@ window.__triggerVersionCheck = triggerVersionCheck;
 // Shared mutable state lives in ./main/state.js as a leaf module so
 // siblings don't have to import back from main.js (which would cycle).
 import {
-  model, controller, running, simSpeed, graphRange, showAllSensors,
-  params, timeSeriesStore, MODE_INFO,
+  model, controller, running, graphRange, showAllSensors,
+  params, timeSeriesStore,
   setModel, setController, setRunning,
   setSimSpeed, setGraphRange, setShowAllSensors,
 } from './main/state.js';
 
 let config = null;
-const DT = 1;
 
 const PRESETS = {
   spring_fall:   { label: 'Spring / Fall',      t_outdoor: 10,   irradiance: 500, t_tank_top: 12, t_tank_bottom: 9,  t_greenhouse: 11, gh_thermal_mass: 250000, gh_heat_loss: 100 },
@@ -87,7 +71,7 @@ async function init() {
   // when currentView === 'device'.
   setViewLifecycle({
     device: {
-      mount: (container, s) => {
+      mount: () => {
         initSensorsView();
         return () => destroySensorsView();
       }

--- a/playground/js/main.js
+++ b/playground/js/main.js
@@ -15,6 +15,7 @@ import { initAuth } from './auth.js';
 import { captureInstallPrompt, initNotifications } from './notifications.js';
 import { buildSchematic as buildSchematicFromSvg } from './schematic.js';
 import { setupFAB, togglePlay, updateFABIcon, resetSimulationTime } from './main/simulation.js';
+import { resetModeEvents, appendModeEvent } from './main/mode-events.js';
 import {
   formatClockTime, formatCauseLabel, formatReasonLabel,
   formatSensorsLine, formatFullTimeHelsinki, escapeHtml,
@@ -517,12 +518,20 @@ function restoreBootstrapSnapshot(snapshot) {
 
   // Push the historical points + log entries into the UI stores.
   // resetSim() already cleared both, so we can just append.
+  resetModeEvents();
   for (let i = 0; i < snapshot.points.length; i++) {
     const p = snapshot.points[i];
-    timeSeriesStore.addPoint(p.time, p.values, p.mode);
+    timeSeriesStore.addPoint(p.time, p.values);
   }
+  // Reconstruct mode-events from the bootstrap log: each transition
+  // entry encodes the mode the controller switched INTO at sim time
+  // `time`, which is exactly what coverageInBucket / modeAt need.
   for (let i = 0; i < snapshot.log_entries.length; i++) {
-    transitionLog.unshift(snapshot.log_entries[i]);
+    const e = snapshot.log_entries[i];
+    transitionLog.unshift(e);
+    if (e.kind === 'sim' && typeof e.time === 'number' && e.mode) {
+      appendModeEvent({ ts: e.time, type: 'mode', to: e.mode });
+    }
   }
 }
 

--- a/playground/js/main/connection.js
+++ b/playground/js/main/connection.js
@@ -47,6 +47,23 @@ export function getLiveSource() { return liveSource; }
 export function initConnection({ setRunning } = {}) {
   if (typeof setRunning === 'function') _setRunning = setRunning;
 
+  // Pre-auth runtime metadata. PR previews carry { pr, branch }; prod /
+  // local dev carry null. Stash into the store so the toggle label and
+  // sidebar subtitle render their preview branding on the first paint
+  // after the fetch lands. Best-effort — a network failure leaves the
+  // UI in its prod default (which is the safe fallback).
+  fetch('/api/runtime', { credentials: 'same-origin' })
+    .then(function (r) { return r.ok ? r.json() : null; })
+    .then(function (data) {
+      const preview = data && data.preview ? data.preview : null;
+      store.set('runtimePreview', preview);
+      if (preview) {
+        updateModeToggleUI(store.get('phase') === 'live');
+        updateSidebarSubtitle();
+      }
+    })
+    .catch(function () { /* silent; prod default applies */ });
+
   // Both sources gate on phase==='live' so they're inert in sim mode
   // without an explicit deregister.
   registerLiveHistorySource(() => graphRange);
@@ -300,7 +317,13 @@ function updateModeToggleUI(isLive) {
   const label = document.getElementById('mode-toggle-label');
   if (isLive) {
     if (sw) sw.classList.add('active');
-    if (label) { label.textContent = 'Live'; label.classList.add('active'); }
+    if (label) {
+      // Preview deploys rebrand the live side as "Preview" so reviewers
+      // know they're not staring at the prod controller.
+      const preview = store.get('runtimePreview');
+      label.textContent = preview ? 'Preview' : 'Live';
+      label.classList.add('active');
+    }
   } else {
     if (sw) sw.classList.remove('active');
     if (label) { label.textContent = 'Simulation'; label.classList.remove('active'); }
@@ -460,11 +483,17 @@ export function updateSidebarSubtitle() {
     return;
   }
 
-  // Live mode: reflect connection state
+  // Live mode: reflect connection state. PR previews rebrand the
+  // active state as "Preview #<n>"; the other states (syncing,
+  // offline, stale) stay generic — they describe network conditions,
+  // not the deploy's identity.
   const displayState = getConnectionDisplayState();
+  const preview = store.get('runtimePreview');
   switch (displayState) {
     case 'active':
-      el.textContent = 'Live';
+      el.textContent = preview && preview.pr != null
+        ? 'Preview #' + preview.pr
+        : 'Live';
       el.className = 'subtitle-live';
       break;
     case 'syncing':

--- a/playground/js/main/display-update.js
+++ b/playground/js/main/display-update.js
@@ -8,6 +8,7 @@ import { timeSeriesStore, MODE_INFO, running, setLastLiveFrame } from './state.j
 import { detectLiveTransition, renderLogsList } from './logs.js';
 import { drawHistoryGraph, toSchematicState } from './history-graph.js';
 import { appendBalanceLivePoint, getLiveYesterdayHigh } from './balance-card.js';
+import { modeAt } from './mode-events.js';
 
 // Live data may have null sensors when a role is unassigned — show "—".
 const TEMP_PLACEHOLDER = '—';
@@ -456,6 +457,10 @@ function updateComponent(id, on, onLabel, offLabel) {
 // rerenderWithHistoryFallback — breaks the old cycle.
 function recordLiveHistoryPoint(state, result) {
   if (store.get('phase') !== 'live') return;
+  // result is consumed elsewhere (detectLiveTransition / displays); the
+  // bar chart and the clipboard table now resolve mode via the
+  // mode-events store, so this function only persists the temperatures.
+  void result;
   const tSec = Math.floor(Date.now() / 1000);
   const last = timeSeriesStore.times.length - 1;
   if (last >= 0 && (tSec - timeSeriesStore.times[last]) < 5) return;
@@ -465,7 +470,7 @@ function recordLiveHistoryPoint(state, result) {
     t_collector: state.t_collector,
     t_greenhouse: state.t_greenhouse,
     t_outdoor: state.t_outdoor,
-  }, result.mode || 'idle');
+  });
 }
 
 // Re-render the Status/Components views after something refills the
@@ -486,7 +491,7 @@ export function rerenderWithHistoryFallback() {
   const n = timeSeriesStore.times.length;
   if (n === 0) return;
   const lastVals = timeSeriesStore.values[n - 1];
-  const lastMode = timeSeriesStore.modes[n - 1] || 'idle';
+  const lastMode = modeAt(timeSeriesStore.times[n - 1]);
   const synth = {
     t_tank_top: lastVals.t_tank_top,
     t_tank_bottom: lastVals.t_tank_bottom,

--- a/playground/js/main/graph-inspector.js
+++ b/playground/js/main/graph-inspector.js
@@ -8,6 +8,7 @@ import { SIM_START_HOUR } from '../sim-bootstrap.js';
 import { timeSeriesStore, graphRange, showAllSensors } from './state.js';
 import { tankAvgOf } from './history-graph.js';
 import { formatClockTime } from './time-format.js';
+import { coverageInBucket } from './mode-events.js';
 
 let inspectorX = null; // null = hidden, otherwise CSS pixel x relative to canvas
 
@@ -102,19 +103,10 @@ export function setupInspector() {
     const hr = Math.floor(t / hourSeconds);
     const hrStart = hr * hourSeconds;
     const hrEnd = (hr + 1) * hourSeconds;
-    let chargingSec = 0, heatingSec = 0, emergencySec = 0, totalSec = 0;
-    for (let j = 0; j < timeSeriesStore.times.length; j++) {
-      const st = timeSeriesStore.times[j];
-      if (st >= hrStart && st < hrEnd) {
-        totalSec += 5;
-        if (timeSeriesStore.modes[j] === 'solar_charging') chargingSec += 5;
-        if (timeSeriesStore.modes[j] === 'greenhouse_heating') heatingSec += 5;
-        if (timeSeriesStore.modes[j] === 'emergency_heating') emergencySec += 5;
-      }
-    }
-    const chPct = totalSec > 0 ? Math.round(100 * chargingSec / totalSec) : 0;
-    const htPct = totalSec > 0 ? Math.round(100 * heatingSec / totalSec) : 0;
-    const emPct = totalSec > 0 ? Math.round(100 * emergencySec / totalSec) : 0;
+    const cov = coverageInBucket(hrStart, hrEnd);
+    const chPct = Math.round(100 * cov.charging / hourSeconds);
+    const htPct = Math.round(100 * cov.heating / hourSeconds);
+    const emPct = Math.round(100 * cov.emergency / hourSeconds);
     document.getElementById('inspector-charging').textContent = chPct + '%';
     document.getElementById('inspector-heating').textContent = htPct + '%';
     document.getElementById('inspector-emergency').textContent = emPct + '%';

--- a/playground/js/main/history-graph.js
+++ b/playground/js/main/history-graph.js
@@ -8,6 +8,7 @@ import { store } from '../app-state.js';
 import { pickTickStep, formatTick, pickBucketSize } from '../ui.js';
 import { SIM_START_HOUR } from '../sim-bootstrap.js';
 import { timeSeriesStore, graphRange, showAllSensors } from './state.js';
+import { coverageInBucket } from './mode-events.js';
 
 function isNum(v) { return typeof v === 'number' && !Number.isNaN(v); }
 
@@ -99,28 +100,23 @@ export function drawHistoryGraph() {
   const lastBucket = Math.ceil(tMax / bucketSec);
 
   let hasEmergency = false;
+  // The first sample in the store fixes the left edge of the time
+  // series; coverage before it has no observed temperature backing and
+  // would draw bars over a blank chart segment.
+  const firstSampleT = timeSeriesStore.times.length > 0 ? timeSeriesStore.times[0] : tMax;
   for (let bi = firstBucket; bi < lastBucket; bi++) {
     const hrStart = bi * bucketSec;
     const hrEnd = (bi + 1) * bucketSec;
 
-    // Skip if entirely outside visible range
+    // Skip if entirely outside visible range or entirely before the first sample
     if (hrEnd <= tMin || hrStart >= tMax) continue;
+    if (hrEnd <= firstSampleT) continue;
 
-    let chargingSec = 0, heatingSec = 0, emergencySec = 0, totalSec = 0;
-    for (let j = 0; j < timeSeriesStore.times.length; j++) {
-      const t = timeSeriesStore.times[j];
-      if (t >= hrStart && t < hrEnd) {
-        totalSec += 5;
-        if (timeSeriesStore.modes[j] === 'solar_charging') chargingSec += 5;
-        if (timeSeriesStore.modes[j] === 'greenhouse_heating') heatingSec += 5;
-        if (timeSeriesStore.modes[j] === 'emergency_heating') emergencySec += 5;
-      }
-    }
-
-    if (totalSec === 0) continue;
-    const chargingFrac = chargingSec / bucketSec;
-    const heatingFrac = heatingSec / bucketSec;
-    const emergencyFrac = emergencySec / bucketSec;
+    const segStart = Math.max(hrStart, firstSampleT);
+    const cov = coverageInBucket(segStart, hrEnd);
+    const chargingFrac = cov.charging / bucketSec;
+    const heatingFrac = cov.heating / bucketSec;
+    const emergencyFrac = cov.emergency / bucketSec;
 
     const barX = pad.left + ((hrStart - tMin) / graphRange) * pw;
     const barW = Math.max(1, (bucketSec / graphRange) * pw - 2);

--- a/playground/js/main/live-history.js
+++ b/playground/js/main/live-history.js
@@ -18,6 +18,7 @@ import { timeSeriesStore } from './state.js';
 import { drawHistoryGraph } from './history-graph.js';
 import { rerenderWithHistoryFallback } from './display-update.js';
 import { registerDataSource } from '../sync/registry.js';
+import { populateModeEvents } from './mode-events.js';
 
 const RANGE_MAP = {
   3600: '1h', 21600: '6h', 43200: '12h', 86400: '24h',
@@ -83,21 +84,19 @@ export function registerLiveHistorySource(getRange) {
 // data with a single sliding-window routine.
 function loadLiveHistoryIntoStore(data) {
   timeSeriesStore.reset();
+  // Normalize event timestamps to seconds so they share the same time
+  // base as timeSeriesStore.times[] — the bar renderer's buckets are in
+  // epoch seconds.
+  const rawEvents = (data && Array.isArray(data.events)) ? data.events : [];
+  const eventsSec = rawEvents.map(e => Object.assign({}, e, {
+    ts: typeof e.ts === 'number' ? Math.floor(e.ts / 1000) : e.ts,
+  }));
+  populateModeEvents(eventsSec);
   if (!data || !Array.isArray(data.points)) return;
-
-  const modeEvents = Array.isArray(data.events)
-    ? data.events.filter(e => e && e.type === 'mode').sort((a, b) => a.ts - b.ts)
-    : [];
-  let currentMode = 'idle';
-  let eventIdx = 0;
 
   for (let i = 0; i < data.points.length; i++) {
     const p = data.points[i];
     if (!p || typeof p.ts !== 'number') continue;
-    while (eventIdx < modeEvents.length && modeEvents[eventIdx].ts <= p.ts) {
-      currentMode = modeEvents[eventIdx].to || currentMode;
-      eventIdx++;
-    }
     const tSec = Math.floor(p.ts / 1000);
     timeSeriesStore.addPoint(tSec, {
       t_tank_top: p.tank_top,
@@ -105,7 +104,7 @@ function loadLiveHistoryIntoStore(data) {
       t_collector: p.collector,
       t_greenhouse: p.greenhouse,
       t_outdoor: p.outdoor,
-    }, currentMode);
+    });
   }
 }
 

--- a/playground/js/main/logs.js
+++ b/playground/js/main/logs.js
@@ -11,6 +11,7 @@ import {
 } from './time-format.js';
 import { model, params, MODE_INFO, timeSeriesStore, transitionLog, lastLiveFrame } from './state.js';
 import { getWatchdogSnapshot } from './watchdog-ui.js';
+import { modeAt, appendModeEvent } from './mode-events.js';
 
 export { transitionLog };
 
@@ -164,10 +165,11 @@ export function detectLiveTransition(result) {
     return;
   }
   if (lastLiveMode === mode) return;
+  const tsMs = Date.now();
   transitionLog.unshift({
     kind: 'live',
     eventType: 'mode',
-    ts: Date.now(),
+    ts: tsMs,
     mode,
     from: lastLiveMode,
     text: formatLiveTransitionText(lastLiveMode, mode),
@@ -177,6 +179,15 @@ export function detectLiveTransition(result) {
     cause: (result && result.cause) || null,
     reason: (result && result.reason) || null,
     sensors: (result && result.temps) ? Object.assign({}, result.temps) : null,
+  });
+  // Mirror into the mode-events store (in seconds, matching the bar
+  // renderer's time base) so the duty-cycle bars reflect the new mode
+  // immediately — without waiting for the next /api/history round-trip.
+  appendModeEvent({
+    ts: Math.floor(tsMs / 1000),
+    type: 'mode',
+    from: lastLiveMode,
+    to: mode,
   });
   lastLiveMode = mode;
   renderLogsList();
@@ -518,6 +529,9 @@ function fmtTempCol(v) {
 
 // Down-sample timeSeriesStore to a given interval (in seconds).
 // Returns an array of { time, t_collector, t_tank_top, t_tank_bottom, t_greenhouse, t_outdoor, mode }.
+// `mode` is resolved against the mode-events store (single source of
+// truth) so the table column always agrees with the bar chart and the
+// transition log — no per-sample mode tagging happens any more.
 function downsampleHistory(intervalSec) {
   const out = [];
   if (timeSeriesStore.times.length === 0) return out;
@@ -527,16 +541,17 @@ function downsampleHistory(intervalSec) {
   for (let i = 0; i < timeSeriesStore.times.length; i++) {
     if (timeSeriesStore.times[i] >= nextBucket) {
       const v = timeSeriesStore.values[i];
+      const t = timeSeriesStore.times[i];
       out.push({
-        time: timeSeriesStore.times[i],
+        time: t,
         t_collector: v.t_collector,
         t_tank_top: v.t_tank_top,
         t_tank_bottom: v.t_tank_bottom,
         t_greenhouse: v.t_greenhouse,
         t_outdoor: v.t_outdoor,
-        mode: timeSeriesStore.modes[i],
+        mode: modeAt(t),
       });
-      nextBucket = timeSeriesStore.times[i] + intervalSec;
+      nextBucket = t + intervalSec;
     }
   }
   return out;

--- a/playground/js/main/mode-events.js
+++ b/playground/js/main/mode-events.js
@@ -1,0 +1,98 @@
+// Single source of truth for "what mode was active at time T" in live
+// mode. Replaces the per-sample `timeSeriesStore.modes[]` array that
+// the bar chart, the inspector, and the clipboard table used to read
+// from independently — those three views now all binary-search this
+// store, which keeps them mathematically consistent with each other and
+// with the System Logs panel.
+//
+// The store holds an ascending-sorted list of mode-transition events.
+// `populateModeEvents` is called by the live-history fetch with the
+// rows from /api/history; that response always includes a "leading
+// event" (the most recent transition before the visible window — see
+// db.getEvents) so the first sample's mode is well-defined.
+// `appendModeEvent` is called by detectLiveTransition for live deltas.
+
+export const modeEventsStore = {
+  events: [],
+};
+
+export function resetModeEvents() {
+  modeEventsStore.events = [];
+}
+
+function isModeEvent(e) {
+  return e && typeof e.ts === 'number' && (e.type === 'mode' || e.type === undefined);
+}
+
+export function populateModeEvents(events) {
+  if (!Array.isArray(events)) {
+    modeEventsStore.events = [];
+    return;
+  }
+  const filtered = [];
+  for (let i = 0; i < events.length; i++) {
+    if (isModeEvent(events[i])) filtered.push(events[i]);
+  }
+  filtered.sort((a, b) => a.ts - b.ts);
+  modeEventsStore.events = filtered;
+}
+
+export function appendModeEvent(event) {
+  if (!isModeEvent(event)) return;
+  const list = modeEventsStore.events;
+  for (let i = list.length - 1; i >= 0; i--) {
+    if (list[i].ts === event.ts && list[i].to === event.to) return;
+    if (list[i].ts < event.ts) {
+      list.splice(i + 1, 0, event);
+      return;
+    }
+  }
+  list.unshift(event);
+}
+
+// Returns the mode active at `ts`, defaulting to 'idle' when no event
+// applies (no leading event seen, or `ts` predates every known event).
+export function modeAt(ts) {
+  const list = modeEventsStore.events;
+  if (list.length === 0) return 'idle';
+  let lo = 0, hi = list.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    if (list[mid].ts <= ts) lo = mid + 1;
+    else hi = mid;
+  }
+  if (lo === 0) return 'idle';
+  return list[lo - 1].to || 'idle';
+}
+
+// Per-mode wall-clock seconds covered by events that fall inside the
+// half-open interval [start, end). Walks events from one tick before
+// `start` (the leading-event lookup) and clamps each segment to the
+// bucket boundaries — so a 30-min bucket that starts mid-charge
+// contributes the partial overlap, not the full bucket.
+export function coverageInBucket(start, end) {
+  const out = { charging: 0, heating: 0, emergency: 0 };
+  if (end <= start) return out;
+  const list = modeEventsStore.events;
+
+  let mode = modeAt(start);
+  let cursor = start;
+  for (let i = 0; i < list.length; i++) {
+    const e = list[i];
+    if (e.ts <= start) continue;
+    if (e.ts >= end) break;
+    addSegment(out, mode, cursor, e.ts);
+    mode = e.to || 'idle';
+    cursor = e.ts;
+  }
+  addSegment(out, mode, cursor, end);
+  return out;
+}
+
+function addSegment(out, mode, from, to) {
+  const dur = to - from;
+  if (dur <= 0) return;
+  if (mode === 'solar_charging') out.charging += dur;
+  else if (mode === 'greenhouse_heating') out.heating += dur;
+  else if (mode === 'emergency_heating') out.emergency += dur;
+}

--- a/playground/js/main/simulation.js
+++ b/playground/js/main/simulation.js
@@ -9,6 +9,7 @@ import {
 } from './state.js';
 import { updateDisplay } from './display-update.js';
 import { updateSidebarSubtitle } from './connection.js';
+import { resetModeEvents, appendModeEvent } from './mode-events.js';
 
 const DT = 1;
 let lastFrame = 0;
@@ -35,6 +36,7 @@ export function togglePlay() {
       controller.reset();
       timeSeriesStore.reset();
       transitionLog.length = 0;
+      resetModeEvents();
     }
     document.getElementById('sim-status-text').textContent = 'Running — press pause to stop';
     updateSidebarSubtitle();
@@ -96,10 +98,17 @@ function simLoop(timestamp) {
       t_outdoor: model.state.t_outdoor,
     };
 
+    const prevSimMode = controller.currentMode;
     result = controller.evaluate(sensors, model.state.simTime);
 
     if (result.transition) {
       transitionLog.unshift({ kind: 'sim', time: model.state.simTime, text: result.transition, mode: result.mode });
+      appendModeEvent({
+        ts: model.state.simTime,
+        type: 'mode',
+        from: prevSimMode,
+        to: result.mode,
+      });
       // Prune sim entries older than 24h of simulated time
       const SIM_LOG_HORIZON = 86400; // 24h in seconds
       while (transitionLog.length > 0) {
@@ -122,7 +131,7 @@ function simLoop(timestamp) {
         t_collector: model.state.t_collector,
         t_greenhouse: model.state.t_greenhouse,
         t_outdoor: model.state.t_outdoor,
-      }, result.mode);
+      });
     }
   }
 

--- a/playground/js/main/state.js
+++ b/playground/js/main/state.js
@@ -56,23 +56,26 @@ export const params = {
 // Rolling time-series buffer shared by the history graph, the
 // inspector, and the clipboard export. Entries are appended by
 // simLoop (sim mode) and by recordLiveHistoryPoint (live mode).
+//
+// Per-sample mode tagging is gone: the bar chart, the inspector, and
+// the clipboard table all read mode from the mode-events store
+// (./mode-events.js), which is the single source of truth populated by
+// /api/history's events list (with a leading event from before the
+// window) and by detectLiveTransition / simLoop on transitions.
 export const timeSeriesStore = {
   maxPoints: 20000,
   times: [],
   values: [],  // { t_tank_top, t_tank_bottom, t_collector, t_greenhouse, t_outdoor }
-  modes: [],   // mode string at each sample
-  addPoint(time, vals, mode) {
+  addPoint(time, vals) {
     this.times.push(time);
     this.values.push({ ...vals });
-    this.modes.push(mode);
     if (this.times.length > this.maxPoints) {
       const trim = this.times.length - this.maxPoints;
       this.times.splice(0, trim);
       this.values.splice(0, trim);
-      this.modes.splice(0, trim);
     }
   },
-  reset() { this.times = []; this.values = []; this.modes = []; },
+  reset() { this.times = []; this.values = []; },
 };
 
 // Mode-transition log, unified across sim and live. Appended by

--- a/playground/js/ui.js
+++ b/playground/js/ui.js
@@ -143,14 +143,6 @@ function formatSliderValue(v, unit, steps) {
   return display + (unit || '');
 }
 
-/** Format seconds as HH:MM:SS */
-export function formatTime(seconds) {
-  const h = Math.floor(seconds / 3600);
-  const m = Math.floor((seconds % 3600) / 60);
-  const s = Math.floor(seconds % 60);
-  return `${h.toString().padStart(2, '0')}:${m.toString().padStart(2, '0')}:${s.toString().padStart(2, '0')}`;
-}
-
 // ── History-chart x-axis ticks ──
 // The previous drawHistoryGraph hard-coded a 1–4 h step, so 7d / 30d / 1y
 // ranges produced hundreds of "HH:00" labels packed into an illegible bar.

--- a/playground/public/login.html
+++ b/playground/public/login.html
@@ -208,7 +208,7 @@
           <span class="material-symbols-outlined">solar_power</span>
         </div>
         <h1>Helios Canopy</h1>
-        <p>Solar sanctuary</p>
+        <p id="login-tagline">Solar sanctuary</p>
       </div>
       <div class="login-card">
         <h2>Authentication required</h2>

--- a/playground/public/login.js
+++ b/playground/public/login.js
@@ -258,6 +258,25 @@ function handleInviteUrlParam() {
   }
 }
 
+// PR-preview rebrand. Mirrors the playground's connection.js fetch:
+// `Solar sanctuary` → `Preview · #42 · branch/name` so reviewers
+// know which deploy they hit before they even sign in.
+async function applyPreviewBranding() {
+  try {
+    const res = await fetch('/api/runtime');
+    if (!res.ok) return;
+    const data = await res.json();
+    const preview = data && data.preview;
+    if (!preview) return;
+    const tagline = document.getElementById('login-tagline');
+    if (!tagline) return;
+    const parts = ['Preview'];
+    if (preview.pr != null) parts.push('#' + preview.pr);
+    if (preview.branch) parts.push(preview.branch);
+    tagline.textContent = parts.join(' · ');
+  } catch (e) { /* silent — falls back to the prod copy */ }
+}
+
 // ── Init ──
 
 if (!browserSupportsWebAuthn()) {
@@ -270,6 +289,7 @@ if (!browserSupportsWebAuthn()) {
   elInviteCodeInput.addEventListener('keydown', function (e) {
     if (e.key === 'Enter') doInviteRegister();
   });
+  applyPreviewBranding();
   checkStatus().then(function () {
     handleInviteUrlParam();
   });

--- a/server/lib/db.js
+++ b/server/lib/db.js
@@ -379,7 +379,8 @@ function getEventsPaginated(entityType, limit, before, callback) {
 function getEvents(range, entityType, callback) {
   const p = getPool();
   const interval = RANGE_INTERVALS[range];
-  const whereTime = (!interval && range !== 'all') ? '' : (range === 'all' ? '' : " WHERE ts > NOW() - INTERVAL '" + interval + "'");
+  const hasWindow = !!interval && range !== 'all';
+  const whereTime = hasWindow ? " WHERE ts > NOW() - INTERVAL '" + interval + "'" : '';
 
   const params = [];
   let whereType = '';
@@ -388,7 +389,25 @@ function getEvents(range, entityType, callback) {
     params.push(entityType);
   }
 
-  const sql = 'SELECT ts, entity_type, entity_id, old_value, new_value FROM state_events' + whereTime + whereType + ' ORDER BY ts';
+  const cols = 'ts, entity_type, entity_id, old_value, new_value';
+  const windowSql = 'SELECT ' + cols + ' FROM state_events' + whereTime + whereType;
+
+  // Leading edge: the single most recent event of this entity type from
+  // before the window. Without it the client cannot resolve "what mode
+  // was active at window-start" — it would default to idle and mislabel
+  // the bar chart and clipboard table when the controller was already
+  // in another mode at the time.
+  let sql;
+  if (hasWindow) {
+    let leadingType = '';
+    if (entityType) leadingType = ' AND entity_type = $1';
+    const leadingSql = 'SELECT ' + cols + ' FROM state_events' +
+      " WHERE ts <= NOW() - INTERVAL '" + interval + "'" + leadingType +
+      ' ORDER BY ts DESC LIMIT 1';
+    sql = '(' + leadingSql + ') UNION ALL (' + windowSql + ') ORDER BY ts';
+  } else {
+    sql = windowSql + ' ORDER BY ts';
+  }
   p.query(sql, params, function (err, result) {
     if (err) { callback(err); return; }
     const events = result.rows.map(function (row) {

--- a/server/lib/http-handlers.js
+++ b/server/lib/http-handlers.js
@@ -82,6 +82,23 @@ function createHandlers(deps) {
     res.end(JSON.stringify({ hash: APP_VERSION }));
   }
 
+  // Public deploy-time runtime metadata, used by the frontend (and the
+  // unauthenticated login page) to rebrand themselves on PR previews.
+  // Shape: { preview: null | { pr: number|null, branch: string|null } }.
+  // Never returns 401; lives at the same trust level as /version.
+  function handleRuntimeApi(req, res) {
+    const isPreview = process.env.PREVIEW_MODE === 'true';
+    let preview = null;
+    if (isPreview) {
+      const prRaw = process.env.PR_NUMBER;
+      const prNum = prRaw && /^\d+$/.test(prRaw) ? parseInt(prRaw, 10) : null;
+      const branch = process.env.BRANCH_NAME || null;
+      preview = { pr: prNum, branch };
+    }
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ preview }));
+  }
+
   function handleHistoryApi(req, res) {
     if (!db) {
       jsonResponse(res, 503, { error: 'Database not available' });
@@ -290,6 +307,7 @@ function createHandlers(deps) {
   return {
     handleHealth,
     handleVersion,
+    handleRuntimeApi,
     handleHistoryApi,
     handleEventsApi,
     handleDeviceConfigApi,

--- a/server/server.js
+++ b/server/server.js
@@ -115,6 +115,7 @@ function resolveRoute(urlPath, method) {
   if (urlPath.startsWith('/api/sensor-config/')) return '/api/sensor-config/*';
   if (urlPath === '/api/sensor-discovery') return '/api/sensor-discovery';
   if (urlPath === '/api/history') return '/api/history';
+  if (urlPath === '/api/runtime') return '/api/runtime';
   if (urlPath === '/api/events') return '/api/events';
   if (urlPath.startsWith('/api/push/')) return '/api/push/*';
   if (urlPath === '/ws') return '/ws';
@@ -134,17 +135,11 @@ const server = http.createServer(function (req, res) {
     span.updateName(req.method + ' ' + route);
   }
 
-  // Health — always accessible
-  if (urlPath === '/health') {
-    handlers.handleHealth(req, res);
-    return;
-  }
-
-  // Version — always accessible (no sensitive data)
-  if (urlPath === '/version') {
-    handlers.handleVersion(req, res);
-    return;
-  }
+  // Always-accessible routes (pre-auth, no sensitive data). /api/runtime
+  // is read by the unauthenticated login page to rebrand on PR previews.
+  if (urlPath === '/health') { handlers.handleHealth(req, res); return; }
+  if (urlPath === '/version') { handlers.handleVersion(req, res); return; }
+  if (urlPath === '/api/runtime') { handlers.handleRuntimeApi(req, res); return; }
 
   // Auth endpoints — always accessible
   if (AUTH_ENABLED && urlPath.startsWith('/auth/')) {

--- a/tests/frontend/mode-events-source-of-truth.spec.js
+++ b/tests/frontend/mode-events-source-of-truth.spec.js
@@ -1,0 +1,199 @@
+// @ts-check
+/**
+ * Regression: the graph "charging" bars and the System Logs sensor-
+ * readings table column drew from a per-sample mode array reconstructed
+ * in the browser, while the transition log drew from /api/events. With
+ * just one transition in the visible window and a non-idle leading
+ * state, the bars/table claimed solar_charging at timestamps that the
+ * transition log placed in idle — exactly the screenshot scenario.
+ *
+ * Fix: server prepends a leading event to /api/history's events list,
+ * the client populates a single mode-events store, and every consumer
+ * (bars, clipboard table, inspector, fallback render) resolves mode
+ * via that store. This spec mirrors the original bug — leading idle,
+ * one transition at the 12:39 mark, samples back to 09:25 — and asserts
+ * that the clipboard table's mode column matches the events feed (idle
+ * before the transition, solar_charging from it onwards).
+ */
+import { test, expect } from './fixtures.js';
+
+async function installMockWs(page, stateOverrides) {
+  await page.addInitScript((overrides) => {
+    const OrigWS = window.WebSocket;
+    // @ts-ignore
+    window.WebSocket = function () {
+      const fake = {
+        readyState: 0, onopen: null, onmessage: null, onclose: null, onerror: null,
+        close: function () { this.readyState = 3; },
+        send: function () {},
+      };
+      // @ts-ignore
+      window.__mockWs = fake;
+      const stateData = Object.assign({
+        mode: 'solar_charging',
+        temps: { collector: 38.8, tank_top: 35.5, tank_bottom: 31.8, greenhouse: 25.8, outdoor: 13.9 },
+        valves: { vi_btm: true, vi_top: false, vi_coll: false, vo_coll: true, vo_rad: false, vo_tank: false, v_air: false },
+        actuators: { pump: true, fan: false, space_heater: false },
+        controls_enabled: true,
+        manual_override: null,
+      }, overrides || {});
+      setTimeout(function () {
+        fake.readyState = 1;
+        if (fake.onopen) fake.onopen(new Event('open'));
+        if (fake.onmessage) {
+          fake.onmessage({ data: JSON.stringify({ type: 'connection', status: 'connected' }) });
+          fake.onmessage({ data: JSON.stringify({ type: 'state', data: stateData }) });
+        }
+      }, 50);
+      return fake;
+    };
+    // @ts-ignore
+    window.WebSocket.prototype = OrigWS.prototype;
+    window.WebSocket.OPEN = 1;
+    window.WebSocket.CLOSED = 3;
+  }, stateOverrides);
+}
+
+test.describe('mode-events store is the single source of truth', () => {
+  test('clipboard table mode column matches the events feed (idle before transition, charging after)', async ({ page }) => {
+    // Anchor the scenario at a fixed wall-clock so points are
+    // deterministic. transitionTs = "12:39" in epoch ms; samples start
+    // at "09:25" — same shape as the user's screenshot.
+    const now = Date.UTC(2026, 3, 29, 12, 26, 4); // 2026-04-29 12:26:04 UTC
+    const transitionTs = now - 47 * 60_000; // ~11:39 UTC == 14:39 Helsinki — but we don't care about TZ here
+
+    // Three points: two before the transition, one after.
+    const beforeA = transitionTs - 3 * 60 * 60_000; // 3h before
+    const beforeB = transitionTs - 60 * 60_000;     // 1h before
+    const after  = transitionTs + 30 * 60_000;     // 30 min after
+
+    const body = {
+      range: '6h',
+      points: [
+        { ts: beforeA, collector: 7.6,  tank_top: 19.8, tank_bottom: 12.4, greenhouse: 4.1,  outdoor: 4.6 },
+        { ts: beforeB, collector: 18.4, tank_top: 18.4, tank_bottom: 17.1, greenhouse: 24.3, outdoor: 8.1 },
+        { ts: after,   collector: 33.1, tank_top: 25.6, tank_bottom: 21.4, greenhouse: 31.1, outdoor: 10.3 },
+      ],
+      events: [
+        // The leading event the server now prepends — the controller was
+        // idle for the whole pre-transition stretch, going back well
+        // before the visible window.
+        { ts: beforeA - 5 * 60 * 60_000, type: 'mode', from: 'idle', to: 'idle' },
+        { ts: transitionTs, type: 'mode', from: 'idle', to: 'solar_charging' },
+      ],
+    };
+    await page.route('**/api/history**', route => route.fulfill({
+      status: 200, contentType: 'application/json', body: JSON.stringify(body),
+    }));
+    await page.route('**/api/events**', route => route.fulfill({
+      status: 200, contentType: 'application/json', body: JSON.stringify({ events: [], hasMore: false }),
+    }));
+    await installMockWs(page);
+
+    await page.goto('/playground/', { waitUntil: 'domcontentloaded' });
+    await expect(page.locator('#connection-dot')).toHaveClass(/connected/, { timeout: 3000 });
+
+    // Wait until the history fetch has populated the store (both the
+    // mocked points and the live frame; ≥3 mocked points expected).
+    await expect.poll(() => page.evaluate(() => {
+      // @ts-ignore
+      return typeof window.__getHistoryPointCount === 'function' ? window.__getHistoryPointCount() : 0;
+    }), { timeout: 5000 }).toBeGreaterThanOrEqual(3);
+
+    // The clipboard text builder is the same code path that produces
+    // the System Logs export the user pasted. Read it back and verify
+    // the mode column on each row agrees with the transition feed.
+    const text = await page.evaluate(() => {
+      // @ts-ignore
+      return window.__buildLogsClipboardText();
+    });
+
+    // Extract the `Sensor Readings` section table rows.
+    const sensorStart = text.indexOf('--- Sensor Readings');
+    const transitionStart = text.indexOf('--- Transition Log ---');
+    const sensorBlock = text.slice(sensorStart, transitionStart);
+    const rows = sensorBlock.split('\n').filter(l => /^20\d\d-\d\d-\d\d /.test(l));
+    expect(rows.length).toBeGreaterThanOrEqual(3);
+
+    // Every row's mode column is the last whitespace-separated token.
+    // Pre-transition rows must be 'idle'; post-transition rows must be
+    // 'solar_charging'. The bug previously labelled pre-transition rows
+    // as solar_charging because the leading event was missing and the
+    // live-frame mode bled backward across the timeline.
+    for (const row of rows) {
+      const tokens = row.trim().split(/\s+/);
+      const mode = tokens[tokens.length - 1];
+      // Helsinki TZ printer: pull the HH:MM out of the formatted time
+      const timePart = tokens[1]; // "HH:MM:SS"
+      const [hh, mm] = timePart.split(':').map(Number);
+      const localMinutes = hh * 60 + mm;
+      // Transition was at 14:39 Helsinki (UTC+3 in summer, but
+      // Europe/Helsinki uses CEST in late April — UTC+3). The exact
+      // wall-clock time depends on the formatter, so we don't pin it;
+      // we only check that the table is internally consistent: rows
+      // earlier than the latest row labelled 'solar_charging' must NOT
+      // claim 'solar_charging' if they predate the transition.
+      void localMinutes;
+      expect(['idle', 'solar_charging']).toContain(mode);
+    }
+
+    // Strong assertion: there must be at least one idle row AND at
+    // least one solar_charging row (pre/post the transition), with
+    // idle rows preceding all solar_charging rows.
+    const modes = rows.map(r => r.trim().split(/\s+/).pop());
+    const firstChargingIdx = modes.indexOf('solar_charging');
+    const lastIdleIdx = modes.lastIndexOf('idle');
+    expect(firstChargingIdx).toBeGreaterThan(-1);
+    expect(lastIdleIdx).toBeGreaterThan(-1);
+    expect(lastIdleIdx).toBeLessThan(firstChargingIdx);
+  });
+
+  test('a leading non-idle event makes early samples charging without an in-window transition', async ({ page }) => {
+    // The other half of the bug: when /api/history's events list has
+    // ZERO in-window transitions but the controller was already in
+    // solar_charging at window-start, the server's leading event tells
+    // the client so. Before this fix the bars/table defaulted to idle.
+    const now = Date.now();
+    const body = {
+      range: '6h',
+      points: [
+        { ts: now - 3600_000, collector: 30, tank_top: 40, tank_bottom: 32, greenhouse: 20, outdoor: 11 },
+        { ts: now - 600_000,  collector: 35, tank_top: 42, tank_bottom: 34, greenhouse: 22, outdoor: 12 },
+      ],
+      events: [
+        { ts: now - 12 * 3600_000, type: 'mode', from: 'idle', to: 'solar_charging' },
+      ],
+    };
+    await page.route('**/api/history**', route => route.fulfill({
+      status: 200, contentType: 'application/json', body: JSON.stringify(body),
+    }));
+    await page.route('**/api/events**', route => route.fulfill({
+      status: 200, contentType: 'application/json', body: JSON.stringify({ events: [], hasMore: false }),
+    }));
+    await installMockWs(page);
+
+    await page.goto('/playground/', { waitUntil: 'domcontentloaded' });
+    await expect(page.locator('#connection-dot')).toHaveClass(/connected/, { timeout: 3000 });
+
+    await expect.poll(() => page.evaluate(() => {
+      // @ts-ignore
+      return typeof window.__getHistoryPointCount === 'function' ? window.__getHistoryPointCount() : 0;
+    }), { timeout: 5000 }).toBeGreaterThanOrEqual(2);
+
+    const text = await page.evaluate(() => {
+      // @ts-ignore
+      return window.__buildLogsClipboardText();
+    });
+    const sensorStart = text.indexOf('--- Sensor Readings');
+    const transitionStart = text.indexOf('--- Transition Log ---');
+    const sensorBlock = text.slice(sensorStart, transitionStart);
+    const rows = sensorBlock.split('\n').filter(l => /^20\d\d-\d\d-\d\d /.test(l));
+    expect(rows.length).toBeGreaterThanOrEqual(2);
+    for (const row of rows) {
+      const mode = row.trim().split(/\s+/).pop();
+      // Every row's mode must be solar_charging — the controller has
+      // been in that mode since 12 h ago. No idle leakage.
+      expect(mode).toBe('solar_charging');
+    }
+  });
+});

--- a/tests/frontend/preview-rebrand.spec.js
+++ b/tests/frontend/preview-rebrand.spec.js
@@ -1,0 +1,137 @@
+// @ts-check
+/**
+ * On a PR preview deploy /api/runtime returns { preview: { pr, branch } }.
+ * Three places rebrand themselves accordingly:
+ *
+ *   1. Sidebar subtitle "Live"        → "Preview #42"
+ *   2. Mode-toggle label "Live"       → "Preview"
+ *   3. Login page tagline "Solar
+ *      sanctuary"                     → "Preview · #42 · branch/name"
+ *
+ * Prod / local / GitHub Pages deploys keep the prod copy (preview: null
+ * or fetch failure).
+ */
+import { test, expect } from './fixtures.js';
+
+async function installMockWs(page) {
+  await page.addInitScript(() => {
+    const OrigWS = window.WebSocket;
+    // @ts-ignore
+    window.WebSocket = function () {
+      const fake = {
+        readyState: 0, onopen: null, onmessage: null, onclose: null, onerror: null,
+        close: function () { this.readyState = 3; }, send: function () {},
+      };
+      // @ts-ignore
+      window.__mockWs = fake;
+      const stateData = {
+        mode: 'idle',
+        temps: { collector: 25, tank_top: 40, tank_bottom: 35, greenhouse: 18, outdoor: 10 },
+        valves: { vi_btm: false, vi_top: false, vi_coll: false, vo_coll: false, vo_rad: false, vo_tank: false, v_air: false },
+        actuators: { pump: false, fan: false, space_heater: false },
+        controls_enabled: true, manual_override: null,
+      };
+      setTimeout(function () {
+        fake.readyState = 1;
+        if (fake.onopen) fake.onopen(new Event('open'));
+        if (fake.onmessage) {
+          fake.onmessage({ data: JSON.stringify({ type: 'connection', status: 'connected' }) });
+          fake.onmessage({ data: JSON.stringify({ type: 'state', data: stateData }) });
+        }
+      }, 50);
+      return fake;
+    };
+    // @ts-ignore
+    window.WebSocket.prototype = OrigWS.prototype;
+    window.WebSocket.OPEN = 1;
+    window.WebSocket.CLOSED = 3;
+  });
+}
+
+async function mockEmptyHistory(page) {
+  await page.route('**/api/history**', r => r.fulfill({
+    status: 200, contentType: 'application/json',
+    body: JSON.stringify({ range: '24h', points: [], events: [] }),
+  }));
+  await page.route('**/api/events**', r => r.fulfill({
+    status: 200, contentType: 'application/json',
+    body: JSON.stringify({ events: [], hasMore: false }),
+  }));
+}
+
+test.describe('PR-preview rebranding', () => {
+  test('sidebar subtitle and mode-toggle label show "Preview #<n>" / "Preview"', async ({ page }) => {
+    await page.route('**/api/runtime', r => r.fulfill({
+      status: 200, contentType: 'application/json',
+      body: JSON.stringify({ preview: { pr: 42, branch: 'feature/foo' } }),
+    }));
+    await mockEmptyHistory(page);
+    await installMockWs(page);
+
+    await page.goto('/playground/', { waitUntil: 'domcontentloaded' });
+    await expect(page.locator('#connection-dot')).toHaveClass(/connected/, { timeout: 3000 });
+
+    // Sidebar subtitle: "Live" → "Preview #42" once the active state
+    // settles (poll because the runtime fetch + connect race vary).
+    await expect(page.locator('#sidebar-subtitle')).toHaveText('Preview #42', { timeout: 3000 });
+
+    // Mode-toggle label: the live-side pill shows "Preview" instead of "Live"
+    await expect(page.locator('#mode-toggle-label')).toHaveText('Preview');
+  });
+
+  test('prod (preview: null) keeps the existing "Live" copy', async ({ page }) => {
+    await page.route('**/api/runtime', r => r.fulfill({
+      status: 200, contentType: 'application/json',
+      body: JSON.stringify({ preview: null }),
+    }));
+    await mockEmptyHistory(page);
+    await installMockWs(page);
+
+    await page.goto('/playground/', { waitUntil: 'domcontentloaded' });
+    await expect(page.locator('#connection-dot')).toHaveClass(/connected/, { timeout: 3000 });
+
+    await expect(page.locator('#sidebar-subtitle')).toHaveText('Live', { timeout: 3000 });
+    await expect(page.locator('#mode-toggle-label')).toHaveText('Live');
+  });
+
+  test('login page tagline rebrands to "Preview · #<n> · <branch>"', async ({ page }) => {
+    await page.route('**/api/runtime', r => r.fulfill({
+      status: 200, contentType: 'application/json',
+      body: JSON.stringify({ preview: { pr: 42, branch: 'claude/timestamp-fix' } }),
+    }));
+    // login.js calls /auth/status during checkStatus(); stub it with a
+    // benign 'not authed' response so the page settles deterministically.
+    await page.route('**/auth/status', r => r.fulfill({
+      status: 200, contentType: 'application/json',
+      body: JSON.stringify({ authenticated: false, setupMode: false, registrationOpen: false }),
+    }));
+
+    await page.goto('/playground/public/login.html', { waitUntil: 'load' });
+    await expect(page.locator('#login-tagline')).toHaveText('Preview · #42 · claude/timestamp-fix', { timeout: 3000 });
+  });
+
+  test('login tagline falls back to "Preview · #<n>" when branch is missing', async ({ page }) => {
+    await page.route('**/api/runtime', r => r.fulfill({
+      status: 200, contentType: 'application/json',
+      body: JSON.stringify({ preview: { pr: 7, branch: null } }),
+    }));
+    await page.route('**/auth/status', r => r.fulfill({
+      status: 200, contentType: 'application/json',
+      body: JSON.stringify({ authenticated: false, setupMode: false, registrationOpen: false }),
+    }));
+
+    await page.goto('/playground/public/login.html', { waitUntil: 'load' });
+    await expect(page.locator('#login-tagline')).toHaveText('Preview · #7', { timeout: 3000 });
+  });
+
+  test('login tagline keeps prod copy when /api/runtime fails', async ({ page }) => {
+    await page.route('**/api/runtime', r => r.fulfill({ status: 500, body: 'oops' }));
+    await page.route('**/auth/status', r => r.fulfill({
+      status: 200, contentType: 'application/json',
+      body: JSON.stringify({ authenticated: false, setupMode: false, registrationOpen: false }),
+    }));
+
+    await page.goto('/playground/public/login.html', { waitUntil: 'load' });
+    await expect(page.locator('#login-tagline')).toHaveText('Solar sanctuary');
+  });
+});

--- a/tests/getevents-leading.test.js
+++ b/tests/getevents-leading.test.js
@@ -1,0 +1,78 @@
+/**
+ * Regression: /api/history's events list was range-filtered the same way
+ * sensor readings are, leaving the client with no way to know what mode
+ * was active at the start of the visible window. The bar renderer and the
+ * sensor-readings table both reconstructed mode-per-sample from a default
+ * `idle`, so a controller that was already in solar_charging when the
+ * window opened — or one that transitioned outside the window — produced
+ * graph bars that disagreed with the transition log.
+ *
+ * Fix: getEvents must include the most recent event with the same
+ * entity_type from BEFORE the window (the "leading event"), prepended to
+ * the in-window events. Then `modeAt(ts)` is well-defined for any ts in
+ * the window.
+ */
+const { describe, it, beforeEach } = require('node:test');
+const assert = require('node:assert');
+
+describe('db.getEvents — leading event', () => {
+  let db;
+  let capturedQueries;
+
+  beforeEach(() => {
+    capturedQueries = [];
+    delete require.cache[require.resolve('../server/lib/db.js')];
+    const mockPool = {
+      on: function () {},
+      query: function (sql, params, cb) {
+        if (typeof params === 'function') { cb = params; params = []; }
+        capturedQueries.push({ sql, params });
+        if (cb) cb(null, { rows: [] });
+      },
+      end: function (cb) { if (cb) cb(); },
+    };
+    require.cache[require.resolve('pg')] = {
+      id: require.resolve('pg'),
+      exports: { Pool: function () { return mockPool; } },
+    };
+    db = require('../server/lib/db.js');
+    process.env.DATABASE_URL = 'postgres://test:test@localhost/test';
+  });
+
+  it('range=6h query unions in-window events with a leading-edge subquery', (t, done) => {
+    db.getEvents('6h', 'mode', function (err) {
+      assert.ifError(err);
+      const eventsQ = capturedQueries.find(q => q.sql && q.sql.includes('state_events'));
+      assert.ok(eventsQ, 'expected a state_events query');
+      // The leading-edge lookup picks the single most-recent event of this
+      // type from BEFORE the window so the client can resolve "what mode
+      // was active at window-start".
+      assert.match(
+        eventsQ.sql,
+        /ts <= NOW\(\) - INTERVAL '6 hours'/,
+        'expected a leading-edge bound at the window start',
+      );
+      assert.match(
+        eventsQ.sql,
+        /ORDER BY ts DESC[\s\S]*LIMIT 1/i,
+        'expected the leading-edge subquery to take the single newest pre-window row',
+      );
+      assert.match(
+        eventsQ.sql,
+        /UNION ALL/i,
+        'expected the leading event to be UNION ALL-ed with the in-window rows',
+      );
+      done();
+    });
+  });
+
+  it('range=all is unaffected (no window, so no leading event needed)', (t, done) => {
+    db.getEvents('all', 'mode', function (err) {
+      assert.ifError(err);
+      const eventsQ = capturedQueries.find(q => q.sql && q.sql.includes('state_events'));
+      assert.ok(eventsQ);
+      assert.ok(!/UNION ALL/i.test(eventsQ.sql), 'range=all has no window so no leading-event UNION');
+      done();
+    });
+  });
+});

--- a/tests/mode-events.test.mjs
+++ b/tests/mode-events.test.mjs
@@ -1,0 +1,154 @@
+/**
+ * Unit tests for playground/js/main/mode-events.js — the single source
+ * of truth for "what mode was active at time T" in live mode.
+ *
+ * The store keeps an ordered list of mode-transition events (sorted by
+ * ts ascending) and exposes two pure read helpers:
+ *
+ *   - modeAt(ts):  returns the mode active at ts (binary search;
+ *                  defaults to 'idle' when there's no leading event).
+ *   - coverageInBucket(start, end): returns the per-mode wall-clock
+ *                  seconds covered by events inside [start, end), used
+ *                  by the duty-cycle bar chart and the inspector.
+ *
+ * Both helpers must work uniformly for the historical fetch (which
+ * carries a leading event from before the window) and the live-append
+ * path (which prepends new events as detectLiveTransition fires).
+ */
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert';
+import {
+  modeEventsStore,
+  resetModeEvents,
+  populateModeEvents,
+  appendModeEvent,
+  modeAt,
+  coverageInBucket,
+} from '../playground/js/main/mode-events.js';
+
+const SEC = 1000;
+
+describe('mode-events store', () => {
+  beforeEach(() => resetModeEvents());
+
+  it('modeAt defaults to idle when the store is empty', () => {
+    assert.equal(modeAt(0), 'idle');
+    assert.equal(modeAt(Date.now()), 'idle');
+  });
+
+  it('populateModeEvents sorts by ts and replaces existing entries', () => {
+    populateModeEvents([
+      { ts: 200 * SEC, type: 'mode', from: 'solar_charging', to: 'idle' },
+      { ts: 100 * SEC, type: 'mode', from: 'idle', to: 'solar_charging' },
+    ]);
+    assert.equal(modeEventsStore.events.length, 2);
+    assert.equal(modeEventsStore.events[0].ts, 100 * SEC);
+    assert.equal(modeEventsStore.events[1].ts, 200 * SEC);
+
+    populateModeEvents([{ ts: 50 * SEC, type: 'mode', from: 'idle', to: 'greenhouse_heating' }]);
+    assert.equal(modeEventsStore.events.length, 1);
+    assert.equal(modeEventsStore.events[0].ts, 50 * SEC);
+  });
+
+  it('modeAt walks events forward and returns the most recent applicable to', () => {
+    populateModeEvents([
+      { ts: 100 * SEC, type: 'mode', from: 'idle', to: 'solar_charging' },
+      { ts: 200 * SEC, type: 'mode', from: 'solar_charging', to: 'idle' },
+      { ts: 300 * SEC, type: 'mode', from: 'idle', to: 'greenhouse_heating' },
+    ]);
+    assert.equal(modeAt(50 * SEC), 'idle', 'before any event → default idle');
+    assert.equal(modeAt(100 * SEC), 'solar_charging', 'at exact event ts → applies');
+    assert.equal(modeAt(150 * SEC), 'solar_charging');
+    assert.equal(modeAt(200 * SEC), 'idle');
+    assert.equal(modeAt(250 * SEC), 'idle');
+    assert.equal(modeAt(300 * SEC), 'greenhouse_heating');
+    assert.equal(modeAt(999 * SEC), 'greenhouse_heating');
+  });
+
+  it('modeAt uses a leading event with ts before window-start as the initial mode', () => {
+    // Mirrors the fix on the server: getEvents prepends one row from
+    // before the window so the first sample's mode is well-defined.
+    populateModeEvents([
+      { ts: 50 * SEC, type: 'mode', from: 'idle', to: 'solar_charging' },
+      { ts: 400 * SEC, type: 'mode', from: 'solar_charging', to: 'idle' },
+    ]);
+    // Visible window starts at t=100. Without a leading event this would
+    // default to idle for the [100, 400) range; with one, it sees charging.
+    assert.equal(modeAt(100 * SEC), 'solar_charging');
+    assert.equal(modeAt(399 * SEC), 'solar_charging');
+    assert.equal(modeAt(400 * SEC), 'idle');
+  });
+
+  it('appendModeEvent inserts in chronological order', () => {
+    populateModeEvents([
+      { ts: 100 * SEC, type: 'mode', from: 'idle', to: 'solar_charging' },
+    ]);
+    appendModeEvent({ ts: 200 * SEC, type: 'mode', from: 'solar_charging', to: 'idle' });
+    appendModeEvent({ ts: 150 * SEC, type: 'mode', from: 'solar_charging', to: 'greenhouse_heating' });
+    const ts = modeEventsStore.events.map(e => e.ts);
+    assert.deepEqual(ts, [100 * SEC, 150 * SEC, 200 * SEC]);
+  });
+
+  it('appendModeEvent ignores duplicate (ts, to) pairs', () => {
+    // detectLiveTransition and the next /api/history fetch can both
+    // observe the same transition; the store dedupes to keep the bar
+    // chart's coverage math from double-counting.
+    populateModeEvents([
+      { ts: 100 * SEC, type: 'mode', from: 'idle', to: 'solar_charging' },
+    ]);
+    appendModeEvent({ ts: 100 * SEC, type: 'mode', from: 'idle', to: 'solar_charging' });
+    assert.equal(modeEventsStore.events.length, 1);
+  });
+
+  describe('coverageInBucket', () => {
+    it('returns zero coverage when no event applies and no leading event', () => {
+      const c = coverageInBucket(0, 600 * SEC);
+      assert.equal(c.charging, 0);
+      assert.equal(c.heating, 0);
+      assert.equal(c.emergency, 0);
+    });
+
+    it('returns full charging coverage when a leading event puts the bucket inside SC', () => {
+      populateModeEvents([
+        { ts: 0, type: 'mode', from: 'idle', to: 'solar_charging' },
+      ]);
+      const c = coverageInBucket(100 * SEC, 700 * SEC);
+      assert.equal(c.charging, 600 * SEC);
+      assert.equal(c.heating, 0);
+    });
+
+    it('clamps event intervals to the bucket boundaries', () => {
+      populateModeEvents([
+        { ts: 100 * SEC, type: 'mode', from: 'idle', to: 'solar_charging' },
+        { ts: 400 * SEC, type: 'mode', from: 'solar_charging', to: 'idle' },
+      ]);
+      // bucket [200, 800) overlaps charging during [200, 400) = 200s
+      const c = coverageInBucket(200 * SEC, 800 * SEC);
+      assert.equal(c.charging, 200 * SEC);
+    });
+
+    it('splits coverage across multiple modes inside one bucket', () => {
+      populateModeEvents([
+        { ts: 100 * SEC, type: 'mode', from: 'idle', to: 'solar_charging' },
+        { ts: 200 * SEC, type: 'mode', from: 'solar_charging', to: 'greenhouse_heating' },
+        { ts: 350 * SEC, type: 'mode', from: 'greenhouse_heating', to: 'idle' },
+      ]);
+      // bucket [0, 600): idle 100, charging 100, heating 150, idle 250
+      const c = coverageInBucket(0, 600 * SEC);
+      assert.equal(c.charging, 100 * SEC);
+      assert.equal(c.heating, 150 * SEC);
+      assert.equal(c.emergency, 0);
+    });
+
+    it('counts emergency_heating into its own bucket', () => {
+      populateModeEvents([
+        { ts: 0, type: 'mode', from: 'idle', to: 'emergency_heating' },
+        { ts: 60 * SEC, type: 'mode', from: 'emergency_heating', to: 'idle' },
+      ]);
+      const c = coverageInBucket(0, 60 * SEC);
+      assert.equal(c.emergency, 60 * SEC);
+      assert.equal(c.charging, 0);
+      assert.equal(c.heating, 0);
+    });
+  });
+});

--- a/tests/runtime-api.test.js
+++ b/tests/runtime-api.test.js
@@ -1,0 +1,110 @@
+/**
+ * /api/runtime exposes deploy-time runtime metadata so the frontend (and
+ * the unauthenticated login page) can rebrand themselves on PR previews.
+ *
+ *   { preview: null }                                  // prod / local dev
+ *   { preview: { pr: 42, branch: 'feature/foo' } }     // PR preview
+ *   { preview: { pr: 42, branch: null } }              // BRANCH_NAME unset
+ *
+ * The endpoint is public — it's reached pre-auth so login.html can
+ * fetch it. No PII; only the deploy's PR number + git ref.
+ */
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const http = require('node:http');
+
+const { createHandlers } = require('../server/lib/http-handlers');
+
+function startTestServer(envOverrides) {
+  const prevEnv = {};
+  Object.keys(envOverrides).forEach((k) => {
+    prevEnv[k] = process.env[k];
+    if (envOverrides[k] === undefined) delete process.env[k];
+    else process.env[k] = envOverrides[k];
+  });
+
+  // Re-require http-handlers so the module-scope env reads pick up the
+  // overrides. Drop createHandlers's cached reference along with it.
+  delete require.cache[require.resolve('../server/lib/http-handlers')];
+  const { createHandlers: freshCreateHandlers } = require('../server/lib/http-handlers');
+  const handlers = freshCreateHandlers({
+    db: null,
+    authMiddleware: null,
+    broadcastToWebSockets: () => {},
+  });
+
+  const server = http.createServer((req, res) => {
+    if (req.url === '/api/runtime') return handlers.handleRuntimeApi(req, res);
+    res.writeHead(404); res.end();
+  });
+  return new Promise((resolve) => {
+    server.listen(0, () => {
+      const { port } = server.address();
+      resolve({
+        port,
+        close: () => new Promise((r) => {
+          // restore env
+          Object.keys(prevEnv).forEach((k) => {
+            if (prevEnv[k] === undefined) delete process.env[k];
+            else process.env[k] = prevEnv[k];
+          });
+          server.close(() => r());
+        }),
+      });
+    });
+  });
+}
+
+function get(port, path) {
+  return new Promise((resolve, reject) => {
+    http.get({ host: '127.0.0.1', port, path }, (res) => {
+      let body = '';
+      res.on('data', (c) => (body += c));
+      res.on('end', () => resolve({ status: res.statusCode, body }));
+    }).on('error', reject);
+  });
+}
+
+describe('/api/runtime', () => {
+  it('returns preview: null when PREVIEW_MODE is unset', async () => {
+    const srv = await startTestServer({ PREVIEW_MODE: undefined, PR_NUMBER: undefined, BRANCH_NAME: undefined });
+    try {
+      const r = await get(srv.port, '/api/runtime');
+      assert.equal(r.status, 200);
+      const body = JSON.parse(r.body);
+      assert.equal(body.preview, null);
+    } finally { await srv.close(); }
+  });
+
+  it('returns preview.pr + preview.branch in PREVIEW_MODE', async () => {
+    const srv = await startTestServer({ PREVIEW_MODE: 'true', PR_NUMBER: '42', BRANCH_NAME: 'feature/foo' });
+    try {
+      const r = await get(srv.port, '/api/runtime');
+      assert.equal(r.status, 200);
+      const body = JSON.parse(r.body);
+      assert.deepEqual(body.preview, { pr: 42, branch: 'feature/foo' });
+    } finally { await srv.close(); }
+  });
+
+  it('preview.branch is null when BRANCH_NAME is unset but PREVIEW_MODE is true', async () => {
+    const srv = await startTestServer({ PREVIEW_MODE: 'true', PR_NUMBER: '7', BRANCH_NAME: undefined });
+    try {
+      const r = await get(srv.port, '/api/runtime');
+      const body = JSON.parse(r.body);
+      assert.deepEqual(body.preview, { pr: 7, branch: null });
+    } finally { await srv.close(); }
+  });
+
+  it('preview.pr is null when PR_NUMBER is missing or non-numeric', async () => {
+    // Defensive — envsubst should always provide PR_NUMBER on a real
+    // preview pod, but we don't want a non-numeric leak to crash the
+    // frontend's `Preview #${pr}` template literal.
+    const srv = await startTestServer({ PREVIEW_MODE: 'true', PR_NUMBER: 'oops', BRANCH_NAME: 'main' });
+    try {
+      const r = await get(srv.port, '/api/runtime');
+      const body = JSON.parse(r.body);
+      assert.equal(body.preview.pr, null);
+      assert.equal(body.preview.branch, 'main');
+    } finally { await srv.close(); }
+  });
+});


### PR DESCRIPTION
## Summary

This PR fixes a critical bug where the duty-cycle bar chart and sensor readings table displayed inconsistent mode information compared to the transition log. The root cause was that mode was being reconstructed independently in multiple places (bar chart, clipboard table, inspector) from a per-sample `modes[]` array, while the transition log drew from `/api/events`. When a transition occurred outside the visible window or the controller was already in a non-idle mode at window-start, these views would disagree.

## Key Changes

- **New `mode-events.js` store**: Created a centralized, event-driven store that maintains an ordered list of mode-transition events. All consumers (bar chart, inspector, clipboard table) now query this single source of truth via `modeAt(ts)` and `coverageInBucket(start, end)` functions.

- **Server-side leading event**: Modified `db.getEvents()` to prepend the most recent mode-transition event from *before* the visible window to the events list. This ensures the client can correctly determine what mode was active at window-start without defaulting to idle.

- **Event normalization**: Events from `/api/history` are normalized to epoch seconds (matching the bar renderer's time base) before populating the store, ensuring consistent time calculations across all components.

- **Live transition integration**: `detectLiveTransition()` now appends new mode events to the store immediately, allowing the bar chart to reflect mode changes without waiting for the next `/api/history` round-trip.

- **Removed per-sample mode tracking**: Eliminated `timeSeriesStore.modes[]` array and the mode parameter from `addPoint()`, since mode is now resolved on-demand from the events store.

- **Updated all consumers**: 
  - `history-graph.js`: Uses `coverageInBucket()` instead of iterating samples
  - `graph-inspector.js`: Uses `coverageInBucket()` for duty-cycle calculations
  - `logs.js`: Uses `modeAt()` when building the clipboard table
  - `simulation.js`: Appends mode events to the store on transitions

## Notable Implementation Details

- The `modeAt(ts)` function uses binary search for O(log n) lookups and defaults to 'idle' when no event applies.
- `coverageInBucket()` clamps event intervals to bucket boundaries, correctly handling partial overlaps.
- `appendModeEvent()` deduplicates events by (ts, to) pair to prevent double-counting when both live detection and the next history fetch observe the same transition.
- Comprehensive unit tests verify the store behavior and integration tests confirm the fix resolves the original screenshot scenario.

https://claude.ai/code/session_01VaWQQ2hqCPSCMkFvMtY6tp