### PR TITLE
control: surface wanted mode + reason in min_duration held entry

### DIFF
--- a/playground/js/main/logs-clipboard.js
+++ b/playground/js/main/logs-clipboard.js
@@ -197,19 +197,56 @@ function formatWatchdogSnoozed(wz, nowSec) {
 }
 
 // Per-tick `held` diagnostic from the evaluator. Surfaces in the
-// controller-state block of the System Logs export so the operator
-// can see "held by refill_cooldown — 12m remaining" without having
-// to deduce it from sensor values + system knowledge. Three sub-
-// fields (pumpMode / emergencyHeating / fanCooling); each renders
-// as its own line with a remaining-time countdown when bounded.
-const HELD_REASON_LABELS = {
-  refill_cooldown: 'refill cooldown',
-  freeze_guard: 'collector or outdoor below freeze threshold',
-  wb_ban: 'mode disabled / banned',
-  min_duration: '5-min mode-duration hold',
+// controller-state block of the System Logs export AND a banner under
+// the active-mode card so the operator can read "Change to Idle pending
+// — tank stopped gaining heat. Hold 3m remaining." without having to
+// deduce it from sensor values + system knowledge. Three sub-fields
+// (pumpMode / emergencyHeating / fanCooling); each renders as its own
+// line with a countdown when the guard is time-bounded.
+//
+// Subject phrasing per sub-field:
+//   pumpMode          → "Change to <Mode> pending" / "<Subject> held"
+//   emergencyHeating  → "Emergency heating suppressed"
+//   fanCooling        → "Fan cooling suppressed"
+//
+// blockedBy → human label maps to a phrase that fits BOTH the "would
+// have done X but" framing and the standalone overlay-suppressed lines.
+const HELD_BLOCKED_PHRASES = {
+  refill_cooldown: 'refill cooldown still ticking',
+  freeze_guard: 'collector or outdoor still below freeze threshold',
+  wb_ban: 'mode disabled or in watchdog cool-off',
+  min_duration: '5-min minimum mode duration',
   ea_mask: 'actuator disabled in device config',
   controls_disabled: 'controls disabled (master switch off)',
   sensor_stale: 'sensor reading stale',
+};
+
+// blockedBy code → label embedded in the trailing "Hold X" /
+// "Cool-off X" hint (we drop the verbose phrase to keep the line short
+// when an explicit countdown is also rendered).
+const HELD_BLOCKED_SHORT = {
+  refill_cooldown: 'cool-off',
+  min_duration: 'hold',
+  wb_ban: 'cool-off',
+};
+
+// Reason codes the evaluator emits for the natural pump-mode pick.
+// Matches REASON_LABELS in time-format.js but kept local to avoid an
+// import cycle (logs-clipboard imports time-format already, this is the
+// reverse direction). Subset focused on decisions that actually surface
+// as "wanted" in held.pumpMode.
+const HELD_WANTED_REASON_LABELS = {
+  solar_enter: 'collector hot enough to charge',
+  solar_refill: 'refilling drained collectors',
+  solar_active: 'tank still gaining heat',
+  solar_stall: 'tank stopped gaining heat',
+  solar_drop_from_peak: 'tank cooling below peak',
+  overheat_circulate: 'collector overheat — would circulate to cool',
+  greenhouse_enter: 'greenhouse cold — would heat',
+  greenhouse_active: 'greenhouse still cold',
+  greenhouse_warm: 'greenhouse warm enough',
+  greenhouse_tank_depleted: 'tank too cool to heat greenhouse',
+  idle: 'no trigger active',
 };
 
 function prettyMode(code) {
@@ -227,23 +264,54 @@ function formatRemaining(untilSec, nowSec) {
   return h + 'h' + (m < 10 ? '0' : '') + m + 'm remaining';
 }
 
+// Render the pump-mode held entry. Two flavours:
+//   - wanted set: "Change to Idle pending — tank stopped gaining heat.
+//                  Hold 3m remaining."
+//   - wanted unset: "Pump mode held — 5-min minimum mode duration.
+//                    3m remaining."
+// The wanted-set form is the user-facing phrasing the operator asked for
+// (PR #126 / live-banner readability follow-up).
+function formatPumpMode(entry, nowSec) {
+  const blockedPhrase = HELD_BLOCKED_PHRASES[entry.blockedBy] || entry.blockedBy;
+  const remaining = formatRemaining(entry.until, nowSec);
+  const shortLabel = HELD_BLOCKED_SHORT[entry.blockedBy] || 'guard';
+  if (entry.wanted) {
+    const wantedLabel = prettyMode(entry.wanted);
+    const reasonLabel = entry.wantedReason
+      ? (HELD_WANTED_REASON_LABELS[entry.wantedReason] || entry.wantedReason)
+      : null;
+    let line = 'Change to ' + wantedLabel + ' pending';
+    if (reasonLabel) line += ' — ' + reasonLabel + '.';
+    else line += '.';
+    if (remaining) line += ' ' + capitalise(shortLabel) + ' ' + remaining + '.';
+    return line;
+  }
+  let line = 'Pump mode held — ' + blockedPhrase + '.';
+  if (remaining) line += ' ' + remaining + '.';
+  return line;
+}
+
+// Render an overlay held entry (heater / fan). The "wanted" flag is
+// always true when the entry exists (otherwise the evaluator wouldn't
+// populate it), so we phrase it as "<Subject> suppressed by <reason>".
+function formatOverlay(subject, entry, nowSec) {
+  const blockedPhrase = HELD_BLOCKED_PHRASES[entry.blockedBy] || entry.blockedBy;
+  const remaining = formatRemaining(entry.until, nowSec);
+  let line = subject + ' suppressed — ' + blockedPhrase + '.';
+  if (remaining) line += ' Cool-off ' + remaining + '.';
+  return line;
+}
+
+function capitalise(s) {
+  return s ? s[0].toUpperCase() + s.slice(1) : s;
+}
+
 export function formatHeldLines(held, nowSec) {
   if (!held) return [];
   const out = [];
-  const fmt = (subject, entry) => {
-    if (!entry) return;
-    const reason = HELD_REASON_LABELS[entry.blockedBy] || entry.blockedBy;
-    const remaining = formatRemaining(entry.until, nowSec);
-    let line = subject + ': held by ' + reason;
-    if (entry.wanted) {
-      line += ' — would enter ' + prettyMode(entry.wanted);
-    }
-    if (remaining) line += ' (' + remaining + ')';
-    out.push(line);
-  };
-  fmt('Pump mode', held.pumpMode);
-  fmt('Emergency heating', held.emergencyHeating);
-  fmt('Fan cooling', held.fanCooling);
+  if (held.pumpMode) out.push(formatPumpMode(held.pumpMode, nowSec));
+  if (held.emergencyHeating) out.push(formatOverlay('Emergency heating', held.emergencyHeating, nowSec));
+  if (held.fanCooling) out.push(formatOverlay('Fan cooling', held.fanCooling, nowSec));
   return out;
 }
 

--- a/shelly/control-logic.js
+++ b/shelly/control-logic.js
@@ -476,14 +476,11 @@ function evaluate(state, config, deviceConfig) {
     return attachHeld(stampOverlays(makeResult(MODES.ACTIVE_DRAIN, flags, dc, true, "overheat_drain"), flags, dc), held);
   }
 
-  // Minimum mode duration (not for IDLE or EMERGENCY_HEATING, not for drain above)
-  if (state.currentMode !== MODES.IDLE &&
-      state.currentMode !== MODES.EMERGENCY_HEATING &&
-      elapsed < getMinDuration(state, cfg)) {
-    held.pumpMode = heldEntry("min_duration", null, null,
-      state.modeEnteredAt + getMinDuration(state, cfg));
-    return attachHeld(stampOverlays(makeResult(state.currentMode, flags, dc, false, "min_duration"), flags, dc), held);
-  }
+  // Minimum mode duration is enforced AFTER pump-mode selection (see the
+  // "Min-duration override" block further down). Running selection first
+  // lets the held entry surface the would-be decision so the operator
+  // sees "change to Idle pending — tank stopped gaining heat" instead of
+  // a bare "held by min_duration".
 
   // ── Pump mode selection (solar > greenhouse heating > idle) ──
   // Solar charging has priority: free energy, time-limited (daylight only).
@@ -622,7 +619,36 @@ function evaluate(state, config, deviceConfig) {
     }
   }
 
-  // Clear peak tracking if we are not staying in / entering SOLAR_CHARGING
+  // ── Min-duration override ──
+  // Once an active pump mode has started, hold it for getMinDuration
+  // seconds before allowing automation to switch away. Runs AFTER
+  // pump-mode selection so we know what the natural choice would have
+  // been — that gets stashed on held.pumpMode as { wanted, wantedReason }
+  // so the playground can render "change to Idle pending — tank stopped
+  // gaining heat. Hold 3m remaining."
+  // Skipped for IDLE (no transition cost to escape) and EMERGENCY_HEATING
+  // (heater overlay is purely hysteresis-driven, no entry/exit ceremony).
+  // Drain modes (ACTIVE_DRAIN, freeze_drain, overheat_drain) early-return
+  // above this block so they bypass the hold.
+  if (state.currentMode !== MODES.IDLE &&
+      state.currentMode !== MODES.EMERGENCY_HEATING &&
+      elapsed < getMinDuration(state, cfg)) {
+    if (pumpMode !== state.currentMode) {
+      held.pumpMode = heldEntry("min_duration", pumpMode, reason,
+        state.modeEnteredAt + getMinDuration(state, cfg));
+    } else {
+      // Natural choice is to stay put — still surface the hold so the
+      // operator sees the countdown, but no "would change to" framing.
+      held.pumpMode = heldEntry("min_duration", null, null,
+        state.modeEnteredAt + getMinDuration(state, cfg));
+    }
+    pumpMode = state.currentMode;
+    reason = "min_duration";
+  }
+
+  // Clear peak tracking if we are not staying in / entering SOLAR_CHARGING.
+  // Runs AFTER the min-duration override so a held SOLAR_CHARGING keeps
+  // its peak (we're still pumping; the tank is still being driven).
   if (pumpMode !== MODES.SOLAR_CHARGING) {
     flags.solarChargePeakTankAvg = null;
     flags.solarChargePeakTankAvgAt = 0;

--- a/tests/control-logic-held.test.js
+++ b/tests/control-logic-held.test.js
@@ -115,21 +115,52 @@ describe('held field — pump mode', () => {
     assert.strictEqual(result.held.pumpMode.until, undefined);
   });
 
-  it('captures min_duration with until when current mode is held by the 5-min lock', () => {
-    // GREENHOUSE_HEATING entered 60 s ago; minModeDuration = 300 s. Hold
-    // is active. Greenhouse is now warm enough to exit, but the hold
-    // keeps us in GH for another 240 s.
+  it('captures min_duration with wanted mode + reason from the would-be decision', () => {
+    // SOLAR_CHARGING entered 60 s ago; minModeDuration = 300 s. Tank
+    // stalled (peak set 600 s ago, no rise) — natural pump-mode would
+    // exit to IDLE with reason "solar_stall". The hold keeps SC for
+    // another 240 s. The held entry must surface BOTH the wanted mode
+    // (IDLE) AND the underlying reason (solar_stall) so the operator
+    // can read "change to idle pending: tank stopped gaining heat" in
+    // the live banner — not just "held by min_duration".
     const result = evaluate(makeState({
-      temps: { collector: 5, tank_top: 40, tank_bottom: 30, greenhouse: 15, outdoor: 10 },
+      temps: { collector: 35, tank_top: 40, tank_bottom: 40, greenhouse: 15, outdoor: 10 },
+      currentMode: MODES.SOLAR_CHARGING,
+      modeEnteredAt: 1940,  // 60 s ago at now=2000
+      now: 2000,
+      // Peak was 800 s ago and tank hasn't risen — solar_stall.
+      solarChargePeakTankAvg: 40,
+      solarChargePeakTankAvgAt: 1200,
+    }), null, allEnabled);
+    assert.strictEqual(result.nextMode, MODES.SOLAR_CHARGING);
+    assert.strictEqual(result.reason, 'min_duration');
+    assert.ok(result.held && result.held.pumpMode);
+    assert.strictEqual(result.held.pumpMode.blockedBy, 'min_duration');
+    assert.strictEqual(result.held.pumpMode.until, 1940 + 300);
+    assert.strictEqual(result.held.pumpMode.wanted, MODES.IDLE);
+    assert.strictEqual(result.held.pumpMode.wantedReason, 'solar_stall');
+  });
+
+  it('omits wanted/wantedReason on min_duration when current matches the natural pick', () => {
+    // GREENHOUSE_HEATING entered 60 s ago, greenhouse still cold + tank
+    // still has delta — the natural pump mode is the same GH we're
+    // already in, so technically no transition is "pending". Still
+    // surface min_duration so the operator sees the hold, but skip the
+    // "would change to X" framing.
+    const result = evaluate(makeState({
+      temps: { collector: 5, tank_top: 40, tank_bottom: 30, greenhouse: 8, outdoor: 5 },
       currentMode: MODES.GREENHOUSE_HEATING,
       modeEnteredAt: 1940,
       now: 2000,
+      collectorsDrained: true,
     }), null, allEnabled);
     assert.strictEqual(result.nextMode, MODES.GREENHOUSE_HEATING);
     assert.strictEqual(result.reason, 'min_duration');
     assert.ok(result.held && result.held.pumpMode);
     assert.strictEqual(result.held.pumpMode.blockedBy, 'min_duration');
-    assert.strictEqual(result.held.pumpMode.until, 1940 + 300);
+    assert.strictEqual(result.held.pumpMode.wanted, undefined,
+      'no wanted entry — would have stayed put anyway');
+    assert.strictEqual(result.held.pumpMode.wantedReason, undefined);
   });
 });
 


### PR DESCRIPTION
## Summary

Follow-up on #125. The first cut of the held banner showed `Pump mode: held by 5-min mode-duration hold (3m remaining)` — too cryptic. The operator wants to see what the system *would* change to and *why*, not just the name of the guard that's holding it.

This restructures `evaluate()` so the min-duration hold check runs **after** pump-mode selection. That lets `held.pumpMode` carry the natural pick (`wanted`, `wantedReason`) so the playground banner can read:

```
Change to Idle pending — tank stopped gaining heat. Hold 3m remaining.
```

instead of:

```
Pump mode: held by 5-min mode-duration hold (3m remaining)
```

`formatHeldLines()` rewritten with two flavours:

- **wanted set** (refill_cooldown / freeze_guard / wb_ban / min_duration with a real next-mode pick) → `Change to <Mode> pending — <reason>. <Hold|Cool-off> Xm remaining.`
- **wanted unset** (min_duration where the natural pick is the same mode you're already in) → `Pump mode held — 5-min minimum mode duration. Xm remaining.`

Overlay sub-fields (heater / fan) keep their suppressed-overlay phrasing.

### Side effects to watch

Running pump-mode selection during a hold could in principle mutate state. The only mutation that mattered was the post-selection peak-clear (`solarChargePeakTankAvg → null` when `pumpMode !== SC`) — moved to **after** the min-duration override so a held SC keeps its peak (we're still pumping; tank is still being driven). Drain modes still early-return ahead of selection, so freeze/overheat preempt as before.

## Test plan

- [x] New test `captures min_duration with wanted mode + reason from the would-be decision` — asserts `held.pumpMode.wanted` + `wantedReason` on a SOLAR_CHARGING + stalled scenario
- [x] New test `omits wanted/wantedReason on min_duration when current matches the natural pick` — covers the GH-still-cold-during-hold case so the banner doesn't say "would change to Greenhouse Heating" when we *are* in GH
- [x] All 1003 unit tests pass
- [x] All 267 Playwright tests pass
- [x] Lint, knip, file-size strict, assets strict
- [x] STATE_BYTES + RUNTIME_PROXY_PEAK still under cap

https://claude.ai/code/session_013U46J33XiqydDQXutyguFZ

---
_Generated by [Claude Code](https://claude.ai/code/session_013U46J33XiqydDQXutyguFZ)_