### PR TITLE
Register previews via the GitHub Deployments API

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -28,6 +28,7 @@ permissions:
   contents: read
   packages: write
   pull-requests: write
+  deployments: write
 
 jobs:
   # Gate: only run on labeled PRs (or manual dispatch). The
@@ -125,6 +126,49 @@ jobs:
           echo "${{ secrets.KUBE_CONFIG_DATA }}" | base64 -d > ~/.kube/config
           chmod 600 ~/.kube/config
 
+      # Register a GitHub Deployment so the PR's "Deployments" sidebar
+      # links to the preview (with a "View deployment" button that opens
+      # in a new tab — Markdown comments cannot force new-tab links).
+      # Marked transient + non-production so GitHub renders the right
+      # badge and lets us mark it inactive on teardown.
+      - name: Create GitHub Deployment
+        if: github.event_name == 'pull_request'
+        id: gh-deployment
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v8.0.0
+        with:
+          script: |
+            const pr = ${{ needs.preflight.outputs.pr_number }};
+            const sha = '${{ needs.preflight.outputs.sha }}';
+            const result = await github.rest.repos.createDeployment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: sha,
+              environment: `preview-pr-${pr}`,
+              description: `Preview for PR #${pr}`,
+              auto_merge: false,
+              required_contexts: [],
+              transient_environment: true,
+              production_environment: false,
+            });
+            // 201: deployment created. 202: API returned merge info /
+            // status checks instead — shouldn't happen with our flags
+            // (auto_merge=false, required_contexts=[]) but fail loudly.
+            if (Array.isArray(result.data) || !result.data.id) {
+              throw new Error('createDeployment did not return a deployment: ' + JSON.stringify(result.data));
+            }
+            const deploymentId = result.data.id;
+            core.setOutput('deployment_id', String(deploymentId));
+
+            // Initial in_progress status so the sidebar shows "Deploying".
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: deploymentId,
+              state: 'in_progress',
+              description: 'Building and applying manifests',
+              log_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            });
+
       - name: Render preview manifests
         env:
           PR_NUMBER: ${{ needs.preflight.outputs.pr_number }}
@@ -176,6 +220,27 @@ jobs:
             "certificate/$CERT_NAME" \
             --timeout=180s
 
+      # Flip the GitHub Deployment to success with environment_url so
+      # the sidebar's "View deployment" button opens the live URL in
+      # a new tab. auto_inactive marks any older deployments for the
+      # same environment as inactive automatically.
+      - name: Mark GitHub Deployment success
+        if: github.event_name == 'pull_request' && steps.gh-deployment.outputs.deployment_id
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v8.0.0
+        with:
+          script: |
+            const pr = ${{ needs.preflight.outputs.pr_number }};
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: ${{ steps.gh-deployment.outputs.deployment_id }},
+              state: 'success',
+              environment_url: `https://pr-${pr}.greenhouse.madekivi.fi`,
+              log_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              auto_inactive: true,
+              description: 'Preview live',
+            });
+
       - name: Comment on PR with preview URL
         if: github.event_name == 'pull_request'
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v8.0.0
@@ -214,3 +279,19 @@ jobs:
                 issue_number: pr, body,
               });
             }
+
+      # If any prior step in this job failed, flip the GH Deployment to
+      # failure so the sidebar doesn't show "Deploying" forever.
+      - name: Mark GitHub Deployment failure
+        if: failure() && steps.gh-deployment.outputs.deployment_id
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v8.0.0
+        with:
+          script: |
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: ${{ steps.gh-deployment.outputs.deployment_id }},
+              state: 'failure',
+              log_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              description: 'Preview deploy failed — see action logs',
+            });

--- a/.github/workflows/preview-teardown.yml
+++ b/.github/workflows/preview-teardown.yml
@@ -21,6 +21,7 @@ env:
 permissions:
   contents: read
   pull-requests: write
+  deployments: write
 
 jobs:
   preflight:
@@ -113,3 +114,29 @@ jobs:
                 comment_id: existing.id, body,
               });
             }
