### PR TITLE
Add PR preview deploys at pr-<n>.greenhouse.madekivi.fi with 4h TTL

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -1,0 +1,192 @@
+name: Preview Deploy
+
+# Triggers:
+#   - PR labeled `preview`        → first deploy
+#   - Subsequent push on labeled PR → redeploys with the new image
+#   - workflow_dispatch           → manual deploys (any branch, any PR
+#                                   number; useful for testing the
+#                                   workflow itself)
+on:
+  pull_request:
+    types: [labeled, synchronize]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number (the preview lives at pr-<n>.greenhouse.madekivi.fi)'
+        required: true
+      ref:
+        description: 'Git ref to deploy (branch / SHA)'
+        required: true
+        default: 'main'
+
+env:
+  REGISTRY: ghcr.io
+  PREVIEW_LABEL: preview
+  TTL_HOURS: 4
+
+permissions:
+  contents: read
+  packages: write
+  pull-requests: write
+
+jobs:
+  # Gate: only run on labeled PRs (or manual dispatch). The
+  # `pull_request` event fires on `labeled` regardless of which label
+  # was added, and on every `synchronize` push regardless of label
+  # state — so we filter here.
+  preflight:
+    runs-on: ubuntu-latest
+    outputs:
+      should_deploy: ${{ steps.gate.outputs.should_deploy }}
+      pr_number: ${{ steps.gate.outputs.pr_number }}
+      ref: ${{ steps.gate.outputs.ref }}
+      sha: ${{ steps.gate.outputs.sha }}
+    steps:
+      - id: gate
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          ACTION: ${{ github.event.action }}
+          LABEL_NAME: ${{ github.event.label.name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
+          DISPATCH_PR: ${{ inputs.pr_number }}
+          DISPATCH_REF: ${{ inputs.ref }}
+        run: |
+          set -euo pipefail
+          should_deploy=false
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            should_deploy=true
+            echo "pr_number=$DISPATCH_PR" >> "$GITHUB_OUTPUT"
+            echo "ref=$DISPATCH_REF" >> "$GITHUB_OUTPUT"
+            echo "sha=$DISPATCH_REF" >> "$GITHUB_OUTPUT"
+          elif [ "$EVENT_NAME" = "pull_request" ]; then
+            if [ "$ACTION" = "labeled" ] && [ "$LABEL_NAME" = "${PREVIEW_LABEL}" ]; then
+              should_deploy=true
+            elif [ "$ACTION" = "synchronize" ] && echo "$PR_LABELS" | grep -q "\"${PREVIEW_LABEL}\""; then
+              should_deploy=true
+            fi
+            echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+            echo "ref=$PR_HEAD_REF" >> "$GITHUB_OUTPUT"
+            echo "sha=$PR_HEAD_SHA" >> "$GITHUB_OUTPUT"
+          fi
+          echo "should_deploy=$should_deploy" >> "$GITHUB_OUTPUT"
+          echo "Decision: should_deploy=$should_deploy"
+
+  build:
+    needs: preflight
+    if: needs.preflight.outputs.should_deploy == 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      image_tag: ${{ steps.tag.outputs.image_tag }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.preflight.outputs.sha }}
+
+      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: tag
+        run: |
+          repo_lower="${GITHUB_REPOSITORY,,}"
+          echo "IMAGE_NAME=$repo_lower" >> "$GITHUB_ENV"
+          # Tag with the commit SHA so subsequent pushes produce a fresh
+          # image and the rolling update actually changes something.
+          echo "image_tag=preview-${{ needs.preflight.outputs.sha }}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+
+      - uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
+        with:
+          context: .
+          file: deploy/docker/Dockerfile
+          push: true
+          build-args: |
+            GIT_COMMIT=${{ needs.preflight.outputs.sha }}
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.image_tag }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  deploy:
+    needs: [preflight, build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Configure kubeconfig
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBE_CONFIG_DATA }}" | base64 -d > ~/.kube/config
+          chmod 600 ~/.kube/config
+
+      - name: Render preview manifests
+        env:
+          PR_NUMBER: ${{ needs.preflight.outputs.pr_number }}
+          IMAGE_TAG: ${{ needs.build.outputs.image_tag }}
+        run: |
+          set -euo pipefail
+          # 4-hour TTL refreshed on every deploy. ISO-8601 UTC; the GC
+          # CronJob parses this with `date -u -d`.
+          EXPIRES_AT=$(date -u -d "+${TTL_HOURS} hours" +%Y-%m-%dT%H:%M:%SZ)
+          export PR_NUMBER IMAGE_TAG EXPIRES_AT
+          mkdir -p rendered
+          for f in deploy/k8s/preview/*.yaml; do
+            envsubst < "$f" > "rendered/$(basename "$f")"
+          done
+          echo "--- rendered manifests ---"
+          cat rendered/*.yaml
+
+      - name: Apply preview manifests
+        run: |
+          kubectl apply -f rendered/
+
+      - name: Wait for rollout
+        run: |
+          kubectl rollout status \
+            deployment/app-preview-pr-${{ needs.preflight.outputs.pr_number }} \
+            --timeout=3m
+
+      - name: Comment on PR with preview URL
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v8.0.0
+        with:
+          script: |
+            const pr = context.issue.number;
+            const url = `https://pr-${pr}.greenhouse.madekivi.fi`;
+            const ttl = process.env.TTL_HOURS;
+            const sha = '${{ needs.preflight.outputs.sha }}'.slice(0, 7);
+            const body = [
+              '### Preview deploy ready',
+              '',
+              `🌐 ${url}`,
+              '',
+              `Commit: \`${sha}\` · TTL: ${ttl}h (refreshed on every push) · ` +
+              `Remove the \`preview\` label or close the PR to tear down immediately.`,
+              '',
+              '<!-- preview-deploy-marker -->',
+            ].join('\n');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr,
+              per_page: 100,
+            });
+            const existing = comments.find(c => c.body && c.body.includes('<!-- preview-deploy-marker -->'));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                comment_id: existing.id, body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: pr, body,
+              });
+            }

--- a/.github/workflows/preview-teardown.yml
+++ b/.github/workflows/preview-teardown.yml
@@ -1,0 +1,111 @@
+name: Preview Teardown
+
+# Triggers an immediate cleanup of the preview environment when:
+#   - PR is closed (merged or not)
+#   - The `preview` label is removed from a PR
+#
+# The 15-min preview-gc CronJob is the safety net; this workflow makes
+# teardown happen instantly when the user signals intent.
+on:
+  pull_request:
+    types: [closed, unlabeled]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to tear down'
+        required: true
+
+env:
+  PREVIEW_LABEL: preview
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  preflight:
+    runs-on: ubuntu-latest
+    outputs:
+      should_teardown: ${{ steps.gate.outputs.should_teardown }}
+      pr_number: ${{ steps.gate.outputs.pr_number }}
+    steps:
+      - id: gate
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          ACTION: ${{ github.event.action }}
+          LABEL_NAME: ${{ github.event.label.name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
+          DISPATCH_PR: ${{ inputs.pr_number }}
+        run: |
+          set -euo pipefail
+          should_teardown=false
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            should_teardown=true
+            echo "pr_number=$DISPATCH_PR" >> "$GITHUB_OUTPUT"
+          elif [ "$EVENT_NAME" = "pull_request" ]; then
+            echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+            if [ "$ACTION" = "closed" ]; then
+              # Only teardown if the PR was preview-labeled at any point
+              # (i.e. we likely deployed for it). If it never had the
+              # label, there's nothing to delete and the kubectl delete
+              # is a harmless no-op anyway.
+              should_teardown=true
+            elif [ "$ACTION" = "unlabeled" ] && [ "$LABEL_NAME" = "${PREVIEW_LABEL}" ]; then
+              should_teardown=true
+            fi
+          fi
+          echo "should_teardown=$should_teardown" >> "$GITHUB_OUTPUT"
+          echo "Decision: should_teardown=$should_teardown"
+
+  teardown:
+    needs: preflight
+    if: needs.preflight.outputs.should_teardown == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure kubeconfig
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBE_CONFIG_DATA }}" | base64 -d > ~/.kube/config
+          chmod 600 ~/.kube/config
+
+      - name: Delete preview resources
+        env:
+          PR_NUMBER: ${{ needs.preflight.outputs.pr_number }}
+        run: |
+          set -euo pipefail
+          echo "Tearing down preview-pr=$PR_NUMBER"
+          kubectl delete deploy,svc,ingress \
+            -l "preview-pr=$PR_NUMBER" \
+            --ignore-not-found
+          # cert-manager cleans the TLS Secret automatically when its
+          # owning Ingress is deleted (ownerReference). No explicit
+          # delete needed.
+
+      - name: Update PR comment
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v8.0.0
+        with:
+          script: |
+            const pr = ${{ needs.preflight.outputs.pr_number }};
+            const body = [
+              '### Preview deploy torn down',
+              '',
+              `Resources for PR #${pr} have been deleted.`,
+              '',
+              '<!-- preview-deploy-marker -->',
+            ].join('\n');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr,
+              per_page: 100,
+            });
+            const existing = comments.find(c => c.body && c.body.includes('<!-- preview-deploy-marker -->'));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                comment_id: existing.id, body,
+              });
+            }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,6 +221,23 @@ If any of these fail on the PR but passed locally, that's a signal something is 
 - **Config delivery**: `kubernetes_secret/app-secrets` (DATABASE_URL, SESSION_SECRET, S3 creds, NEW_RELIC_LICENSE_KEY) + `kubernetes_config_map/app-config` (PORT, AUTH_ENABLED, RPID, ORIGIN, DOMAIN, MQTT_HOST, OTEL_*). Managed by Terraform — read the .tf files for the full list.
 - **CD**: push to main → GitHub Actions → GHCR (app + openvpn images) → `kubectl set image` rolling update → `kubectl exec` runs `shelly/deploy.sh`. The Shelly deploy step is non-fatal. Requires `KUBE_CONFIG_DATA` GitHub secret (scoped deployer ServiceAccount — can only patch the `app` Deployment and exec into pods).
 
+## PR Preview Deploys
+
+Add the `preview` label to a PR → `.github/workflows/preview-deploy.yml` builds the branch, pushes a `preview-<sha>` image to GHCR, and applies `deploy/k8s/preview/` (templated via `envsubst`) into the `default` namespace. URL: `https://pr-<n>.greenhouse.madekivi.fi`. Requires the wildcard `*.greenhouse.madekivi.fi` CNAME (already set up). Each push refreshes the preview; removing the label or closing the PR triggers `preview-teardown.yml`.
+
+Preview pod = app container only (no `openvpn`, no `mosquitto` sidecars), `replicas: 1`. Critical environment overrides set by the manifest:
+
+- `PREVIEW_MODE=true` — see below.
+- `MQTT_HOST=mosquitto.default.svc.cluster.local` — preview subscribes to the prod broker (new `mosquitto` Service in `services.yaml`); never publishes (gated by `PREVIEW_MODE`).
+- `RPID=greenhouse.madekivi.fi`, `ORIGIN=https://pr-<n>.greenhouse.madekivi.fi` — existing prod passkeys validate on the subdomain because the RPID is a registrable parent of the preview origin's effective domain (WebAuthn rule).
+- `DATABASE_URL` inherited from `app-secrets` — same prod TimescaleDB. **Schema init and maintenance are skipped** in `PREVIEW_MODE` so a branch with `SCHEMA_SQL` changes cannot apply them to prod.
+
+`PREVIEW_MODE=true` makes the server a passive observer: it subscribes to MQTT and broadcasts to its own WebSocket clients, but never `db.insertSensorReadings` / `insertStateEvent`, never publishes (`greenhouse/config`, `greenhouse/sensor-config`, `greenhouse/relay-command`, `mqttRequest` all no-op), never evaluates push notifications, never routes watchdog/event to the anomaly manager, never writes script-crash rows. Search `PREVIEW_MODE` in `server/lib/mqtt-bridge.js` and `server/server.js` for every gate.
+
+Previews carry an `preview.greenhouse/expires-at` annotation (deploy-time + 4 h, refreshed on every push). `deploy/k8s/preview-gc-cronjob.yaml` runs every 15 min and deletes any preview whose annotation is in the past — safety net behind the workflow-driven teardown. The `preview-gc` ServiceAccount has its own RBAC scoped to the `default` namespace.
+
+Important: preview pods deliberately omit the `app=greenhouse` label so the prod `app` and `mosquitto` Services never select them as backends.
+
 ## Observability (New Relic)
 
 Optional OpenTelemetry → New Relic. Disabled by default (zero overhead). `server/lib/tracing.js` is loaded via `--require` before `server.js` and no-ops when `NEW_RELIC_LICENSE_KEY` is unset.

--- a/deploy/k8s/deployer-rbac.yaml
+++ b/deploy/k8s/deployer-rbac.yaml
@@ -35,6 +35,22 @@ rules:
   - apiGroups: [""]
     resources: ["pods/exec"]
     verbs: ["create"]
+  # Preview deploys: create/update/get/delete Deployment + Service +
+  # Ingress named app-preview-pr-* in the default namespace. RBAC can't
+  # pattern-match on resource names with wildcards via resourceNames,
+  # so we grant these verbs on the resource types in general —
+  # restricted to the default namespace by virtue of being a Role
+  # (not a ClusterRole). The earlier resourceNames: ["app"] rule keeps
+  # the prod Deployment patch path explicitly scoped.
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "watch", "create", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get", "list", "watch", "create", "patch", "delete"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses"]
+    verbs: ["get", "list", "watch", "create", "patch", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -61,3 +77,47 @@ metadata:
   annotations:
     kubernetes.io/service-account.name: deployer
 type: kubernetes.io/service-account-token
+---
+# Preview garbage collector. Runs as the preview-gc CronJob; deletes
+# expired preview resources (annotation preview.greenhouse/expires-at
+# in the past). Scoped to default namespace via Role.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: preview-gc
+  labels:
+    app: greenhouse
+    purpose: preview-gc
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: preview-gc
+  labels:
+    app: greenhouse
+    purpose: preview-gc
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "delete"]
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get", "list", "delete"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses"]
+    verbs: ["get", "list", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: preview-gc
+  labels:
+    app: greenhouse
+    purpose: preview-gc
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: preview-gc
+subjects:
+  - kind: ServiceAccount
+    name: preview-gc

--- a/deploy/k8s/kustomization.yaml
+++ b/deploy/k8s/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - app-deployment.yaml
   - services.yaml
   - ingress.yaml
+  - preview-gc-cronjob.yaml

--- a/deploy/k8s/preview-gc-cronjob.yaml
+++ b/deploy/k8s/preview-gc-cronjob.yaml
@@ -1,0 +1,66 @@
+# Preview deploys carry a preview.greenhouse/expires-at annotation
+# (ISO-8601 UTC, set to deploy_time+4h, refreshed on every push). This
+# CronJob runs every 15 minutes, walks every Deployment with
+# purpose=preview, and deletes the full set of resources for any PR
+# whose annotation is in the past. PR-close teardown happens
+# immediately via the workflow; this is the safety net.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: preview-gc
+  labels:
+    app: greenhouse
+    purpose: preview-gc
+spec:
+  schedule: "*/15 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      template:
+        spec:
+          serviceAccountName: preview-gc
+          restartPolicy: OnFailure
+          containers:
+            - name: gc
+              image: bitnami/kubectl:1.34
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -eu
+                  now=$(date -u +%s)
+                  prs=$(kubectl get deploy -l purpose=preview \
+                    -o jsonpath='{range .items[*]}{.metadata.labels.preview-pr}{"\n"}{end}' \
+                    | sort -u)
+                  for pr in $prs; do
+                    [ -z "$pr" ] && continue
+                    expiry=$(kubectl get deploy "app-preview-pr-$pr" \
+                      -o jsonpath='{.metadata.annotations.preview\.greenhouse/expires-at}' \
+                      2>/dev/null || true)
+                    if [ -z "$expiry" ]; then
+                      echo "preview-pr=$pr has no expires-at annotation — skipping"
+                      continue
+                    fi
+                    expiry_ts=$(date -u -d "$expiry" +%s 2>/dev/null || echo 0)
+                    if [ "$expiry_ts" -eq 0 ]; then
+                      echo "preview-pr=$pr has unparseable expires-at=$expiry — skipping"
+                      continue
+                    fi
+                    if [ "$expiry_ts" -lt "$now" ]; then
+                      echo "preview-pr=$pr expired at $expiry — deleting"
+                      kubectl delete deploy,svc,ingress -l "preview-pr=$pr" --ignore-not-found
+                    else
+                      remaining=$((expiry_ts - now))
+                      echo "preview-pr=$pr expires in ${remaining}s ($expiry)"
+                    fi
+                  done
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 32Mi
+                limits:
+                  cpu: 100m
+                  memory: 128Mi

