### PR TITLE
Decouple direction-of-change arrows from the graph timeframe selector

### DIFF
--- a/playground/js/main.js
+++ b/playground/js/main.js
@@ -40,7 +40,7 @@ window.__triggerVersionCheck = triggerVersionCheck;
 // siblings don't have to import back from main.js (which would cycle).
 import {
   model, controller, running, showAllSensors,
-  params, timeSeriesStore,
+  params, timeSeriesStore, trendStore,
   setModel, setController, setRunning,
   setSimSpeed, setShowAllSensors,
 } from './main/state.js';
@@ -319,6 +319,7 @@ function resetSim() {
   });
   controller.reset();
   timeSeriesStore.reset();
+  trendStore.reset();
   transitionLog.length = 0;
   resetChartZoom();
   resetYesterdayTracking();
@@ -371,6 +372,11 @@ function restoreBootstrapSnapshot(snapshot) {
   for (let i = 0; i < snapshot.points.length; i++) {
     const p = snapshot.points[i];
     timeSeriesStore.addPoint(p.time, p.values);
+    // Seed trendStore so rising/falling arrows show on the first
+    // render after auto-bootstrap (GitHub Pages deploy) instead of
+    // staying blank for the first ~5 min of sim time. trendStore's
+    // age-based pruning keeps only the trailing window.
+    trendStore.addPoint(p.time, p.values);
   }
   // Reconstruct mode-events from the bootstrap log: each transition
   // entry encodes the mode the controller switched INTO at sim time

--- a/playground/js/main/connection.js
+++ b/playground/js/main/connection.js
@@ -4,7 +4,7 @@ import { LiveSource } from '../data-source.js';
 import { store } from '../app-state.js';
 import { initSyncCoordinator } from '../sync/coordinator.js';
 import { attachScriptStatusWebSocket } from '../actions/script-monitor.js';
-import { graphRange, timeSeriesStore, running } from './state.js';
+import { graphRange, timeSeriesStore, trendStore, running } from './state.js';
 import { attachWatchdogWebSocket } from './watchdog-ui.js';
 import { handleOverrideResponse, updateRelayBoard } from './relay-board.js';
 import { updateDrainageControl } from './drainage-control.js';
@@ -416,8 +416,12 @@ function clearLiveDisplay() {
   // Clear component statuses
   const compEls = document.querySelectorAll('.comp-status');
   compEls.forEach(function(el) { el.textContent = '--'; });
-  // Clear simulation graph data and redraw empty canvas
+  // Clear simulation graph data and redraw empty canvas. trendStore
+  // is reset too so the rising/falling arrows don't carry simulation
+  // values into the live view (and vice versa) before fresh samples
+  // arrive.
   timeSeriesStore.reset();
+  trendStore.reset();
   resetChartZoom();
   drawHistoryGraph();
   // Clear the transition log — fetchLiveEvents() will repopulate it from the DB

--- a/playground/js/main/display-update.js
+++ b/playground/js/main/display-update.js
@@ -4,7 +4,7 @@
 
 import { store } from '../app-state.js';
 import { tankStoredEnergyKwh } from '../physics.js';
-import { timeSeriesStore, MODE_INFO, running, setLastLiveFrame } from './state.js';
+import { timeSeriesStore, trendStore, MODE_INFO, running, setLastLiveFrame } from './state.js';
 import { detectLiveTransition, renderLogsList } from './logs.js';
 import { drawHistoryGraph, toSchematicState } from './history-graph.js';
 import { appendBalanceLivePoint, getLiveYesterdayHigh } from './balance-card.js';
@@ -19,28 +19,31 @@ function fmtTemp(v, digits) {
   return isNum(v) ? v.toFixed(digits) : TEMP_PLACEHOLDER;
 }
 
-// 15-minute rolling window, 1 °C/hr threshold → ≥0.25 °C per 15 min
-// counts as rising/falling. Window is long enough to populate from
-// the first page-load history fetch, short enough that weather +
-// charging-state changes surface within a minute.
-const TREND_WINDOW_S = 900;
-const TREND_THRESHOLD = 0.25;
+// 5-minute rolling window, ~1 °C/hr threshold → ≥0.083 °C per 5 min
+// counts as rising/falling. Reads from trendStore (not timeSeriesStore)
+// so the user picking a longer graph range — which resets timeSeriesStore
+// and reloads downsampled history — does not blow away the high-resolution
+// recent samples the trend computation needs. The trend is an "is it
+// changing right now?" indicator and is intentionally decoupled from
+// the graph card's timeframe selector.
+const TREND_WINDOW_S = 300;
+const TREND_THRESHOLD = 0.083;
 
 function trendFor(resolver) {
-  if (timeSeriesStore.times.length < 2) return null;
-  const now = timeSeriesStore.times[timeSeriesStore.times.length - 1];
+  if (trendStore.times.length < 2) return null;
+  const now = trendStore.times[trendStore.times.length - 1];
   const windowStart = now - TREND_WINDOW_S;
-  let startIdx = timeSeriesStore.times.length - 1;
-  for (let i = timeSeriesStore.times.length - 2; i >= 0; i--) {
-    if (timeSeriesStore.times[i] < windowStart) break;
+  let startIdx = trendStore.times.length - 1;
+  for (let i = trendStore.times.length - 2; i >= 0; i--) {
+    if (trendStore.times[i] < windowStart) break;
     startIdx = i;
   }
-  if (startIdx >= timeSeriesStore.times.length - 1) return null;
+  if (startIdx >= trendStore.times.length - 1) return null;
   const fn = typeof resolver === 'function'
     ? resolver
     : (entry) => entry[resolver];
-  const latest = fn(timeSeriesStore.values[timeSeriesStore.values.length - 1]);
-  const earlier = fn(timeSeriesStore.values[startIdx]);
+  const latest = fn(trendStore.values[trendStore.values.length - 1]);
+  const earlier = fn(trendStore.values[startIdx]);
   if (!isNum(latest) || !isNum(earlier)) return null;
   const delta = latest - earlier;
   if (delta >= TREND_THRESHOLD) return 'rising';
@@ -484,15 +487,20 @@ function recordLiveHistoryPoint(state, result) {
   // mode-events store, so this function only persists the temperatures.
   void result;
   const tSec = Math.floor(Date.now() / 1000);
-  const last = timeSeriesStore.times.length - 1;
-  if (last >= 0 && (tSec - timeSeriesStore.times[last]) < 5) return;
-  timeSeriesStore.addPoint(tSec, {
+  const vals = {
     t_tank_top: state.t_tank_top,
     t_tank_bottom: state.t_tank_bottom,
     t_collector: state.t_collector,
     t_greenhouse: state.t_greenhouse,
     t_outdoor: state.t_outdoor,
-  });
+  };
+  // trendStore has its own dedup-by-timestamp + age-based pruning, so
+  // we feed it every frame — trendFor wants the freshest sample
+  // available regardless of the graph cadence.
+  trendStore.addPoint(tSec, vals);
+  const last = timeSeriesStore.times.length - 1;
+  if (last >= 0 && (tSec - timeSeriesStore.times[last]) < 5) return;
+  timeSeriesStore.addPoint(tSec, vals);
 }
 
 // Re-render the Status/Components views after something refills the

--- a/playground/js/main/live-history.js
+++ b/playground/js/main/live-history.js
@@ -14,7 +14,7 @@
 //   between /api/history fetches.
 
 import { store } from '../app-state.js';
-import { timeSeriesStore } from './state.js';
+import { timeSeriesStore, trendStore } from './state.js';
 import { drawHistoryGraph } from './history-graph.js';
 import { rerenderWithHistoryFallback } from './display-update.js';
 import { registerDataSource } from '../sync/registry.js';
@@ -100,13 +100,21 @@ function loadLiveHistoryIntoStore(data) {
     const p = data.points[i];
     if (!p || typeof p.ts !== 'number') continue;
     const tSec = Math.floor(p.ts / 1000);
-    timeSeriesStore.addPoint(tSec, {
+    const vals = {
       t_tank_top: p.tank_top,
       t_tank_bottom: p.tank_bottom,
       t_collector: p.collector,
       t_greenhouse: p.greenhouse,
       t_outdoor: p.outdoor,
-    });
+    };
+    timeSeriesStore.addPoint(tSec, vals);
+    // Seed trendStore so the rising/falling arrows populate on first
+    // page load instead of waiting 5 min for live WS frames to fill in.
+    // addPoint drops samples ≤ the last stored timestamp, so a later
+    // timeframe change to (e.g.) 4mo — which returns sparse downsampled
+    // points — cannot clobber high-resolution recent samples already
+    // written by earlier fetches or live frames.
+    trendStore.addPoint(tSec, vals);
   }
 }
 

--- a/playground/js/main/simulation.js
+++ b/playground/js/main/simulation.js
@@ -5,7 +5,7 @@
 import { SIM_START_HOUR, getDayNightEnv } from '../sim-bootstrap.js';
 import {
   running, setRunning, model, controller, params, simSpeed,
-  timeSeriesStore, transitionLog,
+  timeSeriesStore, trendStore, transitionLog,
 } from './state.js';
 import { updateDisplay } from './display-update.js';
 import { updateSidebarSubtitle } from './connection.js';
@@ -35,6 +35,7 @@ export function togglePlay() {
       });
       controller.reset();
       timeSeriesStore.reset();
+      trendStore.reset();
       transitionLog.length = 0;
       resetModeEvents();
     }
@@ -140,13 +141,15 @@ function simLoop(timestamp) {
 
     // Record every ~5 seconds of sim time
     if (Math.floor(model.state.simTime) % 5 === 0) {
-      timeSeriesStore.addPoint(model.state.simTime, {
+      const vals = {
         t_tank_top: model.state.t_tank_top,
         t_tank_bottom: model.state.t_tank_bottom,
         t_collector: model.state.t_collector,
         t_greenhouse: model.state.t_greenhouse,
         t_outdoor: model.state.t_outdoor,
-      });
+      };
+      timeSeriesStore.addPoint(model.state.simTime, vals);
+      trendStore.addPoint(model.state.simTime, vals);
     }
   }
 

--- a/playground/js/main/state.js
+++ b/playground/js/main/state.js
@@ -86,6 +86,49 @@ export const timeSeriesStore = {
   reset() { this.times = []; this.values = []; },
 };
 
+// Dedicated short-window buffer for the rising/falling trend arrows
+// shown in the Status gauge and Components view. Kept separate from
+// timeSeriesStore so picking a longer graph range (which calls
+// timeSeriesStore.reset() and reloads downsampled history) does not
+// blow away the high-resolution recent samples the trend computation
+// reads from. Pruned by age (TREND_RETENTION_S of headroom over the
+// 5 min trend window) so it stays cheap. Survives phase flips; only
+// the explicit reset() (called from sim reset / phase flip) clears it.
+//
+// addPoint accepts samples in any order so the live boot race —
+// where the WebSocket state frame may land before the /api/history
+// seed (whose points are all older) — does not throw away the
+// pre-window history. Out-of-order inserts go to their sorted
+// position; duplicate timestamps are dropped (the earlier write
+// wins, so a later live-WS sample at the same second can't silently
+// overwrite a history point already trusted).
+const TREND_RETENTION_S = 600;
+export const trendStore = {
+  times: [],
+  values: [],
+  addPoint(time, vals) {
+    let lo = 0;
+    let hi = this.times.length;
+    while (lo < hi) {
+      const mid = (lo + hi) >>> 1;
+      if (this.times[mid] < time) lo = mid + 1;
+      else hi = mid;
+    }
+    if (lo < this.times.length && this.times[lo] === time) return;
+    this.times.splice(lo, 0, time);
+    this.values.splice(lo, 0, { ...vals });
+    const latest = this.times[this.times.length - 1];
+    const cutoff = latest - TREND_RETENTION_S;
+    let drop = 0;
+    while (drop < this.times.length && this.times[drop] < cutoff) drop++;
+    if (drop > 0) {
+      this.times.splice(0, drop);
+      this.values.splice(0, drop);
+    }
+  },
+  reset() { this.times = []; this.values = []; },
+};
+
 // Mode-transition log, unified across sim and live. Appended by
 // simLoop (sim mode) and fetchLiveEvents / detectLiveTransition
 // (live mode); read by renderLogsList + buildLogsClipboardText.

--- a/tests/frontend/live-display.spec.js
+++ b/tests/frontend/live-display.spec.js
@@ -329,3 +329,81 @@ test.describe('Collectors fluid-state indicator', () => {
     await expect(page.locator('#comp-collectors')).toHaveText('FILLED');
   });
 });
