### PR TITLE
Wait for TLS Certificate to be Ready before posting preview URL

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -152,6 +152,30 @@ jobs:
             deployment/app-preview-pr-${{ needs.preflight.outputs.pr_number }} \
             --timeout=3m
 
+      # cert-manager creates the Certificate resource asynchronously
+      # from the Ingress's tls: section, so it may not exist the moment
+      # apply returns. We poll for its existence first, then block on
+      # Ready. Without this, the PR comment can post the URL before
+      # cert-manager has finished HTTP-01 — and prod's HSTS
+      # includeSubDomains makes the unverified-cert page un-bypassable
+      # in the browser.
+      - name: Wait for TLS certificate to be Ready
+        env:
+          CERT_NAME: app-preview-pr-${{ needs.preflight.outputs.pr_number }}-tls
+        run: |
+          set -euo pipefail
+          for i in $(seq 1 30); do
+            if kubectl get certificate "$CERT_NAME" >/dev/null 2>&1; then
+              echo "Certificate $CERT_NAME exists — waiting for Ready"
+              break
+            fi
+            echo "Certificate $CERT_NAME not yet created (attempt $i/30)"
+            sleep 2
+          done
+          kubectl wait --for=condition=Ready \
+            "certificate/$CERT_NAME" \
+            --timeout=180s
+
       - name: Comment on PR with preview URL
         if: github.event_name == 'pull_request'
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v8.0.0

--- a/deploy/k8s/deployer-rbac.yaml
+++ b/deploy/k8s/deployer-rbac.yaml
@@ -51,6 +51,12 @@ rules:
   - apiGroups: ["networking.k8s.io"]
     resources: ["ingresses"]
     verbs: ["get", "list", "watch", "create", "patch", "delete"]
+  # `kubectl wait --for=condition=Ready certificate/...` needs get+watch
+  # on cert-manager Certificate resources. Read-only — cert-manager
+  # creates and reconciles these itself from the Ingress tls section.
+  - apiGroups: ["cert-manager.io"]
+    resources: ["certificates"]
+    verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
## Summary

When a preview deploy first comes up, cert-manager issues the per-PR cert asynchronously via HTTP-01 (~30-60 s). If the workflow posts the preview URL before that completes, the user lands on the default ingress cert and gets blocked by HSTS `includeSubDomains` inherited from `greenhouse.madekivi.fi` — Firefox/Chrome don't offer a click-through for that.

This PR adds a wait step in `preview-deploy.yml` that:

1. Polls for the `Certificate` resource to exist (cert-manager creates it asynchronously from the Ingress's `tls:` section, so it isn't there the moment `apply` returns).
2. `kubectl wait --for=condition=Ready certificate/...` with a 3 min budget.

Once that returns, the URL is safe to share. Also adds `get/list/watch` on `cert-manager.io/certificates` to the `deployer` Role — read-only, cert-manager owns the lifecycle.

## Test plan

- [ ] Add the `preview` label to a fresh PR; confirm the workflow blocks at "Wait for TLS certificate to be Ready" until cert-manager finishes HTTP-01, then posts the URL.
- [ ] Visit the URL in a browser that previously hit the prod domain (so HSTS is set) — should load directly without warning.
- [ ] On a second push to the same PR, the wait step should succeed near-instantly because the cert is already Ready.

https://claude.ai/code/session_01MpiBsEDsqVpHmEa5GHja9P

---
_Generated by [Claude Code](https://claude.ai/code/session_01MpiBsEDsqVpHmEa5GHja9P)_