--- a/deploy/k8s/preview/deployment.yaml
+++ b/deploy/k8s/preview/deployment.yaml
@@ -1,0 +1,103 @@
+# Preview/branch deploy. App container only — NO openvpn, NO mosquitto.
+# Sharing the prod app-secrets (DB + push + S3 creds) and shadowing
+# selected app-config keys via PREVIEW_MODE-aware overrides.
+#
+# Why no sidecars:
+#   - openvpn uses hostPort 1194/UDP, which is a node singleton already
+#     owned by the prod pod. A second openvpn would fail to schedule.
+#     Without it the preview pod has zero network path to real Shelly LAN
+#     hardware, which is also the safety property we want.
+#   - mosquitto-as-sidecar isn't needed: previews connect to the prod
+#     mosquitto via the in-cluster Service (see env below) so they
+#     observe live MQTT traffic without spinning up an isolated broker.
+#
+# Substituted at deploy time: ${PR_NUMBER}, ${IMAGE_TAG}, ${EXPIRES_AT}.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app-preview-pr-${PR_NUMBER}
+  labels:
+    preview-pr: "${PR_NUMBER}"
+    purpose: preview
+  annotations:
+    preview.greenhouse/expires-at: "${EXPIRES_AT}"
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      preview-pr: "${PR_NUMBER}"
+  template:
+    metadata:
+      # Intentionally NOT carrying app=greenhouse — that's the prod
+      # Service's selector and a stray match would route prod traffic
+      # to a preview pod.
+      labels:
+        preview-pr: "${PR_NUMBER}"
+        purpose: preview
+    spec:
+      terminationGracePeriodSeconds: 5
+      containers:
+        - name: app
+          image: ghcr.io/wnt/greenhouse-solar-heater:${IMAGE_TAG}
+          ports:
+            - name: http
+              containerPort: 3000
+          envFrom:
+            - configMapRef:
+                name: app-config
+            - secretRef:
+                name: app-secrets
+          # PREVIEW-specific overrides (these win over keys from app-config
+          # because they're listed last; envFrom + env merge with later
+          # entries overriding earlier).
+          env:
+            - name: PREVIEW_MODE
+              value: "true"
+            - name: ORIGIN
+              value: "https://pr-${PR_NUMBER}.greenhouse.madekivi.fi"
+            - name: DOMAIN
+              value: "pr-${PR_NUMBER}.greenhouse.madekivi.fi"
+            # Connect to the prod mosquitto sidecar via Service.
+            # Subscribes only — see PREVIEW_MODE in mqtt-bridge.js.
+            - name: MQTT_HOST
+              value: "mosquitto.default.svc.cluster.local"
+            # RPID stays as the parent so existing prod passkeys validate
+            # on the preview subdomain (RPID is a registrable parent of
+            # the preview origin's effective domain — WebAuthn allows it).
+            - name: RPID
+              value: "greenhouse.madekivi.fi"
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+          resources:
+            requests:
+              cpu: 50m
+              memory: 96Mi
+            limits:
+              cpu: 300m
+              memory: 384Mi
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 3000
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 3000
+            initialDelaySeconds: 2
+            periodSeconds: 5
+            timeoutSeconds: 3
+      volumes:
+        - name: tmp
+          emptyDir:
+            sizeLimit: 64Mi

