### PR TITLE
Add comprehensive e2e test suite for server endpoints and WebSocket

### DIFF
--- a/tests/e2e/device-config-mqtt.spec.js
+++ b/tests/e2e/device-config-mqtt.spec.js
@@ -44,6 +44,8 @@ test.describe('device-config PUT → MQTT publish', () => {
     await expect.poll(() => messages.find(matchOurs) ?? null,
       { timeout: 3000 }).not.toBeNull();
     const msg = messages.find(matchOurs);
-    expect(msg.wb).toEqual({ I: banUntil });
+    // Partial match — sibling workers may have written other wb keys
+    // (GH, SC, …) into the same config; we only own wb.I here.
+    expect(msg.wb.I).toBe(banUntil);
   });
 });

--- a/tests/e2e/device-config-rest.spec.js
+++ b/tests/e2e/device-config-rest.spec.js
@@ -1,0 +1,57 @@
+import { test, expect } from './fixtures.js';
+
+// Round-trip tests for /api/device-config — frontend suite mocks the
+// endpoint and asserts on the request body; here we exercise the real
+// updateConfig() partial-merge logic and version bump.
+//
+// All e2e workers share one server, so each PUT has to use a worker-
+// unique value (counter + pid) to stay independent of sibling tests
+// that may also be writing wb / we / ea.
+
+let counter = 0;
+
+test.describe('PUT /api/device-config round-trips', () => {
+  test('wb mode-ban write echoes back in the PUT response', async ({ page }) => {
+    // wb is a partial-merge map — VALID_MODES keys only. A unique
+    // future timestamp lets us assert "this exact value came back"
+    // without caring what other workers wrote to other keys.
+    const banUntil = Math.floor(Date.now() / 1000) + 7200
+      + (process.pid % 7919) + (++counter);
+    const res = await page.request.put('/api/device-config', {
+      data: { wb: { GH: banUntil } },
+    });
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(body.wb.GH).toBe(banUntil);
+    expect(typeof body.v).toBe('number');
+  });
+
+  test('ea bitmask + ce flag round-trip in one PUT', async ({ page }) => {
+    // ea is a small bitmask (valves=1, pump=2, fan=4, sh=8, ih=16)
+    // and ce is a bool. Both replace-not-merge, so we just assert the
+    // PUT response carries our exact values back.
+    const ea = 1 + 2 + 4; // valves + pump + fan
+    const res = await page.request.put('/api/device-config', {
+      data: { ea, ce: true },
+    });
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(body.ea).toBe(ea);
+    expect(body.ce).toBe(true);
+  });
+
+  test('PUT with invalid `mo` payload returns 400 with a validation error', async ({ page }) => {
+    // updateConfig fails fast on a malformed manual-override session
+    // (mo.a true but missing mo.fm). Stays purely synchronous in
+    // server/lib/device-config.js — no DB or MQTT round-trip — so it
+    // is independent of whatever wb / ea state sibling workers have
+    // accumulated.
+    const res = await page.request.put('/api/device-config', {
+      data: { mo: { a: true, ex: Math.floor(Date.now() / 1000) + 300 } },
+    });
+    expect(res.status()).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/mo\.fm required/);
+  });
+
+});

