### PR TITLE
control: add greenhouse fan-cooling overlay (30 °C on / 28 °C off)

### DIFF
--- a/playground/assets/bootstrap-history.json
+++ b/playground/assets/bootstrap-history.json
@@ -7978,6 +7978,7 @@
     "collectorsDrained": false,
     "lastRefillAttempt": 0,
     "emergencyHeatingActive": false,
+    "greenhouseFanCoolingActive": false,
     "solarChargePeakTankAvg": null,
     "solarChargePeakTankAvgAt": 0
   }

--- a/playground/js/control.js
+++ b/playground/js/control.js
@@ -34,6 +34,7 @@ export class ControlStateMachine {
     this.collectorsDrained = false;
     this.lastRefillAttempt = 0;
     this.emergencyHeatingActive = false;
+    this.greenhouseFanCoolingActive = false;
     // Solar-charging tank-rise tracking (mirrors evaluate() flags).
     // Reset each time we leave SOLAR_CHARGING; carried across ticks
     // while we are in solar charging so the no-rise-for-5-min and
@@ -64,6 +65,7 @@ export class ControlStateMachine {
       collectorsDrained: this.collectorsDrained,
       lastRefillAttempt: this.lastRefillAttempt,
       emergencyHeatingActive: this.emergencyHeatingActive,
+      greenhouseFanCoolingActive: this.greenhouseFanCoolingActive,
       solarChargePeakTankAvg: this.solarChargePeakTankAvg,
       solarChargePeakTankAvgAt: this.solarChargePeakTankAvgAt,
       sensorAge: { collector: 0, tank_top: 0, tank_bottom: 0, greenhouse: 0, outdoor: 0 },
@@ -92,6 +94,7 @@ export class ControlStateMachine {
     this.collectorsDrained = result.flags.collectorsDrained;
     this.lastRefillAttempt = result.flags.lastRefillAttempt;
     this.emergencyHeatingActive = result.flags.emergencyHeatingActive;
+    this.greenhouseFanCoolingActive = !!result.flags.greenhouseFanCoolingActive;
     this.solarChargePeakTankAvg = result.flags.solarChargePeakTankAvg;
     this.solarChargePeakTankAvgAt = result.flags.solarChargePeakTankAvgAt;
 
@@ -116,6 +119,7 @@ export class ControlStateMachine {
       flags: {
         collectors_drained: !!this.collectorsDrained,
         emergency_heating_active: !!this.emergencyHeatingActive,
+        greenhouse_fan_cooling_active: !!this.greenhouseFanCoolingActive,
       },
       transition,
     };
@@ -170,6 +174,7 @@ export class ControlStateMachine {
     this.collectorsDrained = false;
     this.lastRefillAttempt = 0;
     this.emergencyHeatingActive = false;
+    this.greenhouseFanCoolingActive = false;
     this.solarChargePeakTankAvg = null;
     this.solarChargePeakTankAvgAt = 0;
     this.transitionLog = [];

--- a/playground/js/main.js
+++ b/playground/js/main.js
@@ -358,6 +358,7 @@ function restoreBootstrapSnapshot(snapshot) {
   controller.collectorsDrained = fcs.collectorsDrained;
   controller.lastRefillAttempt = fcs.lastRefillAttempt;
   controller.emergencyHeatingActive = fcs.emergencyHeatingActive;
+  controller.greenhouseFanCoolingActive = !!fcs.greenhouseFanCoolingActive;
   controller.solarChargePeakTankAvg = (fcs.solarChargePeakTankAvg !== undefined)
     ? fcs.solarChargePeakTankAvg
     : null;

--- a/scripts/generate-bootstrap-history.mjs
+++ b/scripts/generate-bootstrap-history.mjs
@@ -178,6 +178,7 @@ export function generate() {
     collectorsDrained: !!controller.collectorsDrained,
     lastRefillAttempt: controller.lastRefillAttempt,
     emergencyHeatingActive: !!controller.emergencyHeatingActive,
+    greenhouseFanCoolingActive: !!controller.greenhouseFanCoolingActive,
     solarChargePeakTankAvg: controller.solarChargePeakTankAvg,
     solarChargePeakTankAvgAt: controller.solarChargePeakTankAvgAt,
   };

--- a/shelly/control-logic.js
+++ b/shelly/control-logic.js
@@ -138,6 +138,11 @@ var DEFAULT_CONFIG = {
   greenhouseExitTankDelta: 2,
   emergencyEnterTemp: 9,
   emergencyExitTemp: 12,
+  // Fan-cool overlay hysteresis (overlays.greenhouse_fan_cooling in
+  // system.yaml). Repurposes the radiator fan as a circulation aid
+  // when the greenhouse runs hot.
+  greenhouseFanCoolEnter: 30,
+  greenhouseFanCoolExit: 28,
   // Drain threshold for the colder of (outdoor, collector). Raised
   // 2 → 4 on 2026-04-22 for a safety margin: at 2 °C the collector is
   // already close enough to freezing that a sharp cooling transient
@@ -283,6 +288,7 @@ function evaluate(state, config, deviceConfig) {
     collectorsDrained: state.collectorsDrained,
     lastRefillAttempt: state.lastRefillAttempt,
     emergencyHeatingActive: state.emergencyHeatingActive || false,
+    greenhouseFanCoolingActive: state.greenhouseFanCoolingActive || false,
     // Solar-charging tank-rise tracking. Carried forward only while we
     // remain in SOLAR_CHARGING — cleared whenever pumpMode ends up
     // anything else (see end of function). Metric is the mean of
@@ -316,9 +322,12 @@ function evaluate(state, config, deviceConfig) {
     flags.solarChargePeakTankAvgAt = carriedPeakAt;
   }
 
-  // Sensor staleness — any sensor stale triggers IDLE, emergency off
+  // Sensor staleness — any sensor stale triggers IDLE, all overlays off
+  // (a failed greenhouse sensor must not strand emergency heat or the
+  // fan-cool fan running indefinitely).
   if (anySensorStale(state.sensorAge, cfg.sensorStaleThreshold)) {
     flags.emergencyHeatingActive = false;
+    flags.greenhouseFanCoolingActive = false;
     flags.solarChargePeakTankAvg = null;
     flags.solarChargePeakTankAvgAt = 0;
     return makeResult(MODES.IDLE, flags, dc, false, "sensor_stale");
@@ -369,9 +378,14 @@ function evaluate(state, config, deviceConfig) {
       state.currentMode !== MODES.EMERGENCY_HEATING &&
       elapsed < getMinDuration(state, cfg)) {
     var result = makeResult(state.currentMode, flags, dc, false, "min_duration");
-    // Emergency overlay still applies during min-duration hold
+    // Overlays still apply during min-duration hold; carried-forward
+    // state actuates, hysteresis updates wait for the hold to expire.
     if (t.greenhouse !== null && flags.emergencyHeatingActive) {
       result.actuators.space_heater = true;
+    }
+    if (flags.greenhouseFanCoolingActive &&
+        (!dc || (dc.ce && ((dc.ea || 0) & EA_FAN)))) {
+      result.actuators.fan = true;
     }
     return result;
   }
@@ -386,6 +400,18 @@ function evaluate(state, config, deviceConfig) {
       }
     } else if (t.greenhouse < cfg.emergencyEnterTemp) {
       flags.emergencyHeatingActive = true;
+    }
+  }
+
+  // Fan-cool overlay hysteresis (independent of pump mode; drain paths
+  // return earlier so the fan stays off during drain).
+  if (t.greenhouse !== null) {
+    if (flags.greenhouseFanCoolingActive) {
+      if (t.greenhouse <= cfg.greenhouseFanCoolExit) {
+        flags.greenhouseFanCoolingActive = false;
+      }
+    } else if (t.greenhouse >= cfg.greenhouseFanCoolEnter) {
+      flags.greenhouseFanCoolingActive = true;
     }
   }
 
@@ -540,6 +566,13 @@ function evaluate(state, config, deviceConfig) {
   var result = makeResult(pumpMode, flags, dc, false, reason);
   if (flags.emergencyHeatingActive) {
     result.actuators.space_heater = true;
+  }
+  // Fan-cool overlay is a comfort feature, not a safety override — unlike
+  // emergency_heating it respects EA_FAN and ce. Hysteresis still tracks
+  // regardless so the flag is consistent across ticks.
+  if (flags.greenhouseFanCoolingActive &&
+      (!dc || (dc.ce && ((dc.ea || 0) & EA_FAN)))) {
+    result.actuators.fan = true;
   }
 
   // ── Natural-mode ban check (post-evaluation) ──

--- a/shelly/control.js
+++ b/shelly/control.js
@@ -85,6 +85,7 @@ var state = {
   collectors_drained: false,
   last_refill_attempt: 0,
   emergency_heating_active: false,
+  greenhouse_fan_cooling_active: false,
   // Solar-charging tank-rise tracking (mirrors evaluate() flags). Tank
   // top temperature is tracked so we can keep pumping until the tank
   // stops accepting heat (no rise for 5 min, or 2°C drop from peak).
@@ -132,14 +133,20 @@ function setPump(on) {
   state.pump_on = on;
 }
 
-// Individual per-actuator setFan/setImmersion helpers were removed —
-// all callers go through setActuators. setSpaceHeater kept as a thin
-// standalone because controlLoop() fires it inside an in-flight chain
-// (see its call site in controlLoop) without gating on ce/ea elsewhere.
+// setImmersion helper was removed — all callers go through setActuators.
+// setSpaceHeater + setFan stay as thin standalones because controlLoop()
+// fires them in-line for the same-mode overlay path; one Shelly.call each
+// keeps the 5-call concurrency budget intact.
 function setSpaceHeater(on) {
   if (on && (!deviceConfig.ce || !(deviceConfig.ea & EA_SPACE_HEATER))) return;
   Shelly.call("Switch.Set", {id: 3, on: on});
   state.space_heater_on = on;
+}
+
+function setFan(on) {
+  if (on && (!deviceConfig.ce || !(deviceConfig.ea & EA_FAN))) return;
+  Shelly.call("Switch.Set", {id: 1, on: on});
+  state.fan_on = on;
 }
 
 // setActuators — sequentially sets the 4 local switches (pump, fan, immersion
@@ -339,6 +346,7 @@ function buildEvalState() {
     collectorsDrained: state.collectors_drained,
     lastRefillAttempt: state.last_refill_attempt / 1000,
     emergencyHeatingActive: state.emergency_heating_active,
+    greenhouseFanCoolingActive: state.greenhouse_fan_cooling_active,
     solarChargePeakTankAvg: state.solar_charge_peak_tank_avg,
     solarChargePeakTankAvgAt: state.solar_charge_peak_tank_avg_at,
     sensorAge: sensorAge,
@@ -357,6 +365,7 @@ function applyFlags(flags) {
   state.collectors_drained = flags.collectorsDrained;
   state.last_refill_attempt = flags.lastRefillAttempt * 1000;
   state.emergency_heating_active = flags.emergencyHeatingActive;
+  state.greenhouse_fan_cooling_active = !!flags.greenhouseFanCoolingActive;
   state.solar_charge_peak_tank_avg =
     flags.solarChargePeakTankAvg !== undefined ? flags.solarChargePeakTankAvg : null;
   state.solar_charge_peak_tank_avg_at = flags.solarChargePeakTankAvgAt || 0;
@@ -1033,6 +1042,8 @@ function controlLoop() {
       } else {
         applyFlags(result.flags);
         setSpaceHeater(!!result.actuators.space_heater);
+        // Fan-cool overlay can flip the fan on/off without a mode change.
+        setFan(!!result.actuators.fan);
         emitStateUpdate();
       }
 

--- a/system.yaml
+++ b/system.yaml
@@ -122,7 +122,14 @@ components:
     type: car radiator (syyläri)
     fan: 230V
     position: inside greenhouse, near ground
-    purpose: heat distribution from tank to greenhouse air
+    purpose: >
+      Heat distribution from tank to greenhouse air during
+      greenhouse_heating mode. The fan is also reused as an air-
+      circulation overlay (independent of pump mode) when greenhouse
+      temperature exceeds 30°C — moves air past the radiator and
+      around the greenhouse to reduce stratification and keep
+      conditions comfortable for plants. Hysteresis: fan-cool ON at
+      ≥30°C, OFF at ≤28°C. See `overlays.greenhouse_fan_cooling`.
 
   space_heater:
     type: fan heater
@@ -702,6 +709,41 @@ modes:
       - Run autumn_shutdown if not already done
       - Space heater on standalone thermostat for greenhouse minimum temp
       - System is passive — no Shelly control needed
+
+# =============================================================================
+# ACTUATOR OVERLAYS
+# =============================================================================
+# Overlays apply on top of whatever pump mode is active. They are evaluated
+# after mode selection in control-logic.js evaluate(), and force a single
+# actuator on regardless of the mode's default actuator state. Each overlay
+# tracks its own hysteresis flag carried across ticks via control state.
+
+overlays:
+  emergency_heating:
+    actuator: space_heater
+    enter: t_greenhouse < 9°C
+    exit: t_greenhouse > 12°C
+    notes: >
+      Independent of pump mode — when the greenhouse falls below the
+      enter threshold the space heater fires even if a pump mode is
+      idle or actively heating. The dedicated emergency_heating mode
+      is entered only when no pump mode is selected; otherwise the
+      space heater is overlaid on the active pump mode.
+
+  greenhouse_fan_cooling:
+    actuator: fan
+    enter: t_greenhouse >= 30°C
+    exit:  t_greenhouse <= 28°C
+    notes: >
+      Repurposes the radiator fan as a circulation aid when the
+      greenhouse gets hot. The radiator itself is at greenhouse air
+      temperature when no pump mode is heating it, so the fan
+      primarily destratifies and moves air past the plants rather
+      than removing heat — but air movement alone keeps conditions
+      better for plants. Hysteresis (30/28 °C) prevents short-cycling.
+      Suppressed during active_drain (early-return) and when sensors
+      are stale (early-return). Respects the EA_FAN device-config
+      bit and the watchdog/permanent ban on the active mode.
 
 # =============================================================================
 # SAFETY RULES

--- a/tests/control-logic-fan-cooling.test.js
+++ b/tests/control-logic-fan-cooling.test.js
@@ -1,0 +1,117 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const { evaluate, MODES } = require('../shelly/control-logic.js');
+
+function makeState(overrides) {
+  const base = {
+    temps: { collector: 20, tank_top: 40, tank_bottom: 30, greenhouse: 15, outdoor: 10 },
+    currentMode: MODES.IDLE,
+    modeEnteredAt: 0,
+    now: 2000,
+    collectorsDrained: false,
+    lastRefillAttempt: 0,
+    emergencyHeatingActive: false,
+    greenhouseFanCoolingActive: false,
+    sensorAge: { collector: 0, tank_top: 0, tank_bottom: 0, greenhouse: 0, outdoor: 0 },
+  };
+  return Object.assign({}, base, overrides);
+}
+
+// Repurposes the radiator fan as an air-circulation overlay when the
+// greenhouse gets hot. Independent of pump mode. Hysteresis: enter at
+// >= 30 °C, exit at <= 28 °C.
+
+describe('greenhouse fan cooling overlay', () => {
+  it('activates fan when greenhouse rises to enter threshold (30 °C)', () => {
+    const result = evaluate(makeState({
+      temps: { collector: 20, tank_top: 40, tank_bottom: 30, greenhouse: 30, outdoor: 20 },
+    }), null);
+    assert.strictEqual(result.flags.greenhouseFanCoolingActive, true);
+    assert.strictEqual(result.actuators.fan, true);
+  });
+
+  it('does NOT activate just below enter threshold (29.9 °C)', () => {
+    const result = evaluate(makeState({
+      temps: { collector: 20, tank_top: 40, tank_bottom: 30, greenhouse: 29.9, outdoor: 20 },
+    }), null);
+    assert.strictEqual(result.flags.greenhouseFanCoolingActive, false);
+    assert.strictEqual(result.actuators.fan, false);
+  });
+
+  it('stays on via hysteresis between 28 °C and 30 °C', () => {
+    const result = evaluate(makeState({
+      temps: { collector: 20, tank_top: 40, tank_bottom: 30, greenhouse: 29, outdoor: 20 },
+      greenhouseFanCoolingActive: true,
+    }), null);
+    assert.strictEqual(result.flags.greenhouseFanCoolingActive, true);
+    assert.strictEqual(result.actuators.fan, true);
+  });
+
+  it('deactivates when greenhouse drops to exit threshold (28 °C)', () => {
+    const result = evaluate(makeState({
+      temps: { collector: 20, tank_top: 40, tank_bottom: 30, greenhouse: 28, outdoor: 20 },
+      greenhouseFanCoolingActive: true,
+    }), null);
+    assert.strictEqual(result.flags.greenhouseFanCoolingActive, false);
+    assert.strictEqual(result.actuators.fan, false);
+  });
+
+  it('overlay applies on top of IDLE pump mode (fan-only operation)', () => {
+    const result = evaluate(makeState({
+      temps: { collector: 20, tank_top: 40, tank_bottom: 30, greenhouse: 32, outdoor: 20 },
+    }), null);
+    assert.strictEqual(result.nextMode, MODES.IDLE);
+    assert.strictEqual(result.actuators.pump, false);
+    assert.strictEqual(result.actuators.fan, true);
+  });
+
+  it('overlay applies on top of SOLAR_CHARGING (fan + pump)', () => {
+    const result = evaluate(makeState({
+      temps: { collector: 60, tank_top: 40, tank_bottom: 30, greenhouse: 31, outdoor: 25 },
+    }), null);
+    assert.strictEqual(result.nextMode, MODES.SOLAR_CHARGING);
+    assert.strictEqual(result.actuators.pump, true);
+    assert.strictEqual(result.actuators.fan, true);
+  });
+
+  // Drain modes return early before the overlay block so the fan stays
+  // off — drain is a brief safety operation and must not be sidetracked
+  // by comfort overlays.
+  it('overlay does not run during ACTIVE_DRAIN (drain-mode early return)', () => {
+    const result = evaluate(makeState({
+      temps: { collector: 1, tank_top: 40, tank_bottom: 30, greenhouse: 35, outdoor: 1 },
+    }), null);
+    assert.strictEqual(result.nextMode, MODES.ACTIVE_DRAIN);
+    assert.strictEqual(result.actuators.fan, false);
+  });
+
+  it('clears the cooling flag on sensor staleness', () => {
+    const result = evaluate(makeState({
+      greenhouseFanCoolingActive: true,
+      sensorAge: { collector: 0, tank_top: 0, tank_bottom: 0, greenhouse: 200, outdoor: 0 },
+    }), null);
+    assert.strictEqual(result.nextMode, MODES.IDLE);
+    assert.strictEqual(result.flags.greenhouseFanCoolingActive, false);
+    assert.strictEqual(result.actuators.fan, false);
+  });
+
+  // ea = EA_VALVES | EA_PUMP | EA_SPACE_HEATER | EA_IMMERSION = 1+2+8+16 = 27
+  // (EA_FAN = 4 omitted) — comfort overlay must respect the user's mask.
+  it('respects EA_FAN device-config bit (fan disabled in config)', () => {
+    const result = evaluate(makeState({
+      temps: { collector: 20, tank_top: 40, tank_bottom: 30, greenhouse: 32, outdoor: 20 },
+    }), null, { ce: true, ea: 27, v: 1 });
+    assert.strictEqual(result.flags.greenhouseFanCoolingActive, true,
+      'hysteresis still tracks intent');
+    assert.strictEqual(result.actuators.fan, false,
+      'fan masked off by EA_FAN');
+  });
+
+  it('null greenhouse sensor leaves the cooling flag untouched', () => {
+    const result = evaluate(makeState({
+      temps: { collector: 20, tank_top: 40, tank_bottom: 30, greenhouse: null, outdoor: 20 },
+      greenhouseFanCoolingActive: true,
+    }), null);
+    assert.strictEqual(result.flags.greenhouseFanCoolingActive, true);
+  });
+});

--- a/tests/control-logic.test.js
+++ b/tests/control-logic.test.js
@@ -11,6 +11,7 @@ function makeState(overrides) {
     collectorsDrained: false,
     lastRefillAttempt: 0,
     emergencyHeatingActive: false,
+    greenhouseFanCoolingActive: false,
     sensorAge: { collector: 0, tank_top: 0, tank_bottom: 0, greenhouse: 0, outdoor: 0 }
   };
   return Object.assign({}, base, overrides);
@@ -1117,5 +1118,6 @@ describe('manual override safety interaction', () => {
 });
 
 // planValveTransition scheduler helpers + tests moved to ./control-logic-valves.test.js
+// greenhouse fan-cooling overlay tests moved to ./control-logic-fan-cooling.test.js
 
 

--- a/tests/shelly/platform-limits.js
+++ b/tests/shelly/platform-limits.js
@@ -7,7 +7,7 @@
 
 const CAPS = {
   DEPLOYED_BYTES: 65535,          // Shelly Script.PutCode hard limit, error -103
-  RUNTIME_PROXY_PEAK: 44700,      // re-calibrated 2026-04-23 after adding solarStallBypassDelta config + mean-tank stall metric (measured 44126 + ~574 B margin). Prior: 43800 (measured 43256 + 544 B margin, set 2026-04-20 after adding __test_setTemps / __test_controlTick hooks for scheduler-stack-fuzz automated-freeze coverage). Hooks are stripped at runtime by the __TEST_HARNESS guard — this only affects the in-test measurement.
+  RUNTIME_PROXY_PEAK: 46000,      // re-calibrated 2026-05-01 after adding the greenhouse_fan_cooling overlay (hysteresis flag + setFan helper + same-mode overlay path; measured 45419 + ~580 B margin). Prior: 44700 (measured 44126, set 2026-04-23 after adding solarStallBypassDelta config + mean-tank stall metric). Earlier: 43800 (measured 43256, set 2026-04-20 after adding __test_setTemps / __test_controlTick hooks for scheduler-stack-fuzz automated-freeze coverage). Hooks are stripped at runtime by the __TEST_HARNESS guard — this only affects the in-test measurement.
   STATE_BYTES: 720,               // JSON.stringify(state).length peak — includes transient transition fields (opening[], pending_closes[], manual_override{}). Now deterministic: the 24 h sim uses a seeded PRNG so the measured peak is 699 B every run; 720 leaves ~21 B headroom for small state-shape additions before CI flags a regression.
   LIVE_TIMERS: 3,                 // simultaneous Timer.set handles (5 - 2 reserve)
   MQTT_SUBS: 3,                   // active MQTT.subscribe topics


### PR DESCRIPTION
Repurposes the radiator fan as an air-circulation aid when the greenhouse
runs hot. The overlay is independent of pump mode (idle, solar charging,
greenhouse heating) and tracks hysteresis state across ticks like the
emergency-heating overlay. Drain modes return earlier so the fan stays
off during freeze/overheat drain. Unlike emergency heating, fan-cool is
a comfort overlay and respects EA_FAN + ce so the operator can mask it
out via device config.

Plumbed through control.js (state, buildEvalState, applyFlags, in-line
setFan helper for the same-mode tick), the playground simulator, and the
bootstrap-history snapshot. Bumps RUNTIME_PROXY_PEAK 44700 → 46000 with
the same calibration approach used for the prior solarStallBypassDelta
addition.