+
+test.describe('Direction-of-change is decoupled from the graph timeframe selector', () => {
+  // The trend arrows in the Status gauge ("RISING" / "FALLING" / "STABLE")
+  // and the per-sensor arrows in the Components view must always reflect
+  // the most recent ~5 minutes of samples. Picking a longer graph range
+  // (4mo) reloads the graph's history with downsampled points; that must
+  // NOT clear the trend state.
+  test('trend label stays RISING after switching the graph range', async ({ page }) => {
+    const now = Date.now();
+    // 6 fine-grained recent samples within the trend's 5-min window,
+    // tank_top climbing 32 → 35 °C (well past the 0.083 °C threshold).
+    const fineGrained = [];
+    for (let i = 6; i >= 0; i--) {
+      fineGrained.push({
+        ts: now - i * 30_000,
+        collector: 50 + (6 - i),
+        tank_top: 32 + (6 - i) * 0.5,
+        tank_bottom: 28 + (6 - i) * 0.5,
+        greenhouse: 20,
+        outdoor: 10,
+      });
+    }
+
+    // Server-side handler: respond with the fine-grained set for the
+    // initial 24h fetch, then with a sparse downsampled set (one
+    // ancient point, no recent ones) for any 4mo refetch. The sparse
+    // response is what would silently break the trend if it clobbered
+    // the trendStore.
+    await page.route('**/api/history**', (route) => {
+      const url = route.request().url();
+      const isLong = url.includes('range=4mo');
+      const body = isLong
+        ? JSON.stringify({
+            range: '4mo',
+            points: [
+              // One coarse point months ago; nothing within 5 min of now.
+              { ts: now - 30 * 24 * 3600_000, collector: 20, tank_top: 25, tank_bottom: 22, greenhouse: 18, outdoor: 5 },
+            ],
+            events: [],
+          })
+        : JSON.stringify({
+            range: '24h',
+            points: fineGrained,
+            events: [{ ts: now - 3600_000, type: 'mode', id: 'controller', from: 'idle', to: 'solar_charging' }],
+          });
+      route.fulfill({ status: 200, contentType: 'application/json', body });
+    });
+
+    await installMockWs(page, {
+      temps: { collector: 56, tank_top: 35, tank_bottom: 31, greenhouse: 21, outdoor: 11 },
+    });
+    await page.goto('/playground/#status', { waitUntil: 'domcontentloaded' });
+    await expect(page.locator('#connection-dot')).toHaveClass(/connected/, { timeout: 3000 });
+
+    // Trend should populate from the seeded high-resolution history.
+    await expect(page.locator('#tank-temp-status')).toHaveText('RISING', { timeout: 5000 });
+
+    // Click the 4mo pill — triggers a fresh fetchLiveHistory(10368000)
+    // that returns the sparse downsampled response. timeSeriesStore is
+    // reset by loadLiveHistoryIntoStore; trendStore must NOT be.
+    const longResponse = page.waitForResponse((r) => r.url().includes('range=4mo'));
+    await page.locator('button.time-range-slider-step[data-range="10368000"]').click({ force: true });
+    await longResponse;
+
+    // Wait for applyLiveHistory to actually land — the sparse 4mo
+    // payload reduces __getHistoryPointCount well below the seeded 7
+    // (typically to 1–2 after the rerender pipeline appends the cached
+    // live WS frame). Without this guard the assertion below could
+    // fire before the rerender, masking the bug.
+    await page.waitForFunction(() => window.__getHistoryPointCount() <= 2, null, { timeout: 5000 });
+
+    // Trend label must still read RISING — proves trendStore survived
+    // the timeframe change. Before this fix, trendFor read from
+    // timeSeriesStore, so reducing it to 1 point would force the trend
+    // back to STABLE (the null-trend fallback).
+    await expect(page.locator('#tank-temp-status')).toHaveText('RISING');
+  });
+});