--- a/tests/e2e/events-history.spec.js
+++ b/tests/e2e/events-history.spec.js
@@ -1,0 +1,71 @@
+import { test, expect } from './fixtures.js';
+
+// Read paths that the dashboard's "system logs" + history graphs
+// hit. The frontend suite stubs canned payloads; here we exercise
+// the real getEventsPaginated / getHistory queries against pg-mem.
+
+test.describe('GET /api/events + /api/history', () => {
+  test('GET /api/events?type=mode returns {events, hasMore} shape', async ({ page }) => {
+    // Newest-first cursor pagination. Fresh DB or pre-existing rows
+    // both satisfy the response contract — we only assert shape, not
+    // contents, so the test is independent of sibling-worker writes.
+    const res = await page.request.get('/api/events?type=mode&limit=10');
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body.events)).toBe(true);
+    expect(typeof body.hasMore).toBe('boolean');
+  });
+
+  test('mode change triggers a state_events row visible via /api/events', async ({ page, mqttClient }) => {
+    // detectStateChanges only fires on `previousState !== current`,
+    // so we publish twice — first a baseline, then a change with a
+    // unique `cause` string we can find in the result.
+    const cause = 'e2e-test-' + process.pid + '-' + Date.now();
+
+    function publish(payload) {
+      return new Promise((resolve, reject) => {
+        mqttClient.publish('greenhouse/state', JSON.stringify(payload), { qos: 1 },
+          (err) => err ? reject(err) : resolve());
+      });
+    }
+
+    // Two distinct modes so the bridge writes a transition row. cause
+    // is free-text so it survives the round-trip and lets us pick our
+    // event out of the shared events feed without racing.
+    await publish({ ts: new Date().toISOString(), mode: 'idle', temps: { outdoor: 1 } });
+    await publish({ ts: new Date().toISOString(), mode: 'solar_charging', cause, temps: { outdoor: 2 } });
+
+    await expect.poll(async () => {
+      const res = await page.request.get('/api/events?type=mode&limit=50');
+      if (res.status() !== 200) return null;
+      const body = await res.json();
+      return body.events.find(e => e.cause === cause) ?? null;
+    }, { timeout: 5000 }).not.toBeNull();
+  });
+
+  test('GET /api/history?range=all returns points + events fields', async ({ page, mqttClient }) => {
+    // Seed one reading so points has at least one entry from this
+    // worker (older readings may still be present from sibling tests
+    // — we only assert the shape and that our specific value is
+    // recoverable). range=all hits the aggregate path which pg-mem
+    // can parse.
+    const sentinel = 99 + (process.pid % 1000) / 1000;
+    await new Promise((resolve, reject) => {
+      mqttClient.publish(
+        'greenhouse/state',
+        JSON.stringify({ ts: new Date().toISOString(), mode: 'idle', temps: { tank_top: sentinel } }),
+        { qos: 1 },
+        (err) => err ? reject(err) : resolve(),
+      );
+    });
+
+    await expect.poll(async () => {
+      const res = await page.request.get('/api/history?range=all&sensor=tank_top');
+      if (res.status() !== 200) return null;
+      const body = await res.json();
+      if (!Array.isArray(body.points) || !Array.isArray(body.events)) return null;
+      if (body.range !== 'all') return null;
+      return body.points.find(p => Math.abs((p.tank_top ?? Infinity) - sentinel) < 1e-9) ?? null;
+    }, { timeout: 5000 }).not.toBeNull();
+  });
+});

--- a/tests/e2e/runtime-endpoints.spec.js
+++ b/tests/e2e/runtime-endpoints.spec.js
@@ -1,0 +1,37 @@
+import { test, expect } from './fixtures.js';
+
+// Read-only endpoints exposed pre-auth (handlers in
+// server/lib/http-handlers.js). The frontend suite mocks these — here
+// we drive the real server so a regression in the handler shape is
+// caught before it reaches production. All three are GETs against
+// already-loaded singletons; combined wall time is sub-second.
+
+test.describe('runtime + sensor-config + version GET endpoints', () => {
+  test('GET /version returns a JSON hash field', async ({ page }) => {
+    const res = await page.request.get('/version');
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(typeof body.hash).toBe('string');
+  });
+
+  test('GET /api/runtime returns preview=null outside PREVIEW_MODE', async ({ page }) => {
+    // The harness boots without PREVIEW_MODE — the login page reads
+    // this to decide whether to render PR-specific branding.
+    const res = await page.request.get('/api/runtime');
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveProperty('preview', null);
+  });
+
+  test('GET /api/sensor-config returns hosts and assignments shape', async ({ page }) => {
+    // Pre-auth read used by the Shelly controller as well as the
+    // browser. Hosts are derived from SENSOR_HOST_IPS (unset in the
+    // harness, so empty) and assignments default to {}.
+    const res = await page.request.get('/api/sensor-config');
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body.hosts)).toBe(true);
+    expect(typeof body.assignments).toBe('object');
+    expect(typeof body.version).toBe('number');
+  });
+});