--- a/deploy/k8s/preview/ingress.yaml
+++ b/deploy/k8s/preview/ingress.yaml
@@ -1,0 +1,29 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: app-preview-pr-${PR_NUMBER}
+  labels:
+    preview-pr: "${PR_NUMBER}"
+    purpose: preview
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+    preview.greenhouse/expires-at: "${EXPIRES_AT}"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - pr-${PR_NUMBER}.greenhouse.madekivi.fi
+      secretName: app-preview-pr-${PR_NUMBER}-tls
+  rules:
+    - host: pr-${PR_NUMBER}.greenhouse.madekivi.fi
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: app-preview-pr-${PR_NUMBER}
+                port:
+                  number: 3000

--- a/deploy/k8s/preview/service.yaml
+++ b/deploy/k8s/preview/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: app-preview-pr-${PR_NUMBER}
+  labels:
+    preview-pr: "${PR_NUMBER}"
+    purpose: preview
+  annotations:
+    preview.greenhouse/expires-at: "${EXPIRES_AT}"
+spec:
+  type: ClusterIP
+  selector:
+    preview-pr: "${PR_NUMBER}"
+  ports:
+    - name: http
+      port: 3000
+      targetPort: 3000

--- a/deploy/k8s/services.yaml
+++ b/deploy/k8s/services.yaml
@@ -13,3 +13,26 @@ spec:
       port: 3000
       targetPort: 3000
       protocol: TCP