+
+      # Mark all deployments for this preview environment inactive so
+      # the PR's "Deployments" sidebar reflects the torn-down state
+      # rather than still pointing at a now-404 URL.
+      - name: Mark GitHub Deployments inactive
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v8.0.0
+        with:
+          script: |
+            const pr = ${{ needs.preflight.outputs.pr_number }};
+            const env = `preview-pr-${pr}`;
+            const { data: deployments } = await github.rest.repos.listDeployments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              environment: env,
+              per_page: 100,
+            });
+            for (const d of deployments) {
+              await github.rest.repos.createDeploymentStatus({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                deployment_id: d.id,
+                state: 'inactive',
+                description: 'Preview torn down',
+              });
+            }
+            console.log(`Marked ${deployments.length} deployment(s) inactive for ${env}`);

--- a/playground/index.html
+++ b/playground/index.html
@@ -184,7 +184,7 @@
       <div id="watchdog-cooloff-indicator" class="watchdog-cooloff-indicator" style="display:none;"></div>
 
       <div class="view-header">
-        <h2>How your sanctuary is.</h2>
+        <h2>How your sanctuary is breathing.</h2>
         <p id="status-view-description">Live readings from the Shelly controller. Mode, valves, actuators, and 24h history.</p>
       </div>
 

--- a/playground/index.html
+++ b/playground/index.html
@@ -184,7 +184,7 @@
       <div id="watchdog-cooloff-indicator" class="watchdog-cooloff-indicator" style="display:none;"></div>
 
       <div class="view-header">
-        <h2>How your sanctuary is breathing.</h2>
+        <h2>How your sanctuary is.</h2>
         <p id="status-view-description">Live readings from the Shelly controller. Mode, valves, actuators, and 24h history.</p>
       </div>
 


### PR DESCRIPTION
## Summary

Two related preview-deploy UX asks:

1. **PR sidebar shows "No deployments"** — fix by registering each preview with the GitHub Deployments API so it appears in the right-hand "Deployments" panel with a "View deployment" button.
2. **The comment link doesn't open in a new tab** — Markdown links in PR comments can't (GitHub strips `target=`), but the Deployments-panel button natively does. So registering the deployment solves both at once.

Each deploy now creates a `Deployment` for environment `preview-pr-<n>` (marked `transient_environment` + non-production), starts in `in_progress`, then flips to `success` with `environment_url` set to `https://pr-<n>.greenhouse.madekivi.fi` after the cert wait succeeds. `auto_inactive: true` makes re-pushes mark the previous deployment inactive automatically. A trailing `if: failure()` step flips the deployment to `failure` if any step blew up so the sidebar isn't stuck on "Deploying".

Teardown lists all deployments for the environment and marks each `inactive`, so the sidebar reflects torn-down state instead of pointing at a 404.

Both workflows pick up `deployments: write`. The sticky comment stays — it's still nice for the PR feed.

## Stacked on #108

Branched off `claude/preview-wait-for-cert` to avoid conflicts. Once #108 merges, this auto-rebases against main; if you'd rather merge #108 first and then re-target this PR's base to `main`, that also works.

## Test plan

- [ ] Add the `preview` label to a fresh PR; confirm a "Deployment" appears in the sidebar with state "Deploying", then "Active" once the cert is Ready.
- [ ] Click "View deployment" — should open `https://pr-<n>.greenhouse.madekivi.fi` in a new tab.
- [ ] Push a second commit; confirm the previous deployment is auto-marked inactive and a new "Active" one appears.
- [ ] Close the PR; confirm the deployment(s) flip to "Inactive" in the sidebar.
- [ ] Force a deploy failure (e.g. break the manifest); confirm the deployment ends up "Failed" rather than stuck on "Deploying".

https://claude.ai/code/session_01MpiBsEDsqVpHmEa5GHja9P

---
_Generated by [Claude Code](https://claude.ai/code/session_01MpiBsEDsqVpHmEa5GHja9P)_