--- a/tests/e2e/script-monitor.spec.js
+++ b/tests/e2e/script-monitor.spec.js
@@ -1,0 +1,33 @@
+import { test, expect } from './fixtures.js';
+
+// Read-only health endpoints used by the playground's banners + the
+// device-config Watchdogs panel. The harness can't run a real Shelly
+// script monitor (CONTROLLER_IP is pinned to 127.0.0.1:1 so the RPC
+// fails fast) — these tests verify the endpoints respond with a
+// well-formed payload regardless of the underlying probe outcome.
+
+test.describe('script-monitor + watchdog read endpoints', () => {
+  test('GET /api/script/status returns running + reachable shape', async ({ page }) => {
+    // Shape of getStatus() in server/lib/script-monitor.js. With the
+    // controller intentionally unreachable, reachable=false is the
+    // expected steady state — but the contract is "endpoint returns
+    // 200 with the documented fields", not a specific value.
+    const res = await page.request.get('/api/script/status');
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveProperty('reachable');
+    expect(typeof body.reachable).toBe('boolean');
+    // running is true / false / null (unknown)
+    expect([true, false, null]).toContain(body.running);
+  });
+
+  test('GET /api/script/crashes returns a {crashes: array} body', async ({ page }) => {
+    // Backed by db.listScriptCrashes against pg-mem — the harness
+    // never inserts a row, so the array starts empty, but a sibling
+    // worker could in principle. Assert on shape only.
+    const res = await page.request.get('/api/script/crashes?limit=5');
+    expect(res.status()).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body.crashes)).toBe(true);
+  });
+});

--- a/tests/e2e/websocket-broadcasts.spec.js
+++ b/tests/e2e/websocket-broadcasts.spec.js
@@ -1,0 +1,110 @@
+import { test, expect } from './fixtures.js';
+
+// /ws lifecycle + MQTT-driven state broadcasts. The frontend suite
+// stubs the WebSocket constructor and feeds canned messages; here we
+// dial the real ws-server in server/lib/ws-server.js so the upgrade
+// handshake, retained config replay, and broadcastState fan-out are
+// covered end-to-end.
+
+const WS_URL = 'ws://127.0.0.1:3220/ws';
+
+// Connect, push frames into an array, and resolve once the connection
+// is open. Tests await `messages` to grow then close.
+function connectWs() {
+  const messages = [];
+  const ws = new WebSocket(WS_URL);
+  const ready = new Promise((resolve, reject) => {
+    ws.addEventListener('open', () => resolve());
+    ws.addEventListener('error', reject);
+  });
+  ws.addEventListener('message', (ev) => {
+    try { messages.push(JSON.parse(ev.data)); } catch { /* ignore */ }
+  });
+  return { ws, messages, ready };
+}
+
+async function waitFor(predicate, timeout = 4000) {
+  const t0 = Date.now();
+  while (Date.now() - t0 < timeout) {
+    if (predicate()) return true;
+    await new Promise(r => setTimeout(r, 25));
+  }
+  return false;
+}
+
+test.describe('WebSocket /ws lifecycle', () => {
+  test('client receives a connection-status frame on upgrade', async () => {
+    // server.js sends a `connection` message with the current MQTT
+    // status synchronously after the upgrade. AUTH_ENABLED=false in
+    // the harness means no cookie is needed.
+    const { ws, messages, ready } = connectWs();
+    await ready;
+    const seen = await waitFor(() => messages.some(m => m.type === 'connection'));
+    expect(seen).toBe(true);
+    const conn = messages.find(m => m.type === 'connection');
+    expect(['connected', 'reconnecting', 'disconnected']).toContain(conn.status);
+    ws.close();
+  });
+
+  test('greenhouse/state publish reaches subscribed WS clients', async ({ mqttClient }) => {
+    const { ws, messages, ready } = connectWs();
+    await ready;
+    // Use a unique sentinel temperature so we can distinguish our own
+    // publish from any state messages that other workers may be
+    // generating in parallel against the shared broker.
+    const sentinel = -123.456 - (process.pid % 1000) / 1000;
+    await new Promise((resolve, reject) => {
+      mqttClient.publish(
+        'greenhouse/state',
+        JSON.stringify({ ts: new Date().toISOString(), mode: 'idle', temps: { outdoor: sentinel } }),
+        { qos: 1 },
+        (err) => err ? reject(err) : resolve(),
+      );
+    });
+
+    const got = await waitFor(() =>
+      messages.some(m => m.type === 'state' && m.data && m.data.temps
+        && Math.abs(m.data.temps.outdoor - sentinel) < 1e-9));
+    expect(got).toBe(true);
+    ws.close();
+  });
+
+  test('state broadcast is enriched with manual_override field', async ({ mqttClient }) => {
+    // broadcastState calls enrichState which always tacks on
+    // manual_override (null when no override is active). Confirms the
+    // enrichment hop runs for live broadcasts, not just the
+    // /ws-upgrade replay.
+    const { ws, messages, ready } = connectWs();
+    await ready;
+    const sentinel = -200 - (process.pid % 1000);
+    await new Promise((resolve, reject) => {
+      mqttClient.publish(
+        'greenhouse/state',
+        JSON.stringify({ ts: new Date().toISOString(), mode: 'idle', temps: { outdoor: sentinel } }),
+        { qos: 1 },
+        (err) => err ? reject(err) : resolve(),
+      );
+    });
+    const got = await waitFor(() =>
+      messages.some(m => m.type === 'state' && m.data && m.data.temps
+        && m.data.temps.outdoor === sentinel
+        && Object.prototype.hasOwnProperty.call(m.data, 'manual_override')));
+    expect(got).toBe(true);
+    ws.close();
+  });
+
+  test('upgrade to non-/ws path is refused (socket destroyed)', async () => {
+    // server.js destroys upgrades whose pathname !== '/ws'. The
+    // resulting connection should never reach `open` — we expect
+    // either an error event or a close.
+    const ws = new WebSocket('ws://127.0.0.1:3220/not-ws');
+    const outcome = await new Promise((resolve) => {
+      ws.addEventListener('open', () => resolve('open'));
+      ws.addEventListener('error', () => resolve('error'));
+      ws.addEventListener('close', () => resolve('close'));
+      setTimeout(() => resolve('timeout'), 2000);
+    });
+    expect(['error', 'close']).toContain(outcome);
+    try { ws.close(); } catch { /* already closed */ }
+  });
+});