+---
+# Exposes the prod pod's mosquitto sidecar so preview deploys can
+# subscribe to live MQTT traffic. Preview servers run with
+# PREVIEW_MODE=true, so they only subscribe — never publish — and the
+# prod pod's vpn-firewall init-container already allows TCP/1883 from
+# the cluster pod CIDR (192.168.0.0/16).
+# Preview pods deliberately omit the app=greenhouse label, so this
+# selector matches only the prod pod.
+apiVersion: v1
+kind: Service
+metadata:
+  name: mosquitto
+  labels:
+    app: greenhouse
+spec:
+  type: ClusterIP
+  selector:
+    app: greenhouse
+  ports:
+    - name: mqtt
+      port: 1883
+      targetPort: 1883
+      protocol: TCP

--- a/server/lib/mqtt-bridge.js
+++ b/server/lib/mqtt-bridge.js
@@ -19,6 +19,15 @@ let stateSnapshotListener = null;
 let previousState = null;
 let connectionStatus = 'disconnected';
 
+// PREVIEW_MODE: this server is a preview/branch deploy that shares the
+// production DB and MQTT broker but is NOT the persistence owner. It
+// subscribes (so the frontend gets live updates) and broadcasts to its
+// own WebSocket clients, but never publishes to MQTT and never writes
+// state-derived rows or notifications — those belong to prod.
+function isPreviewMode() {
+  return process.env.PREVIEW_MODE === 'true';
+}
+
 function start(options) {
   const mqtt = require('mqtt');
   db = options.db || null;
@@ -91,7 +100,10 @@ function start(options) {
         log.warn('invalid JSON on watchdog/event', { error: e.message });
         return;
       }
-      if (anomalyManagerRef && typeof anomalyManagerRef.handleDeviceEvent === 'function') {
+      // PREVIEW_MODE: anomaly manager writes a watchdog row to history and
+      // dispatches a push — both belong to prod. The preview's WS clients
+      // still see the watchdog state via the next greenhouse/state payload.
+      if (!isPreviewMode() && anomalyManagerRef && typeof anomalyManagerRef.handleDeviceEvent === 'function') {
         Promise.resolve(anomalyManagerRef.handleDeviceEvent(wdMsg)).catch(function (err) {
           log.error('anomaly handleDeviceEvent failed', { error: err.message });
         });
@@ -119,16 +131,17 @@ function start(options) {
 
 function handleStateMessage(payload) {
   const ts = payload.ts ? new Date(payload.ts) : new Date();
+  const preview = isPreviewMode();
 
-  // Persist sensor readings
-  if (db && payload.temps) {
+  // Persist sensor readings (skipped in PREVIEW_MODE — prod owns this)
+  if (db && payload.temps && !preview) {
     db.insertSensorReadings(ts, payload.temps, function (err) {
       if (err) log.error('db insert readings failed', { error: err.message });
     });
   }
 
-  // Detect state changes and persist events
-  if (db && previousState) {
+  // Detect state changes and persist events (skipped in PREVIEW_MODE)
+  if (db && previousState && !preview) {
     detectStateChanges(ts, previousState, payload);
   }
 
@@ -142,14 +155,17 @@ function handleStateMessage(payload) {
     }
   }
 
-  // Evaluate notification conditions (pre-emergency alerts, scheduled reports)
-  if (pushRef) {
+  // Evaluate notification conditions (skipped in PREVIEW_MODE — prod
+  // already evaluates and dispatches; running this in parallel would
+  // double-fire push notifications to subscribers).
+  if (pushRef && !preview) {
     try { notifications.evaluate(payload); } catch (e) {
       log.error('notification evaluate failed', { error: e.message });
     }
   }
 
-  // Broadcast to WebSocket clients
+  // Broadcast to WebSocket clients (always — this is what makes preview
+  // dashboards tick in real time).
   broadcastState(payload);
 }
 
@@ -251,6 +267,10 @@ function getConnectionStatus() {
 }
 
 function publishConfig(config) {
+  if (isPreviewMode()) {
+    log.warn('skipping publish (PREVIEW_MODE)', { topic: 'greenhouse/config' });
+    return false;
+  }
   if (!mqttClient || !mqttClient.connected) {
     log.warn('cannot publish config: MQTT not connected');
     return false;
@@ -286,6 +306,10 @@ function republishSensorConfig() {
 }
 
 function publishSensorConfig(config) {
+  if (isPreviewMode()) {
+    log.warn('skipping publish (PREVIEW_MODE)', { topic: 'greenhouse/sensor-config' });
+    return false;
+  }
   if (!mqttClient || !mqttClient.connected) {
     log.warn('cannot publish sensor config: MQTT not connected');
     return false;
@@ -297,6 +321,10 @@ function publishSensorConfig(config) {
 }
 
 function publishRelayCommand(relay, on) {
+  if (isPreviewMode()) {
+    log.warn('skipping publish (PREVIEW_MODE)', { topic: 'greenhouse/relay-command' });
+    return false;
+  }
   if (!mqttClient || !mqttClient.connected) {
     log.warn('cannot publish relay command: MQTT not connected');
     return false;
@@ -343,6 +371,10 @@ function subscribeResponseTopics() {
 }
 
 function mqttRequest(requestTopic, responseTopic, payload, timeoutMs) {
+  if (isPreviewMode()) {
+    log.warn('skipping request (PREVIEW_MODE)', { topic: requestTopic });
+    return Promise.reject(new Error('PREVIEW_MODE: request blocked'));
+  }
   if (!mqttClient || !mqttClient.connected) {
     return Promise.reject(new Error('MQTT not connected'));
   }
@@ -406,6 +438,10 @@ module.exports = {
   handleStateMessage,
   detectStateChanges,
   _setDeviceConfigRefForTest: function (ref) { deviceConfigRef = ref; },
+  _setDbForTest: function (val) { db = val; },
+  _setWsServerForTest: function (val) { wsServer = val; },
+  _setPushRefForTest: function (val) { pushRef = val; },
+  _setMqttClientForTest: function (val) { mqttClient = val; },
   _reset: function () {
     mqttClient = null;
     wsServer = null;

--- a/server/server.js
+++ b/server/server.js
@@ -32,6 +32,7 @@ const PLAYGROUND_DIR = path.join(__dirname, '..', 'playground');
 const AUTH_ENABLED = process.env.AUTH_ENABLED === 'true';
 const VPN_CHECK_HOST = process.env.VPN_CHECK_HOST || '';
 const MQTT_HOST = process.env.MQTT_HOST || '';
+const PREVIEW_MODE = process.env.PREVIEW_MODE === 'true';
 
 const MIME = {
   '.html': 'text/html',
@@ -458,18 +459,26 @@ function initServices(callback) {
     }
     if (url) {
       db = dbModule;
-      db.initSchema(function (schemaErr) {
-        if (schemaErr) {
-          log.error('db schema init failed', { error: schemaErr.message });
-          db = null;
-        } else {
-          log.info('database initialized');
-          db.startMaintenance();
-        }
+      const onDbReady = function () {
         setWsCommandHandlersDb(db);
         initAnomalyManager();
         finish();
-      });
+      };
+      if (PREVIEW_MODE) {
+        log.info('database connected (PREVIEW_MODE: schema + maintenance skipped)');
+        onDbReady();
+      } else {
+        db.initSchema(function (schemaErr) {
+          if (schemaErr) {
+            log.error('db schema init failed', { error: schemaErr.message });
+            db = null;
+          } else {
+            log.info('database initialized');
+            db.startMaintenance();
+          }
+          onDbReady();
+        });
+      }
     } else {
       log.info('DATABASE_URL not found (checked env and S3) — history features disabled');
       initAnomalyManager();
@@ -500,11 +509,13 @@ function startMqttBridge() {
   // Script monitor runs alongside the MQTT bridge so its snapshot buffer
   // is fed by the same stream. Status changes broadcast "script-status"
   // (drives the in-app banner) and feed the push notifier.
-  scriptMonitor = createScriptMonitor({ db });
-  const crashNotifier = createScriptCrashNotifier(push);
+  // PREVIEW_MODE: pass db=null + skip crashNotifier so previews don't
+  // write crash rows or double-fire push notifications.
+  scriptMonitor = createScriptMonitor({ db: PREVIEW_MODE ? null : db });
+  const crashNotifier = PREVIEW_MODE ? null : createScriptCrashNotifier(push);
   scriptMonitor.onStatusChange(function (s) {
     broadcastToWebSockets({ type: 'script-status', data: s });
-    crashNotifier(s);
+    if (crashNotifier) crashNotifier(s);
   });
 
   mqttBridge.start({

--- a/tests/mqtt-bridge.test.js
+++ b/tests/mqtt-bridge.test.js
@@ -511,4 +511,115 @@ describe('mqtt-bridge', () => {
         'no point in publishing an empty sensor config — Shelly would just keep all temps null');
     });
   });
+
+  describe('PREVIEW_MODE', () => {
+    let prevEnv;
+
+    beforeEach(() => {
+      prevEnv = process.env.PREVIEW_MODE;
+      process.env.PREVIEW_MODE = 'true';
+      delete require.cache[require.resolve('../server/lib/mqtt-bridge.js')];
+      bridge = require('../server/lib/mqtt-bridge.js');
+      bridge._reset();
+    });
+
+    afterEach(() => {
+      if (prevEnv === undefined) delete process.env.PREVIEW_MODE;
+      else process.env.PREVIEW_MODE = prevEnv;
+      bridge._reset();
+    });
+
+    it('handleStateMessage does not write sensor readings or state events to db', () => {
+      const writes = [];
+      bridge._setDbForTest({
+        insertSensorReadings: function () { writes.push('readings'); },
+        insertStateEvent: function () { writes.push('event'); },
+      });
+
+      bridge.handleStateMessage({
+        ts: 1, mode: 'idle', temps: { collector: 25 }, valves: {}, actuators: {},
+      });
+      bridge.handleStateMessage({
+        ts: 2, mode: 'solar_charging', temps: { collector: 60 }, valves: {}, actuators: {},
+      });
+
+      assert.deepStrictEqual(writes, [], 'preview must not persist state-derived rows');
+    });
+
+    it('handleStateMessage still broadcasts to WebSocket clients (live updates)', () => {
+      const sent = [];
+      bridge._setWsServerForTest({
+        clients: [{ readyState: 1, send: (msg) => sent.push(JSON.parse(msg)) }],
+      });
+
+      bridge.handleStateMessage({
+        ts: 1, mode: 'solar_charging', temps: { collector: 60 }, valves: {}, actuators: {},
+      });
+
+      assert.strictEqual(sent.length, 1);
+      assert.strictEqual(sent[0].type, 'state');
+      assert.strictEqual(sent[0].data.mode, 'solar_charging');
+    });
+
+    it('handleStateMessage does not call notifications.evaluate (no double-fire push)', () => {
+      const notifications = require('../server/lib/notifications');
+      const original = notifications.evaluate;
+      let called = false;
+      notifications.evaluate = function () { called = true; };
+      bridge._setPushRefForTest({ sendByCategory: function () { return Promise.resolve(); } });
+
+      try {
+        bridge.handleStateMessage({
+          ts: 1, mode: 'idle', temps: {}, valves: {}, actuators: {},
+        });
+        assert.strictEqual(called, false, 'preview must not evaluate notifications — prod already does');
+      } finally {
+        notifications.evaluate = original;
+      }
+    });
+
+    it('publishConfig is a no-op (returns false) even when MQTT is connected', () => {
+      const publishCalls = [];
+      bridge._setMqttClientForTest({
+        connected: true,
+        publish: function (topic, msg) { publishCalls.push({ topic, msg }); },
+      });
+
+      const result = bridge.publishConfig({ ce: true, ea: 31, v: 1 });
+      assert.strictEqual(result, false);
+      assert.strictEqual(publishCalls.length, 0, 'preview must never publish to greenhouse/config');
+    });
+
+    it('publishSensorConfig is a no-op (returns false) even when MQTT is connected', () => {
+      const publishCalls = [];
+      bridge._setMqttClientForTest({
+        connected: true,
+        publish: function (topic, msg) { publishCalls.push({ topic, msg }); },
+      });
+
+      const result = bridge.publishSensorConfig({ s: {}, h: [], v: 1 });
+      assert.strictEqual(result, false);
+      assert.strictEqual(publishCalls.length, 0);
+    });
+
+    it('publishRelayCommand is a no-op (returns false) even when MQTT is connected', () => {
+      const publishCalls = [];
+      bridge._setMqttClientForTest({
+        connected: true,
+        publish: function (topic, msg) { publishCalls.push({ topic, msg }); },
+      });
+
+      const result = bridge.publishRelayCommand('pump', true);
+      assert.strictEqual(result, false);
+      assert.strictEqual(publishCalls.length, 0, 'preview must never actuate real relays');
+    });
+
+    it('publishSensorConfigApply rejects with PREVIEW_MODE error', async () => {
+      bridge._setMqttClientForTest({ connected: true, publish: function () {} });
+      await assert.rejects(
+        () => bridge.publishSensorConfigApply({ id: 'x', target: null, config: {} }),
+        /PREVIEW_MODE/
+      );
+    });
+  });
 });


### PR DESCRIPTION
PRs labeled `preview` build a per-commit image, get applied as a
sibling Deployment+Service+Ingress in the default namespace, and
torn down on PR close (or label removal). The preview-gc CronJob
deletes anything whose preview.greenhouse/expires-at annotation is
in the past as a safety net.

Preview pods skip the openvpn + mosquitto sidecars and connect to
the prod broker via a new mosquitto Service. PREVIEW_MODE=true makes
the server a passive observer: it subscribes and broadcasts to its
own WebSocket clients but never writes state-derived rows, never
publishes to MQTT, never evaluates push notifications, never routes
watchdog/event to the anomaly manager, and never runs schema init or
maintenance against the shared prod DB.

Existing prod passkeys validate on the preview subdomain because the
RPID (greenhouse.madekivi.fi) is a registrable parent of the preview
origin's effective domain.

https://claude.ai/code/session_01MpiBsEDsqVpHmEa5GHja9P