### PR TITLE
playground: fix flaky install-modal click test (wireNotificationUI race)

### DIFF
--- a/playground/js/main.js
+++ b/playground/js/main.js
@@ -143,10 +143,19 @@ async function init() {
   // PWA install prompt capture (must be early, before beforeinstallprompt fires)
   captureInstallPrompt();
 
+  // Wire DOM listeners (install modal, notif toggle, category checkboxes,
+  // test buttons) synchronously so __initComplete genuinely means "the page
+  // is interactive". The install-button + toggle handlers gracefully handle
+  // a click that lands before initNotifications() finishes (subscribePush
+  // returns false when swRegistration is null; the modal handler only needs
+  // DOM wiring). Previously this lived inside initNotifications().then()
+  // and raced with __initComplete under parallel-worker load — clicking
+  // #pwa-install-btn from a test could land before the handler attached
+  // and leave the install modal hidden.
+  wireNotificationUI();
+
   // Initialize push notifications (service worker, VAPID key, existing subscription)
-  initNotifications().then(function () {
-    wireNotificationUI();
-  });
+  initNotifications();
 
   // Start polling for JS source updates
   startVersionCheck();


### PR DESCRIPTION
## Summary

Ran the CI suite 5x to hunt for flakes (`npm run test:unit`, `--project=frontend --repeat-each=5`, `--project=e2e --repeat-each=5`) and found one:

- `tests/frontend/pwa-notifications.spec.js:113 › install modal closes via backdrop click` failed **1/1205** in the initial 5x run. Reproduced reliably at `--repeat-each=20` (1 fail) under parallel-worker load.

### Root cause

`#pwa-install-btn`'s click handler is attached by `wireNotificationUI()`. In `playground/js/main.js`, that call was queued behind the async `initNotifications().then(...)`, while `window.__initComplete = true` was set synchronously:

```js
captureInstallPrompt();
initNotifications().then(() => { wireNotificationUI(); });  // ← async
…
window.__initComplete = true;                                // ← sync
```

Tests wait on `__initComplete` to know the page is interactive. Under contention from 4 parallel Playwright workers, the test could fire `await page.locator('#pwa-install-btn').click()` before the `.then` callback ran, so the click hit a button with no listener, the modal never opened, and `expect(...).toBeVisible()` failed with `unexpected value "hidden"`.

### Fix

Move `wireNotificationUI()` to a synchronous call before the async init. Both handlers it wires already guard against pre-init state (`subscribePush` early-returns when `swRegistration` is null; the install-modal handler only needs DOM). This makes `__initComplete` genuinely mean "the page is interactive".

The test scenario is unchanged — same selectors, same assertions, same flow.

### Verification

| Suite                       | Before fix    | After fix     |
|-----------------------------|---------------|---------------|
| `test:unit` × 5             | 5/5 pass      | 5/5 pass      |
| `test:frontend` × 5         | **1204/1205** | **1205/1205** |
| `test:e2e` × 5              | 20/20 pass    | 20/20 pass    |
| backdrop click × 30 targeted| 19/20 pass    | 30/30 pass    |
| backdrop + close × 10×2     | n/a           | 20/20 pass    |
| lint / knip / file-size / assets | pass     | pass          |

## Test plan
- [x] `npm run test:unit` ×5
- [x] `npx playwright test --project=frontend --repeat-each=5` (1205 executions)
- [x] `npx playwright test --project=e2e --repeat-each=5` (20 executions)
- [x] Targeted re-run of the previously-flaky test ×30
- [x] `npm run lint`, `npm run knip`, `npm run check:file-size -- --strict`, `npm run check:assets -- --strict`

https://claude.ai/code/session_01Nct3s5yPFcNVg6G3srinXL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nct3s5yPFcNVg6G3srinXL)_