### PR TITLE
playground: wire notification UI synchronously to close __initComplete race

### DIFF
--- a/playground/js/main.js
+++ b/playground/js/main.js
@@ -143,10 +143,10 @@ async function init() {
   // PWA install prompt capture (must be early, before beforeinstallprompt fires)
   captureInstallPrompt();
 
-  // Initialize push notifications (service worker, VAPID key, existing subscription)
-  initNotifications().then(function () {
-    wireNotificationUI();
-  });
+  // Wire DOM listeners synchronously — must run before __initComplete so
+  // tests (and slow real-network users) don't race against initNotifications().
+  wireNotificationUI();
+  initNotifications();
 
   // Start polling for JS source updates
   startVersionCheck();

--- a/tests/frontend/pwa-notifications.spec.js
+++ b/tests/frontend/pwa-notifications.spec.js
@@ -154,6 +154,65 @@ test.describe('Settings view — desktop', () => {
   });
 });
 
+test.describe('Install button wiring race', () => {
+  // Regression: wireNotificationUI() used to run inside
+  // initNotifications().then(), so __initComplete flipped true while
+  // the install button click handler was still un-attached (~25ms
+  // after, until the SW-registration microtask drained). Under
+  // parallel load this raced ~1/5 runs and the fallback modal stayed
+  // hidden. Contract under test: the button listener is attached by
+  // the time the page reports __initComplete = true.
+
+  test('install button listener is attached before __initComplete = true', async ({ page }) => {
+    await page.route('**/api/push/vapid-key', route => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          publicKey: 'BIlDax-DYNzPJfB4LHkOfn_nnpU1i_-27xp9UHUZS-axEePU-xIB94H4vblRxEJxjR-k-SK70o-mpQoMy2QcZUA',
+        }),
+      });
+    });
+
+    await page.addInitScript(() => {
+      window.__btnClickWiredAt = null;
+      window.__initCompleteAt = null;
+      const origAdd = HTMLElement.prototype.addEventListener;
+      HTMLElement.prototype.addEventListener = function (type, ...args) {
+        if (this.id === 'pwa-install-btn' && type === 'click' && window.__btnClickWiredAt === null) {
+          window.__btnClickWiredAt = performance.now();
+        }
+        return origAdd.call(this, type, ...args);
+      };
+      // Trap the moment main.js sets __initComplete = true.
+      let initCompleteValue = false;
+      Object.defineProperty(window, '__initComplete', {
+        configurable: true,
+        get() { return initCompleteValue; },
+        set(v) {
+          if (v === true && window.__initCompleteAt === null) {
+            window.__initCompleteAt = performance.now();
+          }
+          initCompleteValue = v;
+        },
+      });
+    });
+
+    await page.goto('/playground/?mode=sim');
+    await page.waitForFunction(() => window.__initComplete === true);
+
+    const timing = await page.evaluate(() => ({
+      initCompleteAt: window.__initCompleteAt,
+      btnClickWiredAt: window.__btnClickWiredAt,
+    }));
+    expect(timing.btnClickWiredAt, 'install button click handler must be attached by __initComplete time').not.toBeNull();
+    expect(
+      timing.btnClickWiredAt,
+      `install button must be wired before __initComplete (wired=${timing.btnClickWiredAt}, initComplete=${timing.initCompleteAt})`
+    ).toBeLessThanOrEqual(timing.initCompleteAt);
+  });
+});
+
 test.describe('Install card state when running standalone', () => {
   // When the PWA is launched from the home screen Chrome reports
   // display-mode: standalone. The Install card should swap to an


### PR DESCRIPTION
## Summary

Found a flaky frontend test by running the full CI gate 5×: `pwa-notifications.spec.js:98` ("clicking install shows the fallback instructions modal") fails ~1/5 runs of the full suite. Root cause is a real production race, not a test-only timing issue.

`wireNotificationUI()` — which attaches the install button click handler and install-modal close handlers — used to run inside `initNotifications().then(...)`. `window.__initComplete = true` was set immediately after kicking off that async chain, so under parallel load (4 workers, contended CPU) the page reported "init complete" while the install button still had no listener. Click → no-op → modal stays hidden → 5s timeout → red.

Instrumented `addEventListener` on the button and the `__initComplete` setter and confirmed: handler attaches **~25 ms after** `__initComplete` flips true on a clean run; under load that gap stretches enough to lose the race.

### Fix
Call `wireNotificationUI()` synchronously before `initNotifications()` in `playground/js/main.js`. Click handlers already check subscription state lazily (via `isSubscribed()`), so they don't need the SW registration / VAPID fetch to have completed.

Side benefit: the install / notification UI is also clickable sooner for slow-network real users, not just tests.

### Regression guard
New spec `Install button wiring race › install button listener is attached before __initComplete = true` — instruments `addEventListener` on `#pwa-install-btn` and traps the `__initComplete` setter, then asserts `btnClickWiredAt <= initCompleteAt`. Verified:

- without the fix: `wired=313ms, initComplete=288ms` → fails by 25 ms (matches the timing observation).
- with the fix: handler attached strictly before the flag flips → passes.

The original `clicking install shows the fallback instructions modal` test stays exactly the same — same scenario, just no longer racing.

### Verification
Each step run 5× on this branch with the fix in place:

| step | result |
|---|---|
| `npm run test:unit:ci` | 5/5 pass (~6 s each) |
| `npm run lint` / `knip` / `check:file-size --strict` / `check:assets --strict` | 5/5 pass each |
| `npx playwright test --project=frontend` (full suite) | 5/5 pass — 242/242 tests each run |
| `npx playwright test --project=e2e` | 5/5 pass |

The 1/5 flake observed in the baseline run is gone.

## Test plan

- [x] `npm run test:unit:ci` × 5 → all pass
- [x] `npm run lint` × 5 → all pass
- [x] `npm run knip` × 5 → all pass
- [x] `npm run check:file-size -- --strict` × 5 → all pass (0 over hard cap)
- [x] `npm run check:assets -- --strict` × 5 → all pass
- [x] `npx playwright test --project=frontend` × 5 → all pass (242 tests each, 0 flakes)
- [x] `npx playwright test --project=e2e` × 5 → all pass
- [x] Regression test fails without the production fix (verified by stashing `main.js`)
- [x] Regression test passes with the fix in place

https://claude.ai/code/session_01SfW49s8J9rUPzgKh81Q96p

---
_Generated by [Claude Code](https://claude.ai/code/session_01SfW49s8J9rUPzgKh81Q96p)_