### PR TITLE
playground: move Today's balance card below System Logs

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -351,7 +351,20 @@
           </div>
         </div>
 
-        <!-- Today's balance (full width, above System Logs) -->
+        <!-- System Logs (full width) -->
+        <div class="card bento-span-3">
+          <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:16px;">
+            <h3 style="margin-bottom:0;">System Logs</h3>
+            <button id="copy-logs-btn" class="copy-logs-btn" title="Copy system logs to clipboard">
+              <span class="material-symbols-outlined" style="font-size:16px;">content_copy</span>
+            </button>
+          </div>
+          <div class="logs-list" id="logs-list">
+            <div data-empty="true" style="color:var(--on-surface-variant);font-size:13px;">No transitions yet. Awaiting controller activity…</div>
+          </div>
+        </div>
+
+        <!-- Today's balance (full width, last card) -->
         <div class="card bento-span-3 balance-card" id="balance-card" style="display:none;">
           <h3 class="balance-title">Today's balance.</h3>
           <div class="balance-section" id="balance-night">
@@ -369,19 +382,6 @@
             </div>
             <p class="balance-sentence" id="balance-day-sentence"></p>
             <div class="balance-stats" id="balance-day-stats"></div>
-          </div>
-        </div>
-
-        <!-- System Logs (full width) -->
-        <div class="card bento-span-3">
-          <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:16px;">
-            <h3 style="margin-bottom:0;">System Logs</h3>
-            <button id="copy-logs-btn" class="copy-logs-btn" title="Copy system logs to clipboard">
-              <span class="material-symbols-outlined" style="font-size:16px;">content_copy</span>
-            </button>
-          </div>
-          <div class="logs-list" id="logs-list">
-            <div data-empty="true" style="color:var(--on-surface-variant);font-size:13px;">No transitions yet. Awaiting controller activity…</div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Swap the order of the "Today's balance." and System Logs cards in the Status view so balance is the last card on the page.

## Test plan
- [x] `npm run lint`
- [x] `npm run knip`
- [x] `npm run check:file-size -- --strict`
- [x] `npm run check:assets -- --strict`
- [x] `npm run test:unit` (963 tests)
- [x] `npx playwright test` (260 tests)

https://claude.ai/code/session_01JTe3SbiawtB7Mr9U9Jb92R

---
_Generated by [Claude Code](https://claude.ai/code/session_01JTe3SbiawtB7Mr9U9Jb92R)_