### PR DESCRIPTION
## Summary

- The trend label under the gauge (`RISING` / `FALLING` / `STABLE`) and the per-sensor arrows in the Components view used to read from the same `timeSeriesStore` that backs the history graph. Picking a longer graph range (e.g. 4mo) called `timeSeriesStore.reset()` and reloaded the buffer with downsampled history, wiping the high-resolution recent samples the trend needed — so the arrow flatlined or fell back to STABLE until live WS frames refilled the window.
- Splits the trend off into its own short-window `trendStore` in `playground/js/main/state.js` with ~10 minutes of headroom over a 5-minute window. It is fed by live WS frames + the sim loop + an append-only seed from `/api/history`, and only resets on sim reset / phase flip — never on a graph timeframe change.
- `trendFor()` now uses a 5-minute window with a ~1 °C/hr threshold (0.083 °C / 5 min). `addPoint` does sorted insertion so the live boot race (WS frame landing before the history fetch) keeps both the WS sample and the older history points.
- Logs and other UI surfaces were already independent of `graphRange` and need no change.

## Test plan

- [x] New frontend spec `tests/frontend/live-display.spec.js` — "trend label stays RISING after switching the graph range": seeds 7 fine-grained recent points, asserts `RISING`, clicks the 4mo pill (which returns one ancient point), then asserts `RISING` again. Verified to fail on the unfixed code (label drops to `STABLE`) and pass on the fix.
- [x] `npm run lint` (0 errors)
- [x] `npm run knip` (clean)
- [x] `npm run check:file-size -- --strict` (0 over hard cap)
- [x] `npm run check:assets -- --strict` (clean)
- [x] `npm run test:unit` (1002 passed)
- [x] `npx playwright test` — full frontend + e2e suite (268 passed)

https://claude.ai/code/session_01NKhNHNim7v1Zgt9T4L2kAx

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKhNHNim7v1Zgt9T4L2kAx)_