### PR TITLE
tests: stabilize post-resync live-logs flake under parallel load

### DIFF
--- a/tests/frontend/live-logs.spec.js
+++ b/tests/frontend/live-logs.spec.js
@@ -416,6 +416,19 @@ test.describe('System Logs card is backed by live state events', () => {
     // synthesised history fallback must not invent a partial row.
     await expect(page.locator('#logs-list .log-item')).toHaveCount(1, { timeout: 1000 });
 
+    // Detach the sync coordinator's visibility/pageshow listeners
+    // before firing the WS frame. Under heavy parallel-test CPU load,
+    // headless Chromium has been observed to fire spontaneous
+    // visibilitychange events between the WS frame and the
+    // assertions below; the resulting resync re-fetches /api/events
+    // (which only carries the original solar_charging row in this
+    // test's mock) and applyEventPages(isReset=true) clobbers the
+    // freshly-detected idle entry from transitionLog. _resetForTests
+    // unhooks the listeners without clearing registered sources, so
+    // an explicit triggerResync would still work — but nothing in
+    // the rest of this test triggers one.
+    await page.evaluate(() => { window.__sync._resetForTests(); });
+
     // Now the real WS frame for the idle transition lands, carrying
     // cause / reason / temps. detectLiveTransition must produce a
     // *complete* row — title + cause chip + reason line + sensors line.
@@ -438,7 +451,12 @@ test.describe('System Logs card is backed by live state events', () => {
 
     await expect(page.locator('#logs-list .log-item')).toHaveCount(2, { timeout: 3000 });
     const first = page.locator('#logs-list .log-item').first();
-    await expect(first).toContainText('Idle');
+    // toContainText('Idle') is intentionally avoided here: the "from"
+    // half of the previous solar_charging entry's transition text also
+    // reads "Idle → Collecting Solar Energy", so a substring match
+    // can't tell the two rows apart. Anchor on the title node, which
+    // exclusively renders the destination mode label.
+    await expect(first.locator('.log-title')).toHaveText(/^Idle\b/);
     await expect(first.locator('.log-cause')).toHaveText('Automation');
     await expect(first.locator('.log-reason')).toHaveText('tank stopped gaining heat');
     await expect(first.locator('.log-sensors')).toContainText('coll 25.0°');


### PR DESCRIPTION
## Summary

While running the CI test suite repeatedly (each script 5+ times) the
`tests/frontend/live-logs.spec.js › post-resync history fallback does
not pollute the log with a partial entry` test failed intermittently
(~1/10 full-suite runs locally; 0/20 isolated runs). All other CI
suites (`test:unit`, `test:e2e`, `lint`, `knip`, `check:file-size`,
`check:assets`) passed every run; this is the only flake found.

### Root cause

Under heavy parallel-test CPU contention, headless Chromium fires
spontaneous `visibilitychange` events between the test's WS-frame
injection and the row-content assertions. The resync those events
trigger calls `applyEventPages(isReset=true)`, which clears
`transitionLog` (including the freshly-detected idle entry) and
refills it from the static `/api/events` mock that only carries the
prior `solar_charging` row. The first log row then resolves to the
stale `solar_enter` entry and `toHaveText('tank stopped gaining
heat')` fails with `Received: 'collector hot enough to charge'`.

A secondary problem masked the symptom: the loose
`toContainText('Idle')` check on the first row passed regardless of
which row was at position 0, because the previous `solar_charging`
row's transition text reads `'Idle → Collecting Solar Energy'`. The
real failure (wrong row at position 0) only surfaced one assertion
later.

### Fix

1. Detach the sync coordinator's visibility/pageshow/online listeners
   right before firing the WS frame
   (`window.__sync._resetForTests()`), so spurious `visibilitychange`
   events can no longer race with the assertions. Registered sources
   stay intact; the explicit `triggerResync` earlier in the test runs
   as before.

2. Replace `toContainText('Idle')` with an exact `.log-title` match
   anchored on the destination mode label, so a row-ordering
   regression surfaces at the title check rather than two assertions
   later.

The same regression scenarios are still covered: the
synthetic-render-must-not-add-a-partial-row check at `count === 1`
stays, and the post-WS row's title, cause chip, reason line, and
sensors line are all still asserted.

## Test plan

- [x] `npm run test:unit` — 5/5 green
- [x] `npm run test:frontend` — 8/8 green after the fix (1/10 fail
      before)
- [x] `npm run test:e2e` — 5/5 green
- [x] `npm run lint` / `knip` / `check:file-size --strict` /
      `check:assets --strict` — 5/5 green each
- [x] Modified test alone: 20/20 green

https://claude.ai/code/session_01AqHV5FDda6XyVzJJC39cwy

---
_Generated by [Claude Code](https://claude.ai/code/session_01AqHV5FDda6XyVzJJC39cwy)_