### PR TITLE
Resync System Logs feed on visibility/pageshow/online events

### DIFF
--- a/playground/js/main/connection.js
+++ b/playground/js/main/connection.js
@@ -15,6 +15,7 @@ import { drawHistoryGraph } from './history-graph.js';
 import { resetChartZoom } from './chart-pinch-zoom.js';
 import {
   transitionLog, fetchLiveEvents, resetEventsState,
+  registerLogsEventsSource,
 } from './logs.js';
 import {
   fetchBalanceHistory, renderBalanceCard,
@@ -64,10 +65,11 @@ export function initConnection({ setRunning } = {}) {
     })
     .catch(function () { /* silent; prod default applies */ });
 
-  // Both sources gate on phase==='live' so they're inert in sim mode
-  // without an explicit deregister.
+  // All three sources gate on phase==='live' so they're inert in sim
+  // mode without an explicit deregister.
   registerLiveHistorySource(() => graphRange);
   registerBalanceHistorySource();
+  registerLogsEventsSource();
 
   // Single repaint on the syncing edge collapses the old two-step
   // ("blur clears, then banner clears") into one transition.

--- a/playground/js/main/logs.js
+++ b/playground/js/main/logs.js
@@ -12,6 +12,7 @@ import {
 import { model, params, MODE_INFO, timeSeriesStore, transitionLog, lastLiveFrame } from './state.js';
 import { getWatchdogSnapshot } from './watchdog-ui.js';
 import { modeAt, appendModeEvent } from './mode-events.js';
+import { registerDataSource } from '../sync/registry.js';
 
 export { transitionLog };
 
@@ -34,12 +35,18 @@ export function resetEventsState() {
   lastLiveMode = null;
 }
 
-function fetchEventPage(type, before) {
+function fetchEventPage(type, before, signal) {
   let url = '/api/events?type=' + type + '&limit=' + EVENTS_PAGE_SIZE;
   if (before !== null && before !== undefined) url += '&before=' + before;
-  return fetch(url)
+  return fetch(url, { signal })
     .then(r => r.ok ? r.json() : { events: [], hasMore: false })
-    .catch(() => ({ events: [], hasMore: false }));
+    .catch((e) => {
+      // Re-throw aborts so the sync coordinator drops the result; swallow
+      // everything else (network blips, etc.) so the existing scroll-loader
+      // keeps quietly retrying on the next page.
+      if (e && e.name === 'AbortError') throw e;
+      return { events: [], hasMore: false };
+    });
 }
 
 function modeRowToLogEntry(e) {
@@ -70,6 +77,37 @@ function configRowToLogEntry(e) {
   };
 }
 
+// Apply a paged fetch result into transitionLog + cursor state. Pulled
+// out of fetchLiveEvents so the sync-coordinator data source can reuse
+// the exact same write path on Android resume.
+function applyEventPages(modeData, configData, isReset) {
+  if (store.get('phase') !== 'live') return;
+  const modeEvents = (modeData && Array.isArray(modeData.events)) ? modeData.events : [];
+  const configEvents = (configData && Array.isArray(configData.events)) ? configData.events : [];
+
+  if (isReset) transitionLog.length = 0;
+
+  for (let i = 0; i < modeEvents.length; i++) {
+    transitionLog.push(modeRowToLogEntry(modeEvents[i]));
+  }
+  for (let i = 0; i < configEvents.length; i++) {
+    transitionLog.push(configRowToLogEntry(configEvents[i]));
+  }
+  // Re-sort the merged list newest-first. Stable enough for our N (~20).
+  transitionLog.sort((a, b) => (b.ts || 0) - (a.ts || 0));
+
+  if (!modeData._skipped) {
+    if (modeEvents.length > 0) modeCursor = modeEvents[modeEvents.length - 1].ts;
+    modeHasMore = !!(modeData && modeData.hasMore);
+  }
+  if (!configData._skipped) {
+    if (configEvents.length > 0) configCursor = configEvents[configEvents.length - 1].ts;
+    configHasMore = !!(configData && configData.hasMore);
+  }
+
+  renderLogsList();
+}
+
 // Fetch the next page of events. `reset` true clears the log and
 // fetches both feeds afresh; otherwise advances each feed's cursor
 // independently and appends to the existing list. Sorting by ts DESC
@@ -93,36 +131,26 @@ export function fetchLiveEvents(reset) {
     : Promise.resolve({ events: [], hasMore: false, _skipped: true });
 
   Promise.all([modePromise, configPromise])
-    .then(function ([modeData, configData]) {
-      // Only apply to the current phase — the user may have switched back
-      // to simulation while the requests were in flight.
-      if (store.get('phase') !== 'live') return;
-      const modeEvents = (modeData && Array.isArray(modeData.events)) ? modeData.events : [];
-      const configEvents = (configData && Array.isArray(configData.events)) ? configData.events : [];
-
-      if (isReset) transitionLog.length = 0;
-
-      for (let i = 0; i < modeEvents.length; i++) {
-        transitionLog.push(modeRowToLogEntry(modeEvents[i]));
-      }
-      for (let i = 0; i < configEvents.length; i++) {
-        transitionLog.push(configRowToLogEntry(configEvents[i]));
-      }
-      // Re-sort the merged list newest-first. Stable enough for our N (~20).
-      transitionLog.sort((a, b) => (b.ts || 0) - (a.ts || 0));
-
-      if (!modeData._skipped) {
-        if (modeEvents.length > 0) modeCursor = modeEvents[modeEvents.length - 1].ts;
-        modeHasMore = !!(modeData && modeData.hasMore);
-      }
-      if (!configData._skipped) {
-        if (configEvents.length > 0) configCursor = configEvents[configEvents.length - 1].ts;
-        configHasMore = !!(configData && configData.hasMore);
-      }
-
-      renderLogsList();
-    })
+    .then(([modeData, configData]) => applyEventPages(modeData, configData, isReset))
     .then(() => { eventsLoading = false; });
+}
+
+// Wires the System Logs feed into the sync coordinator so visibility /
+// pageshow / online events re-fetch the latest page of mode + config
+// transitions. Without this the on-screen list froze at whatever was
+// loaded when the user first opened the page — transitions that
+// happened while the tab was backgrounded landed in the DB but the
+// open page never asked for them. Same shape as registerLiveHistorySource.
+export function registerLogsEventsSource() {
+  return registerDataSource({
+    id: 'logs-events',
+    isActive: () => store.get('phase') === 'live',
+    fetch: (signal) => Promise.all([
+      fetchEventPage('mode', null, signal),
+      fetchEventPage('config', null, signal),
+    ]).then(([modeData, configData]) => ({ modeData, configData })),
+    applyToStore: ({ modeData, configData }) => applyEventPages(modeData, configData, true),
+  });
 }
 
 function formatLiveTransitionText(from, to) {

--- a/tests/frontend/visibility-resync.spec.js
+++ b/tests/frontend/visibility-resync.spec.js
@@ -115,6 +115,43 @@ test.describe('visibility resync', () => {
     await expect(overlay).not.toHaveClass(/connection-overlay--syncing/);
   });
 
+  test('hide → show triggers a /api/events re-fetch so the System Logs list refreshes', async ({ page }) => {
+    // Regression: on Android resume the System Logs list stayed frozen
+    // at whatever was fetched when the page was first opened. Mode
+    // transitions that happened during the background interval landed
+    // in the DB but the open page never asked for them. This asserts
+    // the events feed is registered with the sync coordinator so it
+    // re-fetches on visibility/pageshow/online like /api/history does.
+    let eventsHits = 0;
+    await page.route('**/api/history**', route => route.fulfill({
+      status: 200, contentType: 'application/json',
+      body: JSON.stringify({ points: [], events: [] }),
+    }));
+    await page.unroute('**/api/events**');
+    await page.route('**/api/events**', route => {
+      eventsHits++;
+      route.fulfill({
+        status: 200, contentType: 'application/json',
+        body: JSON.stringify({ events: [], hasMore: false }),
+      });
+    });
+    await page.goto('/playground/');
+    await waitForSyncReady(page);
+
+    // Initial load fires one fetch per feed (mode + config).
+    await expect.poll(() => eventsHits, { timeout: 5000 }).toBeGreaterThanOrEqual(2);
+    const baseline = eventsHits;
+
+    // Simulate Android resume.
+    await page.evaluate(() => {
+      Object.defineProperty(document, 'visibilityState', { configurable: true, get: () => 'visible' });
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    // The resync must hit /api/events again (one per feed).
+    await expect.poll(() => eventsHits, { timeout: 5000 }).toBeGreaterThanOrEqual(baseline + 2);
+  });
+
   test('liveFrameSeen is reset on resync start so trends fall back to fresh history', async ({ page }) => {
     // Background: the original Android bug had `liveFrameSeen` stay
     // true across the backgrounding, so on resume the UI used the


### PR DESCRIPTION
## Summary
Registers the System Logs events feed with the sync coordinator so it re-fetches the latest mode and config transitions when the page becomes visible or the device comes online. This fixes a regression where the System Logs list remained frozen at the initial load state on Android resume, even though new transitions were recorded in the database during the background interval.

## Key Changes
- **Refactored event application logic**: Extracted the event page processing from `fetchLiveEvents()` into a new `applyEventPages()` function to enable reuse by the sync coordinator
- **Added AbortSignal support**: Updated `fetchEventPage()` to accept and use an AbortSignal parameter, allowing the sync coordinator to cancel in-flight requests when needed
- **Improved error handling**: Distinguished between AbortError (which should propagate to the sync coordinator) and other network errors (which should be silently retried by the scroll-loader)
- **Registered logs events source**: Created `registerLogsEventsSource()` to wire the events feed into the sync coordinator with the same pattern as the existing history source
- **Added regression test**: Verifies that visibility changes trigger `/api/events` re-fetches for both mode and config feeds

## Implementation Details
- The `applyEventPages()` function handles merging mode and config events, sorting by timestamp, and updating cursor state
- The sync coordinator calls `applyEventPages()` with `isReset=true` to clear and refresh the entire list on resume
- The events source gates on `phase === 'live'` so it remains inert in simulation mode
- Error handling preserves the existing scroll-loader retry behavior for transient network issues while allowing the sync coordinator to handle aborts appropriately

https://claude.ai/code/session_01PWz8nWVjVXdNMASZo43Uat