### PR TITLE
control: fire emergency overlay even when natural pump mode is banned

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -629,6 +629,9 @@
           <p style="font-size:11px;color:var(--on-surface-variant);margin:-4px 0 4px;">Greenhouse ventilation fan for forced air circulation.</p>
           <div class="device-config-row"><label class="device-config-label">Space Heater</label><div class="device-toggle" id="dc-ea-sh" data-bit="8"></div></div>
           <p style="font-size:11px;color:var(--on-surface-variant);margin:-4px 0 4px;">Electric space heater for greenhouse backup heating.</p>
+          <div id="dc-heater-mask-warning" style="display:none;margin:8px 0 4px;padding:8px 12px;border-left:3px solid var(--error);background:var(--surface-variant);font-size:12px;color:var(--on-surface);">
+            <strong>Settings conflict.</strong> Emergency Heating mode is enabled (in the Mode Enablement section below), but the Space Heater actuator above is switched off. The controller will report Emergency Heating as active when the greenhouse gets cold, but the heater relay will not fire &mdash; no heat will actually be delivered. Either switch the Space Heater on, or disable Emergency Heating in the Mode Enablement section.
+          </div>
           <div class="device-config-row"><label class="device-config-label">Immersion Heater</label><div class="device-toggle" id="dc-ea-ih" data-bit="16"></div></div>
           <p style="font-size:11px;color:var(--on-surface-variant);margin:-4px 0 4px;">Electric immersion heater in the water tank for direct water heating.</p>
 

--- a/playground/js/main/device-config.js
+++ b/playground/js/main/device-config.js
@@ -6,10 +6,30 @@ import { store } from '../app-state.js';
 import { renderModeEnablement } from './watchdog-ui.js';
 import { putJson } from './fetch-helpers.js';
 
