### PR TITLE
Register logs source with sync coordinator for resume/recovery

### DIFF
--- a/playground/js/main/connection.js
+++ b/playground/js/main/connection.js
@@ -15,6 +15,7 @@ import { drawHistoryGraph } from './history-graph.js';
 import { resetChartZoom } from './chart-pinch-zoom.js';
 import {
   transitionLog, fetchLiveEvents, resetEventsState,
+  registerLogsSource,
 } from './logs.js';
 import {
   fetchBalanceHistory, renderBalanceCard,
@@ -64,10 +65,11 @@ export function initConnection({ setRunning } = {}) {
     })
     .catch(function () { /* silent; prod default applies */ });
 
-  // Both sources gate on phase==='live' so they're inert in sim mode
-  // without an explicit deregister.
+  // All three sources gate on phase==='live' so they're inert in sim
+  // mode without an explicit deregister.
   registerLiveHistorySource(() => graphRange);
   registerBalanceHistorySource();
+  registerLogsSource();
 
   // Single repaint on the syncing edge collapses the old two-step
   // ("blur clears, then banner clears") into one transition.

--- a/playground/js/main/logs.js
+++ b/playground/js/main/logs.js
@@ -4,6 +4,7 @@
 // have to change.
 
 import { store } from '../app-state.js';
+import { registerDataSource } from '../sync/registry.js';
 import {
   formatClockTime, formatFullTimeHelsinki, formatCauseLabel,
   formatReasonLabel, formatSensorsLine, escapeHtml, formatTimeOfDay,
@@ -34,10 +35,11 @@ export function resetEventsState() {
   lastLiveMode = null;
 }
 
-function fetchEventPage(type, before) {
+function fetchEventPage(type, before, signal) {
   let url = '/api/events?type=' + type + '&limit=' + EVENTS_PAGE_SIZE;
   if (before !== null && before !== undefined) url += '&before=' + before;
-  return fetch(url)
+  const opts = signal ? { signal } : undefined;
+  return fetch(url, opts)
     .then(r => r.ok ? r.json() : { events: [], hasMore: false })
     .catch(() => ({ events: [], hasMore: false }));
 }
@@ -254,6 +256,38 @@ export function renderLogsList() {
   }
 
   container.innerHTML = html;
+}
+
+// Wires the System Logs panel into the sync coordinator so Android
+// resume / network recovery / focus events refresh the events feed.
+// Without this, fetchLiveEvents() only fires on phase switch and the
+// log freezes while the tab is backgrounded. Note: applyToStore must
+// NOT touch lastLiveMode — that tracks live WS state frames; clearing
+// it would make the next frame silently seed instead of appending.
+export function registerLogsSource() {
+  return registerDataSource({
+    id: 'logs',
+    isActive: () => store.get('phase') === 'live',
+    fetch: (signal) => Promise.all([
+      fetchEventPage('mode', null, signal),
+      fetchEventPage('config', null, signal),
+    ]).then(([modeData, configData]) => ({ modeData, configData })),
+    applyToStore: ({ modeData, configData }) => {
+      modeCursor = null; modeHasMore = false;
+      configCursor = null; configHasMore = false;
+      transitionLog.length = 0;
+      const modeEvents = (modeData && Array.isArray(modeData.events)) ? modeData.events : [];
+      const configEvents = (configData && Array.isArray(configData.events)) ? configData.events : [];
+      for (let i = 0; i < modeEvents.length; i++) transitionLog.push(modeRowToLogEntry(modeEvents[i]));
+      for (let i = 0; i < configEvents.length; i++) transitionLog.push(configRowToLogEntry(configEvents[i]));
+      transitionLog.sort((a, b) => (b.ts || 0) - (a.ts || 0));
+      if (modeEvents.length > 0) modeCursor = modeEvents[modeEvents.length - 1].ts;
+      modeHasMore = !!(modeData && modeData.hasMore);
+      if (configEvents.length > 0) configCursor = configEvents[configEvents.length - 1].ts;
+      configHasMore = !!(configData && configData.hasMore);
+      renderLogsList();
+    },
+  });
 }
 
 // Attach a one-time scroll listener that lazy-loads older events when the

--- a/tests/frontend/visibility-resync.spec.js
+++ b/tests/frontend/visibility-resync.spec.js
@@ -29,6 +29,32 @@ test.describe('visibility resync', () => {
     }));
   });
 
+  test('hide → show triggers a /api/events re-fetch (logs source)', async ({ page }) => {
+    let eventsHits = 0;
+    await page.route('**/api/events**', route => {
+      eventsHits++;
+      route.fulfill({
+        status: 200, contentType: 'application/json',
+        body: JSON.stringify({ events: [], hasMore: false }),
+      });
+    });
+    await page.goto('/playground/');
+    await waitForSyncReady(page);
+    // Initial fetchLiveEvents(null) at phase=live hits /api/events
+    // twice (mode + config feed). Wait for that baseline.
+    await expect.poll(() => eventsHits, { timeout: 5000 }).toBeGreaterThanOrEqual(2);
+    const baseline = eventsHits;
+
+    await page.evaluate(() => {
+      Object.defineProperty(document, 'visibilityState', { configurable: true, get: () => 'visible' });
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    // The logs source must re-fetch on resume. Two requests (mode +
+    // config) — assert at least one increment beyond baseline.
+    await expect.poll(() => eventsHits, { timeout: 5000 }).toBeGreaterThan(baseline);
+  });
+
   test('hide → show triggers a /api/history re-fetch', async ({ page }) => {
     let historyHits = 0;
     await page.route('**/api/history**', route => {


### PR DESCRIPTION
## Summary
Integrates the System Logs panel into the sync coordinator to ensure the events feed refreshes when the app resumes from background, recovers network connectivity, or regains focus—without relying solely on phase switches.

## Key Changes
- **logs.js**: 
  - Modified `fetchEventPage()` to accept an optional `signal` parameter for request cancellation support
  - Added `registerLogsSource()` export that registers the logs panel as a data source with the sync coordinator
  - The source fetches both 'mode' and 'config' event feeds and applies them to the store while preserving live WebSocket state tracking
  
- **connection.js**:
  - Imported and called `registerLogsSource()` during initialization alongside existing history and balance sources
  - Updated comment to reflect three (not two) registered sources

- **visibility-resync.spec.js**:
  - Added test case verifying that hiding and showing the page triggers `/api/events` re-fetches through the logs source

## Implementation Details
- The `registerLogsSource()` function gates on `phase === 'live'` to remain inert in simulation mode
- Intentionally does not modify `lastLiveMode` to preserve live WebSocket state tracking—clearing it would cause the next frame to seed instead of append
- Uses `Promise.all()` to fetch both event feeds in parallel and combines results before applying to store
- Properly handles missing or malformed event data with defensive checks

https://claude.ai/code/session_01Kt5tB7ur6UBq8GGnUA3Ufj