### PR DESCRIPTION
## Summary
This PR adds a comprehensive end-to-end test suite that exercises real server implementations rather than mocked endpoints. The new tests cover WebSocket lifecycle, MQTT-driven state broadcasts, REST API endpoints, and device configuration round-trips.

## Key Changes
- **WebSocket lifecycle tests** (`websocket-broadcasts.spec.js`): Tests real WebSocket upgrade handshake, connection status frames, MQTT state broadcast delivery, state enrichment with `manual_override` field, and rejection of non-`/ws` paths
- **Events and history API tests** (`events-history.spec.js`): Validates `/api/events` and `/api/history` endpoints with cursor pagination, state change detection, and sensor data retrieval
- **Device config REST tests** (`device-config-rest.spec.js`): Round-trip tests for `/api/device-config` PUT endpoint covering partial-merge logic, version bumping, and validation error handling
- **Runtime endpoints tests** (`runtime-endpoints.spec.js`): Validates pre-auth read endpoints (`/version`, `/api/runtime`, `/api/sensor-config`) for correct response shapes
- **Script monitor tests** (`script-monitor.spec.js`): Tests health check endpoints (`/api/script/status`, `/api/script/crashes`) with well-formed payloads
- **Fixed flaky device-config MQTT test**: Updated assertion to use partial matching (`msg.wb.I`) instead of full equality, accounting for concurrent writes from sibling workers

## Notable Implementation Details
- Tests use worker-unique identifiers (PID + counter/timestamp) to remain independent when running in parallel against a shared test server
- WebSocket tests use real `ws://` connections to the test server rather than stubbed constructors
- MQTT client fixture is leveraged to publish state changes and verify end-to-end message flow
- Polling helpers with configurable timeouts handle asynchronous message delivery and database writes
- Tests validate response contracts (shape and types) rather than specific values where appropriate, making them resilient to concurrent test execution

https://claude.ai/code/session_01BxBKU4TwAcARfvTXfYdECf