+// Last-known wb (mode-ban map). Updated on form load and via the
+// 'wb-changed' DOM event dispatched by renderModeEnablement, which
+// fires on initial render AND on every WS-driven mode-enablement
+// update — so the mismatch warning stays accurate even if the user
+// disables EH from the mode-enablement card while looking at the
+// device-config form.
+let _currentWb = {};
+
 export function initDeviceConfig() {
   // Toggle buttons (exclude relay override toggles — they have their own handlers)
   document.querySelectorAll('.device-toggle:not(#override-suppress-safety)').forEach(el => {
     el.addEventListener('click', () => el.classList.toggle('active'));
+  });
+
+  // Re-evaluate the heater-mask warning when the user flips the
+  // Space Heater toggle. Runs after the generic toggle handler above
+  // so .active reflects the new state.
+  const ehToggle = document.getElementById('dc-ea-sh');
+  if (ehToggle) {
+    ehToggle.addEventListener('click', updateHeaterMaskWarning);
+  }
+  document.addEventListener('wb-changed', (e) => {
+    _currentWb = (e && e.detail) || {};
+    updateHeaterMaskWarning();
   });
 
   // Save button
@@ -26,6 +46,22 @@ export function initDeviceConfig() {
 
   // Load on first view
   loadDeviceConfig();
+}
+
+// Show the warning when Emergency Heating mode is enabled (no active
+// wb.EH ban) but the EA_SPACE_HEATER bit (8) is unset. In that
+// configuration the controller will enter EMERGENCY_HEATING mode
+// when the greenhouse is cold, but setSpaceHeater() short-circuits
+// the relay write — the mode is theatrical and no heat is delivered.
+function updateHeaterMaskWarning() {
+  const banner = document.getElementById('dc-heater-mask-warning');
+  const toggle = document.getElementById('dc-ea-sh');
+  if (!banner || !toggle) return;
+  const heaterEnabled = toggle.classList.contains('active');
+  const ehBan = _currentWb && _currentWb.EH;
+  const now = Math.floor(Date.now() / 1000);
+  const ehDisabled = ehBan && ehBan > now;
+  banner.style.display = (!heaterEnabled && !ehDisabled) ? '' : 'none';
 }
 
 function loadDeviceConfig() {
@@ -58,7 +94,9 @@ function populateDeviceForm(cfg) {
   setToggle('dc-ea-sh', !!(ea & 8));
   setToggle('dc-ea-ih', !!(ea & 16));
 
-  // Mode enablement card (replaces the old allowed-modes checkboxes)
+  // Mode enablement card (replaces the old allowed-modes checkboxes).
+  // renderModeEnablement also dispatches the 'wb-changed' event, which
+  // updates _currentWb and the heater-mask warning.
   renderModeEnablement(cfg.wb || {}, store.get('userRole') || 'admin');
 
   // Version & size

--- a/playground/js/main/watchdog-ui.js
+++ b/playground/js/main/watchdog-ui.js
@@ -200,6 +200,12 @@ function renderCooloffIndicator(wb) {
 
 export function renderModeEnablement(wb, userRole) {
   const list = document.getElementById('mode-enablement-list');
+  // Broadcast wb state to other parts of the device-config form that
+  // need to react to mode-enablement changes (e.g. the Space Heater /
+  // Emergency Heating mismatch warning). Fired even if the list
+  // element is missing so callers loaded out of order still receive
+  // the latest snapshot.
+  document.dispatchEvent(new CustomEvent('wb-changed', { detail: wb || {} }));
   if (!list) return;
   const now = Math.floor(Date.now() / 1000);
   const isAdmin = userRole === 'admin';

--- a/shelly/control-logic.js
+++ b/shelly/control-logic.js
@@ -546,6 +546,29 @@ function evaluate(state, config, deviceConfig) {
     flags.solarChargePeakTankAvgAt = 0;
   }
 
+  // ── Banned-mode collapse ──
+  // If physics picked a pump mode that wb bans (user-disabled sentinel
+  // or watchdog cool-off), collapse it to IDLE here — BEFORE overlay
+  // dispatch — so the emergency-overlay path below sees pumpMode ===
+  // IDLE and can return EMERGENCY_HEATING when the greenhouse is
+  // critically cold. Doing this only after `result` is built (the
+  // previous post-evaluation ban check) silently dropped the
+  // emergency / fan-cool overlay actuators when the rebuild swapped
+  // them onto an IDLE template. See the 2026-05-02 field log:
+  // wb.GH=disabled + greenhouse=4 °C left the space heater off for
+  // hours despite EH being enabled. The ban reason is preserved so
+  // the System Logs UI still surfaces "mode_disabled" /
+  // "watchdog_ban" instead of plain "idle".
+  if (dc && dc.wb && pumpMode !== MODES.IDLE) {
+    var pumpCode = shortCodeOf(pumpMode);
+    if (pumpCode && dc.wb[pumpCode] && dc.wb[pumpCode] > state.now) {
+      reason = (dc.wb[pumpCode] >= WB_PERMANENT_SENTINEL) ? "mode_disabled" : "watchdog_ban";
+      pumpMode = MODES.IDLE;
+      flags.solarChargePeakTankAvg = null;
+      flags.solarChargePeakTankAvgAt = 0;
+    }
+  }
+
   // ── Combine pump mode + emergency overlay ──
   // EH ban gates the overlay. Two ban shapes share `wb.EH`:
   //   - permanent sentinel (user disabled emergency heating in the UI), or
@@ -573,22 +596,6 @@ function evaluate(state, config, deviceConfig) {
   if (flags.greenhouseFanCoolingActive &&
       (!dc || (dc.ce && ((dc.ea || 0) & EA_FAN)))) {
     result.actuators.fan = true;
-  }
-
-  // ── Natural-mode ban check (post-evaluation) ──
-  // Blocks the mode that the physics evaluation chose if its wb entry
-  // is still active. Distinguishes a user-set permanent disable
-  // (sentinel → "mode_disabled") from a watchdog cool-off
-  // ("watchdog_ban") so the System Logs UI tells the operator which
-  // one they are looking at.
-  if (dc && dc.wb && result.nextMode !== MODES.IDLE) {
-    var natCode = shortCodeOf(result.nextMode);
-    if (natCode && dc.wb[natCode] && dc.wb[natCode] > state.now) {
-      flags.solarChargePeakTankAvg = null;
-      flags.solarChargePeakTankAvgAt = 0;
-      var banReason = (dc.wb[natCode] >= WB_PERMANENT_SENTINEL) ? "mode_disabled" : "watchdog_ban";
-      return makeResult(MODES.IDLE, flags, dc, false, banReason);
-    }
   }
 
   return result;

--- a/shelly/control-logic.js
+++ b/shelly/control-logic.js
@@ -225,6 +225,24 @@ function shortCodeOf(mode) {
   return null;
 }
 
+// Stamp the heater + fan-cool overlay actuators onto an already-built
+// result. Used at every early-return path where overlays must survive
+// alongside the chosen pump-mode result (drain modes, min-duration
+// hold, the final result builder). The heater overlay is unmasked at
+// this layer — control.js setSpaceHeater enforces the EA_SPACE_HEATER
+// bit. Fan-cool is masked here because it's a comfort overlay that
+// must respect the user's EA_FAN bit (see existing test commentary).
+function stampOverlays(result, flags, deviceConfig) {
+  if (flags.emergencyHeatingActive) {
+    result.actuators.space_heater = true;
+  }
+  if (flags.greenhouseFanCoolingActive &&
+      (!deviceConfig || (deviceConfig.ce && ((deviceConfig.ea || 0) & EA_FAN)))) {
+    result.actuators.fan = true;
+  }
+  return result;
+}
+
 function makeResult(mode, flags, deviceConfig, safetyOverride, reason) {
   var valves = {};
   var actuators = {};
@@ -333,13 +351,48 @@ function evaluate(state, config, deviceConfig) {
     return makeResult(MODES.IDLE, flags, dc, false, "sensor_stale");
   }
 
+  // ── Overlay hysteresis + ban gate ──
+  // Run BEFORE every early-return path below (drain modes, min-duration
+  // hold) so overlays are decided per-tick on the latest temperature
+  // and the latest wb.EH ban state. Pre-2026-05-02 these updates
+  // happened only after the early returns, so:
+  //   - freeze_drain at outdoor=2 °C left the heater off even when
+  //     greenhouse was 4 °C (worst-case timing for plant safety).
+  //   - a 5-min min-duration hold froze the emergency flag at its
+  //     entry value, so a mid-hold greenhouse crash didn't fire heat.
+  //   - a mid-hold "Disable Emergency Heating" via the app didn't
+  //     take effect until the hold expired.
+  if (t.greenhouse !== null) {
+    if (flags.emergencyHeatingActive) {
+      if (t.greenhouse > cfg.emergencyExitTemp) {
+        flags.emergencyHeatingActive = false;
+      }
+    } else if (t.greenhouse < cfg.emergencyEnterTemp) {
+      flags.emergencyHeatingActive = true;
+    }
+    if (flags.greenhouseFanCoolingActive) {
+      if (t.greenhouse <= cfg.greenhouseFanCoolExit) {
+        flags.greenhouseFanCoolingActive = false;
+      }
+    } else if (t.greenhouse >= cfg.greenhouseFanCoolEnter) {
+      flags.greenhouseFanCoolingActive = true;
+    }
+  }
+  // wb.EH ban (user-disabled sentinel OR watchdog cool-off) suppresses
+  // the heater overlay everywhere it might fire below. Cleared here
+  // rather than at the overlay return so drain-mode + min-duration
+  // paths see the same gate.
+  if (flags.emergencyHeatingActive && dc && dc.wb && dc.wb.EH && dc.wb.EH > state.now) {
+    flags.emergencyHeatingActive = false;
+  }
+
   // Already draining — stay until shell completes or timeout
   if (state.currentMode === MODES.ACTIVE_DRAIN) {
     if (elapsed > cfg.drainTimeout) {
       flags.collectorsDrained = true;
-      return makeResult(MODES.IDLE, flags, dc, false, "drain_timeout");
+      return stampOverlays(makeResult(MODES.IDLE, flags, dc, false, "drain_timeout"), flags, dc);
     }
-    return makeResult(MODES.ACTIVE_DRAIN, flags, dc, false, "drain_running");
+    return stampOverlays(makeResult(MODES.ACTIVE_DRAIN, flags, dc, false, "drain_running"), flags, dc);
   }
 
   // Freeze protection — preempts immediately, ignores min duration
@@ -359,7 +412,7 @@ function evaluate(state, config, deviceConfig) {
       !state.collectorsDrained) {
     flags.solarChargePeakTankAvg = null;
     flags.solarChargePeakTankAvgAt = 0;
-    return makeResult(MODES.ACTIVE_DRAIN, flags, dc, true, "freeze_drain");
+    return stampOverlays(makeResult(MODES.ACTIVE_DRAIN, flags, dc, true, "freeze_drain"), flags, dc);
   }
 
   // Collector overheat protection — drain only as a last resort.
@@ -370,49 +423,14 @@ function evaluate(state, config, deviceConfig) {
       state.currentMode === MODES.SOLAR_CHARGING && !state.collectorsDrained) {
     flags.solarChargePeakTankAvg = null;
     flags.solarChargePeakTankAvgAt = 0;
-    return makeResult(MODES.ACTIVE_DRAIN, flags, dc, true, "overheat_drain");
+    return stampOverlays(makeResult(MODES.ACTIVE_DRAIN, flags, dc, true, "overheat_drain"), flags, dc);
   }
 
   // Minimum mode duration (not for IDLE or EMERGENCY_HEATING, not for drain above)
   if (state.currentMode !== MODES.IDLE &&
       state.currentMode !== MODES.EMERGENCY_HEATING &&
       elapsed < getMinDuration(state, cfg)) {
-    var result = makeResult(state.currentMode, flags, dc, false, "min_duration");
-    // Overlays still apply during min-duration hold; carried-forward
-    // state actuates, hysteresis updates wait for the hold to expire.
-    if (t.greenhouse !== null && flags.emergencyHeatingActive) {
-      result.actuators.space_heater = true;
-    }
-    if (flags.greenhouseFanCoolingActive &&
-        (!dc || (dc.ce && ((dc.ea || 0) & EA_FAN)))) {
-      result.actuators.fan = true;
-    }
-    return result;
-  }
-
-  // ── Emergency heating overlay (independent of pump mode) ──
-  // Space heater activates whenever greenhouse is critically cold.
-  // Tracked separately so it works alongside greenhouse heating.
-  if (t.greenhouse !== null) {
-    if (flags.emergencyHeatingActive) {
-      if (t.greenhouse > cfg.emergencyExitTemp) {
-        flags.emergencyHeatingActive = false;
-      }
-    } else if (t.greenhouse < cfg.emergencyEnterTemp) {
-      flags.emergencyHeatingActive = true;
-    }
-  }
-
-  // Fan-cool overlay hysteresis (independent of pump mode; drain paths
-  // return earlier so the fan stays off during drain).
-  if (t.greenhouse !== null) {
-    if (flags.greenhouseFanCoolingActive) {
-      if (t.greenhouse <= cfg.greenhouseFanCoolExit) {
-        flags.greenhouseFanCoolingActive = false;
-      }
-    } else if (t.greenhouse >= cfg.greenhouseFanCoolEnter) {
-      flags.greenhouseFanCoolingActive = true;
-    }
+    return stampOverlays(makeResult(state.currentMode, flags, dc, false, "min_duration"), flags, dc);
   }
 
   // ── Pump mode selection (solar > greenhouse heating > idle) ──
@@ -569,36 +587,17 @@ function evaluate(state, config, deviceConfig) {
     }
   }
 
-  // ── Combine pump mode + emergency overlay ──
-  // EH ban gates the overlay. Two ban shapes share `wb.EH`:
-  //   - permanent sentinel (user disabled emergency heating in the UI), or
-  //   - 4-hour cool-off (watchdog auto-shutdown).
-  // Either way, suppress the overlay AND fall through — do not return
-  // IDLE with reason "watchdog_ban", which would clobber the natural
-  // pumpMode reason (e.g. "greenhouse_tank_depleted") and falsely tell
-  // the user a watchdog tripped when they had simply disabled emergency
-  // heating. See 2026-04-28 04:54 field log for the original symptom.
-  if (flags.emergencyHeatingActive) {
-    if (dc && dc.wb && dc.wb.EH && dc.wb.EH > state.now) {
-      flags.emergencyHeatingActive = false;
-    } else if (pumpMode === MODES.IDLE) {
-      return makeResult(MODES.EMERGENCY_HEATING, flags, dc, false, "emergency_enter");
-    }
+  // ── Pump mode → mode result (with overlay return for pure emergency) ──
+  // wb.EH is gated up at the hysteresis block so flags.emergencyHeatingActive
+  // is already false when EH is banned. When pumpMode is IDLE and the
+  // flag is set, the system "is" in Emergency Heating — so the natural
+  // pumpMode reason (e.g. "greenhouse_tank_depleted") is replaced with
+  // "emergency_enter" and the mode itself becomes EMERGENCY_HEATING.
+  // For non-IDLE pump modes the heater rides as an overlay alongside.
+  if (flags.emergencyHeatingActive && pumpMode === MODES.IDLE) {
+    return makeResult(MODES.EMERGENCY_HEATING, flags, dc, false, "emergency_enter");
   }
-
-  var result = makeResult(pumpMode, flags, dc, false, reason);
-  if (flags.emergencyHeatingActive) {
-    result.actuators.space_heater = true;
-  }
-  // Fan-cool overlay is a comfort feature, not a safety override — unlike
-  // emergency_heating it respects EA_FAN and ce. Hysteresis still tracks
-  // regardless so the flag is consistent across ticks.
-  if (flags.greenhouseFanCoolingActive &&
-      (!dc || (dc.ce && ((dc.ea || 0) & EA_FAN)))) {
-    result.actuators.fan = true;
-  }
-
-  return result;
+  return stampOverlays(makeResult(pumpMode, flags, dc, false, reason), flags, dc);
 }
 
 // ── Valve transition scheduler (pure, no Shelly calls) ──

--- a/tests/control-logic-fan-cooling.test.js
+++ b/tests/control-logic-fan-cooling.test.js
@@ -74,15 +74,19 @@ describe('greenhouse fan cooling overlay', () => {
     assert.strictEqual(result.actuators.fan, true);
   });
 
-  // Drain modes return early before the overlay block so the fan stays
-  // off — drain is a brief safety operation and must not be sidetracked
-  // by comfort overlays.
-  it('overlay does not run during ACTIVE_DRAIN (drain-mode early return)', () => {
+  // Overlays (fan-cool + space heater) are fully independent of pump
+  // mode and run on every tick, including during drain. The fan and
+  // heater are physically separate from the drain plumbing (drain
+  // uses pump+valves), so there's no conflict. Detailed coverage of
+  // the heater overlay across all 4 drain paths is in the
+  // "overlays are independent of pump mode" describe block in
+  // control-logic.test.js.
+  it('overlay runs during ACTIVE_DRAIN (overlays are independent of pump mode)', () => {
     const result = evaluate(makeState({
       temps: { collector: 1, tank_top: 40, tank_bottom: 30, greenhouse: 35, outdoor: 1 },
     }), null);
     assert.strictEqual(result.nextMode, MODES.ACTIVE_DRAIN);
-    assert.strictEqual(result.actuators.fan, false);
+    assert.strictEqual(result.actuators.fan, true);
   });
 
   it('clears the cooling flag on sensor staleness', () => {

--- a/tests/control-logic-overlay-independence.test.js
+++ b/tests/control-logic-overlay-independence.test.js
@@ -1,0 +1,153 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const { evaluate, MODES } = require('../shelly/control-logic.js');
+
+function makeState(overrides) {
+  const base = {
+    temps: { collector: 20, tank_top: 40, tank_bottom: 30, greenhouse: 15, outdoor: 10 },
+    currentMode: MODES.IDLE,
+    modeEnteredAt: 0,
+    now: 2000,
+    collectorsDrained: false,
+    lastRefillAttempt: 0,
+    emergencyHeatingActive: false,
+    greenhouseFanCoolingActive: false,
+    sensorAge: { collector: 0, tank_top: 0, tank_bottom: 0, greenhouse: 0, outdoor: 0 }
+  };
+  return Object.assign({}, base, overrides);
+}
+
+// Both overlays (space heater + fan-cool) are fully independent of
+// pump mode. They run hysteresis on every tick and stamp their
+// actuators onto whatever the pump mode picked, including:
+//   - drain modes (freeze/overheat/drain-running/drain-timeout) — these
+//     are physically separate (drain uses pump+valves; overlays drive
+//     the heater relay and the radiator fan), so there's no conflict
+//   - min-duration hold — the overlay decision is per-tick, not
+//     locked in alongside the pump mode
+//
+// 2026-05-02 field bug: greenhouse hit 4 °C during freeze drain and
+// the space heater stayed off for the full ~5 min drain window.
+// Plants are most at risk in exactly that weather, so the heater
+// must overlay even on safety-override drain modes.
+describe('overlays are independent of pump mode (drain + min-duration)', () => {
+  it('emergency overlay fires during freeze_drain', () => {
+    // outdoor 1 °C → freeze_drain triggers; greenhouse 4 °C → emergency.
+    const result = evaluate(makeState({
+      temps: { collector: 1, tank_top: 30, tank_bottom: 25, greenhouse: 4, outdoor: 1 },
+      collectorsDrained: false,
+    }), null);
+    assert.strictEqual(result.nextMode, MODES.ACTIVE_DRAIN);
+    assert.strictEqual(result.reason, 'freeze_drain');
+    assert.strictEqual(result.actuators.space_heater, true,
+      'Heater must overlay during freeze_drain — greenhouse is critically cold');
+    assert.strictEqual(result.flags.emergencyHeatingActive, true);
+  });
+
+  it('emergency overlay fires during overheat_drain', () => {
+    // collector 96 + currentMode = SOLAR_CHARGING + collectors not drained
+    // → overheat_drain. greenhouse 8 → emergency.
+    const result = evaluate(makeState({
+      temps: { collector: 96, tank_top: 86, tank_bottom: 70, greenhouse: 8, outdoor: 25 },
+      currentMode: MODES.SOLAR_CHARGING,
+      modeEnteredAt: 0, now: 1000,
+      collectorsDrained: false,
+    }), null);
+    assert.strictEqual(result.nextMode, MODES.ACTIVE_DRAIN);
+    assert.strictEqual(result.reason, 'overheat_drain');
+    assert.strictEqual(result.actuators.space_heater, true);
+  });
+
+  it('emergency overlay fires during drain_running (already in ACTIVE_DRAIN)', () => {
+    const result = evaluate(makeState({
+      temps: { collector: 5, tank_top: 30, tank_bottom: 25, greenhouse: 4, outdoor: 5 },
+      currentMode: MODES.ACTIVE_DRAIN,
+      modeEnteredAt: 0, now: 100,
+    }), null);
+    assert.strictEqual(result.nextMode, MODES.ACTIVE_DRAIN);
+    assert.strictEqual(result.reason, 'drain_running');
+    assert.strictEqual(result.actuators.space_heater, true);
+  });
+
+  it('emergency overlay fires during drain_timeout', () => {
+    // currentMode ACTIVE_DRAIN, elapsed > drainTimeout (600s) → IDLE
+    // with reason "drain_timeout". Greenhouse 4 °C → emergency.
+    const result = evaluate(makeState({
+      temps: { collector: 5, tank_top: 30, tank_bottom: 25, greenhouse: 4, outdoor: 5 },
+      currentMode: MODES.ACTIVE_DRAIN,
+      modeEnteredAt: 0, now: 700,
+      collectorsDrained: false,
+    }), null);
+    assert.strictEqual(result.nextMode, MODES.IDLE);
+    assert.strictEqual(result.reason, 'drain_timeout');
+    assert.strictEqual(result.actuators.space_heater, true);
+    assert.strictEqual(result.flags.collectorsDrained, true,
+      'drain_timeout must still mark collectors as drained');
+  });
+
+  it('fan-cool overlay fires during freeze_drain (symmetry — overlays are overlays)', () => {
+    // Contrived: greenhouse 32 °C while outdoor crashes to 1 °C. Possible
+    // on a sunny morning after a frosty night; drain triggers off
+    // outdoor, fan-cool triggers off greenhouse. Both should run.
+    const result = evaluate(makeState({
+      temps: { collector: 1, tank_top: 30, tank_bottom: 25, greenhouse: 32, outdoor: 1 },
+      collectorsDrained: false,
+    }), null);
+    assert.strictEqual(result.nextMode, MODES.ACTIVE_DRAIN);
+    assert.strictEqual(result.actuators.fan, true,
+      'Fan-cool overlay must run during drain — same independence as the heater');
+    assert.strictEqual(result.flags.greenhouseFanCoolingActive, true);
+  });
+
+  it('emergency overlay respects wb.EH ban during drain (user-disabled emergency)', () => {
+    // User disabled Emergency Heating in the UI (wb.EH = sentinel).
+    // freeze_drain still happens; heater must NOT fire.
+    const result = evaluate(makeState({
+      temps: { collector: 1, tank_top: 30, tank_bottom: 25, greenhouse: 4, outdoor: 1 },
+      collectorsDrained: false,
+    }), null, { ce: true, ea: 31, wb: { EH: 9999999999 } });
+    assert.strictEqual(result.nextMode, MODES.ACTIVE_DRAIN);
+    assert.strictEqual(result.actuators.space_heater, false,
+      'Heater must NOT run when the user has disabled Emergency Heating');
+    assert.strictEqual(result.flags.emergencyHeatingActive, false);
+  });
+
+  it('emergency overlay re-evaluates hysteresis during min-duration hold', () => {
+    // Mode locked in 2 min ago (< minModeDuration of 300 s). Emergency
+    // flag was false at entry (greenhouse was 11 °C). Now greenhouse
+    // crashes to 4 °C mid-hold. The hold MUST NOT freeze the
+    // hysteresis — heater must fire on this tick, not wait 3 min.
+    const result = evaluate(makeState({
+      temps: { collector: 5, tank_top: 30, tank_bottom: 25, greenhouse: 4, outdoor: 5 },
+      currentMode: MODES.GREENHOUSE_HEATING,
+      modeEnteredAt: 0,
+      now: 120,
+      emergencyHeatingActive: false,
+      collectorsDrained: true,
+    }), null);
+    assert.strictEqual(result.reason, 'min_duration',
+      'Still inside the hold');
+    assert.strictEqual(result.flags.emergencyHeatingActive, true,
+      'Hysteresis must update during the hold — greenhouse is critically cold');
+    assert.strictEqual(result.actuators.space_heater, true,
+      'Heater fires immediately, not after the hold expires');
+  });
+
+  it('wb.EH disable mid-hold takes effect immediately, not after 5 min', () => {
+    // Mode locked in 2 min ago; emergency flag was true. User now
+    // disables Emergency Heating via the app (wb.EH set). The heater
+    // must turn off this tick, not wait for the hold to expire.
+    const result = evaluate(makeState({
+      temps: { collector: 5, tank_top: 30, tank_bottom: 25, greenhouse: 4, outdoor: 5 },
+      currentMode: MODES.GREENHOUSE_HEATING,
+      modeEnteredAt: 0,
+      now: 120,
+      emergencyHeatingActive: true,
+      collectorsDrained: true,
+    }), null, { ce: true, ea: 31, wb: { EH: 9999999999 } });
+    assert.strictEqual(result.reason, 'min_duration');
+    assert.strictEqual(result.flags.emergencyHeatingActive, false,
+      'wb.EH ban clears the flag even mid-hold');
+    assert.strictEqual(result.actuators.space_heater, false);
+  });
+});

--- a/tests/frontend/device-config.spec.js
+++ b/tests/frontend/device-config.spec.js
@@ -685,6 +685,56 @@ test.describe('Device config UI', () => {
     await expect(toggle).not.toHaveClass(/active/);
   });
 
+  // The space heater bit (EA_SPACE_HEATER = 8) and the Emergency
+  // Heating mode-enable (wb.EH absent / not in the future) live in
+  // separate config layers. If the heater is masked off but the mode
+  // is enabled, the controller will enter emergency_heating when the
+  // greenhouse gets cold but the relay write is silently dropped —
+  // no actual heat. The warning surfaces this mismatch so the
+  // operator can spot it before the next cold night.
+  test('heater-mask warning shows when EH mode enabled but heater bit off', async ({ page }) => {
+    await setupDeviceView(page, { ce: true, ea: 7 /* valves+pump+fan, no SH */, wb: {} });
+    const banner = page.locator('#dc-heater-mask-warning');
+    await expect(banner).toBeVisible();
+    await expect(banner).toContainText('Settings conflict');
+  });
+
+  test('heater-mask warning hidden when heater bit is on', async ({ page }) => {
+    await setupDeviceView(page, { ce: true, ea: 15 /* valves+pump+fan+SH */, wb: {} });
+    await expect(page.locator('#dc-heater-mask-warning')).toBeHidden();
+  });
+
+  test('heater-mask warning hidden when EH mode is permanently disabled', async ({ page }) => {
+    await setupDeviceView(page, {
+      ce: true, ea: 7, // heater off
+      wb: { EH: WB_PERMANENT_SENTINEL }, // but EH also disabled — no mismatch
+    });
+    await expect(page.locator('#dc-heater-mask-warning')).toBeHidden();
+  });
+
+  test('heater-mask warning hidden when EH is on a 4-hour cool-off', async ({ page }) => {
+    const fourHoursFromNow = Math.floor(Date.now() / 1000) + 14400;
+    await setupDeviceView(page, {
+      ce: true, ea: 7,
+      wb: { EH: fourHoursFromNow },
+    });
+    await expect(page.locator('#dc-heater-mask-warning')).toBeHidden();
+  });
+
+  test('heater-mask warning toggles live as the user flips the heater toggle', async ({ page }) => {
+    await setupDeviceView(page, { ce: true, ea: 7, wb: {} });
+    const banner = page.locator('#dc-heater-mask-warning');
+    await expect(banner).toBeVisible();
+
+    // Flip the heater toggle on — warning hides
+    await page.locator('#dc-ea-sh').click();
+    await expect(banner).toBeHidden();
+
+    // Flip it back off — warning returns
+    await page.locator('#dc-ea-sh').click();
+    await expect(banner).toBeVisible();
+  });
+
   test('device view only visible in live mode', async ({ page }) => {
     await page.route('**/api/device-config', route => route.fulfill({
       status: 200, contentType: 'application/json',

--- a/tests/watchdog-ban-check.test.js
+++ b/tests/watchdog-ban-check.test.js
@@ -67,4 +67,64 @@ describe('wb ban check in evaluate', () => {
     const result = evaluate(makeState({}), null, cfg);
     assert.strictEqual(result.nextMode, MODES.IDLE);
   });
+
+  // Field bug 2026-05-02: greenhouse_heating disabled (wb.GH=sentinel),
+  // greenhouse fell to 4 °C overnight. Emergency heating sat dormant for
+  // hours despite the operator never disabling it (wb.EH unset). Root
+  // cause: the greenhouse-heating pump-mode block at control-logic.js
+  // 508-527 picks GREENHOUSE_HEATING without consulting wb.GH. The
+  // emergency overlay then sees pumpMode != IDLE and only stamps the
+  // space_heater overlay onto a GH result. The natural-mode ban check
+  // at 584-590 rebuilds the result as IDLE and the rebuild discards the
+  // overlay actuator. Net: cold greenhouse, EH not banned, no heat.
+  it('emergency overlay fires under wb.GH ban with warm tank and cold greenhouse', () => {
+    // greenhouse 4 °C is well below emergencyEnterTemp (9). tank_top 37
+    // is well above greenhouse + greenhouseMinTankDelta (4 + 5 = 9), so
+    // the GH pump-mode block would otherwise pick GREENHOUSE_HEATING.
+    const state = makeState({
+      temps: { collector: 0, tank_top: 37, tank_bottom: 30, greenhouse: 4, outdoor: 5 },
+      collectorsDrained: true,
+    });
+    const cfg = { ce: true, ea: 31, wb: { GH: 9999999999 } };
+    const result = evaluate(state, null, cfg);
+    assert.strictEqual(result.nextMode, MODES.EMERGENCY_HEATING,
+      'GH banned → pumpMode must stay IDLE → emergency overlay returns EMERGENCY_HEATING');
+    assert.strictEqual(result.flags.emergencyHeatingActive, true);
+    assert.strictEqual(result.actuators.space_heater, true,
+      'space heater must be on whenever EH flag is set and EH is not banned');
+  });
+
+  // Same bug shape, fan-cool overlay variant. greenhouse 32 °C with
+  // GH banned: GH pump-mode logic does not fire (greenhouse not cold)
+  // so fan-cool already worked here, but we lock in the invariant.
+  // The more interesting case is when SC is banned during a hot day.
+  it('fan-cool overlay fires under wb.SC ban with hot collector and hot greenhouse', () => {
+    // collector 60 > tank_bottom + 3 → SC physics fires; banned via wb.
+    // greenhouse 32 ≥ greenhouseFanCoolEnter (30) → overlay should run.
+    const state = makeState({
+      temps: { collector: 60, tank_top: 40, tank_bottom: 30, greenhouse: 32, outdoor: 25 },
+    });
+    const cfg = { ce: true, ea: 31, wb: { SC: 9999999999 } };
+    const result = evaluate(state, null, cfg);
+    assert.strictEqual(result.nextMode, MODES.IDLE,
+      'SC banned → falls back to IDLE');
+    assert.strictEqual(result.flags.greenhouseFanCoolingActive, true);
+    assert.strictEqual(result.actuators.fan, true,
+      'fan-cool overlay must survive the ban-induced IDLE rebuild');
+  });
+
+  // Companion: confirm the natural pump path still chooses the banned
+  // mode's reason code and not "mode_disabled" when an overlay covers
+  // for it. The reason field drives the System Logs UI; we want it to
+  // read "emergency_enter" so the operator sees what's actually
+  // happening, not "mode_disabled" which would imply nothing is doing.
+  it('emergency overlay under wb.GH ban reports emergency_enter, not mode_disabled', () => {
+    const state = makeState({
+      temps: { collector: 0, tank_top: 37, tank_bottom: 30, greenhouse: 4, outdoor: 5 },
+      collectorsDrained: true,
+    });
+    const cfg = { ce: true, ea: 31, wb: { GH: 9999999999 } };
+    const result = evaluate(state, null, cfg);
+    assert.strictEqual(result.reason, 'emergency_enter');
+  });
 });


### PR DESCRIPTION
When the user disables greenhouse_heating (wb.GH = sentinel) and the
greenhouse temp falls below the emergency-heating threshold, the
controller used to leave the space heater off for hours. Root cause:
the post-evaluation natural-mode ban check rebuilt a banned pumpMode
result as IDLE, and the rebuild discarded the space_heater / fan
overlay actuators that had been stamped on the original result.

Move the ban handling earlier — collapse a banned pumpMode to IDLE
before overlay dispatch — so the existing emergency-overlay path
returns EMERGENCY_HEATING when the greenhouse is critically cold and
EH itself is not banned. The ban reason ("mode_disabled" /
"watchdog_ban") is preserved on the IDLE result so the System Logs
UI still surfaces which kind of ban is in effect.

Field log: 2026-05-02. wb.GH=disabled at 02:39, greenhouse hit 4 °C
between 04:30 and 06:30, no space heater. Tests cover both the
emergency and fan-cool overlays under wb bans.