### PR TITLE
playground: surface duty-cycle bar bucket size on history chart

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -287,6 +287,9 @@
           </div>
           <div class="graph-container">
             <canvas id="chart"></canvas>
+            <div class="chart-bucket-badge" id="chart-bucket-badge" aria-live="polite" title="Each bar shows duty-cycle aggregated over this interval">
+              <span id="chart-bucket-badge-val">--</span> / bar
+            </div>
             <div class="graph-inspector" id="graph-inspector">
               <div class="graph-inspector-time" id="inspector-time"></div>
               <div class="graph-inspector-row"><span class="graph-inspector-dot" style="background:#ef5350;"></span><span>Collector</span><span class="graph-inspector-val" id="inspector-coll"></span></div>

--- a/playground/js/main/history-graph.js
+++ b/playground/js/main/history-graph.js
@@ -5,7 +5,7 @@
 // in main.js is observed here on the next call.
 
 import { store } from '../app-state.js';
-import { pickTickStep, formatTick, pickBucketSize } from '../ui.js';
+import { pickTickStep, formatTick, pickBucketSize, formatBucketLabel } from '../ui.js';
 import { SIM_START_HOUR } from '../sim-bootstrap.js';
 import { timeSeriesStore, graphRange, showAllSensors, chartZoom } from './state.js';
 import { coverageInBucket } from './mode-events.js';
@@ -172,6 +172,7 @@ export function drawHistoryGraph() {
   const barAreaH = ph * 0.3;
   const barY0 = pad.top + ph;
   const bucketSec = pickBucketSize(visibleRange);
+  updateBucketBadge(bucketSec);
 
   let hasEmergency = false;
   const firstSampleT = timeSeriesStore.times.length > 0 ? timeSeriesStore.times[0] : tMax;
@@ -332,6 +333,19 @@ function drawTempLine(ctx, timeSeriesStore, tMin, tMax, visibleRange, pad, pw, p
   for (let i = 1; i < pts.length; i++) ctx.lineTo(pts[i].x, pts[i].y);
   ctx.stroke();
   ctx.globalAlpha = 1;
+}
+
+// Refresh the "<bucket> / bar" badge in the chart corner so the user
+// always sees what each duty-cycle bar represents at the current zoom.
+// Tooltip carries the long-form explanation; the visible label is just
+// the short bucket size (e.g. "5 min", "1 day").
+function updateBucketBadge(bucketSec) {
+  const valEl = document.getElementById('chart-bucket-badge-val');
+  if (!valEl) return;
+  const label = formatBucketLabel(bucketSec);
+  if (valEl.textContent !== label) valEl.textContent = label;
+  const badge = document.getElementById('chart-bucket-badge');
+  if (badge) badge.title = 'Each bar shows duty-cycle aggregated over ' + label;
 }
 
 // ── SVG Schematic ──

--- a/playground/js/ui.js
+++ b/playground/js/ui.js
@@ -256,6 +256,26 @@ export function pickBucketSize(rangeSec) {
 }
 
 /**
+ * Human-readable label for a bucket size returned by pickBucketSize.
+ * Example outputs: "5 min", "1 h", "1 day", "7 days". Used by the
+ * "<bucket> / bar" badge on the history chart so users can tell what
+ * each duty-cycle bar represents at the current zoom.
+ *
+ * @param {number} bucketSec  bucket span in seconds
+ * @returns {string}
+ */
+export function formatBucketLabel(bucketSec) {
+  if (bucketSec < HOUR_SECONDS) {
+    return Math.round(bucketSec / 60) + ' min';
+  }
+  if (bucketSec < DAY_SECONDS) {
+    return Math.round(bucketSec / HOUR_SECONDS) + ' h';
+  }
+  const days = Math.round(bucketSec / DAY_SECONDS);
+  return days + (days === 1 ? ' day' : ' days');
+}
+
+/**
  * Format a tick label for an epoch-seconds timestamp. The step determines the
  * granularity: sub-day ⇒ HH:MM, single-to-twoweek ⇒ D.M, month+ ⇒ MMM YY.
  *

--- a/playground/public/style.css
+++ b/playground/public/style.css
@@ -726,6 +726,32 @@ select, input, textarea { max-width: 100%; }
 .graph-crosshair::before { top: 0; }
 .graph-crosshair::after { bottom: 0; }
 
+/* Bucket-resolution badge in the corner of the history chart so users can
+ * tell what each duty-cycle bar represents (e.g. "5 min / bar", "1 day /
+ * bar"). Pinned top-right; non-interactive so it doesn't block the
+ * inspector tooltip / pinch-zoom. */
+.chart-bucket-badge {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  z-index: 2;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: var(--on-surface-variant);
+  background: rgba(12, 14, 18, 0.55);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 999px;
+  padding: 2px 8px;
+  pointer-events: none;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.chart-bucket-badge #chart-bucket-badge-val {
+  color: var(--on-surface);
+}
+
 .graph-inspector {
   display: none;
   position: absolute;

--- a/tests/chart-axis.test.mjs
+++ b/tests/chart-axis.test.mjs
@@ -18,7 +18,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
 
-import { pickTickStep, formatTick, pickBucketSize } from '../playground/js/ui.js';
+import { pickTickStep, formatTick, pickBucketSize, formatBucketLabel } from '../playground/js/ui.js';
 
 const HOUR = 3600;
 const DAY = 86400;
@@ -159,5 +159,52 @@ describe('formatTick — label format per step', () => {
     const a = formatTick(T0, HOUR);
     const b = formatTick(T0 + 2 * HOUR, HOUR);
     assert.notStrictEqual(a, b, 'HH:MM labels must change with time');
+  });
+});
+
+describe('formatBucketLabel — human-readable bucket size', () => {
+  // The badge in the corner of the history chart shows "what each bar means"
+  // so users can tell whether they're looking at 5-minute or 1-day buckets.
+  // Issue #132 — without this, pinch-zooming changes the bar resolution
+  // invisibly.
+
+  it('uses minute units below an hour', () => {
+    assert.strictEqual(formatBucketLabel(60), '1 min');
+    assert.strictEqual(formatBucketLabel(5 * 60), '5 min');
+    assert.strictEqual(formatBucketLabel(15 * 60), '15 min');
+    assert.strictEqual(formatBucketLabel(30 * 60), '30 min');
+  });
+
+  it('uses hour units from one hour up to one day', () => {
+    assert.strictEqual(formatBucketLabel(HOUR), '1 h');
+    assert.strictEqual(formatBucketLabel(3 * HOUR), '3 h');
+    assert.strictEqual(formatBucketLabel(6 * HOUR), '6 h');
+    assert.strictEqual(formatBucketLabel(12 * HOUR), '12 h');
+  });
+
+  it('uses singular "day" for 1 day and plural "days" thereafter', () => {
+    assert.strictEqual(formatBucketLabel(DAY), '1 day');
+    assert.strictEqual(formatBucketLabel(2 * DAY), '2 days');
+    assert.strictEqual(formatBucketLabel(4 * DAY), '4 days');
+    assert.strictEqual(formatBucketLabel(7 * DAY), '7 days');
+    assert.strictEqual(formatBucketLabel(14 * DAY), '14 days');
+    assert.strictEqual(formatBucketLabel(30 * DAY), '30 days');
+  });
+
+  it('round-trips every canonical bucket size from pickBucketSize', () => {
+    // Every value pickBucketSize can return must format to a non-empty
+    // label without throwing.
+    const ranges = [
+      1 * HOUR, 6 * HOUR, 12 * HOUR, 24 * HOUR, 48 * HOUR,
+      3 * DAY, 7 * DAY, 14 * DAY, 30 * DAY, 60 * DAY, 120 * DAY, 365 * DAY,
+    ];
+    for (const r of ranges) {
+      const s = pickBucketSize(r);
+      const label = formatBucketLabel(s);
+      assert.ok(typeof label === 'string' && label.length > 0,
+        `bucket ${s}s (range ${r}s) produced empty label: ${JSON.stringify(label)}`);
+      assert.match(label, /^\d+\s+(min|h|day|days)$/,
+        `bucket ${s}s formatted as "${label}" — expected "<n> min|h|day|days"`);
+    }
   });
 });

--- a/tests/frontend/live-display.spec.js
+++ b/tests/frontend/live-display.spec.js
@@ -202,6 +202,46 @@ test.describe('Status history graph includes collector temperature', () => {
   });
 });
 
+test.describe('Bucket-resolution badge on history chart', () => {
+  // Issue #132 — without this badge the user can't tell whether each duty-
+  // cycle bar represents 5 minutes or a whole day at the current zoom.
+
+  test('renders a "<bucket> / bar" badge inside the graph container', async ({ page }) => {
+    await installMockWs(page);
+    await mockHistoryApi(page);
+    await page.goto('/playground/', { waitUntil: 'domcontentloaded' });
+
+    await expect(page.locator('#connection-dot')).toHaveClass(/connected/, { timeout: 3000 });
+
+    const badge = page.locator('#chart-bucket-badge');
+    await expect(badge).toBeVisible();
+    // Default range is 24 h → pickBucketSize returns 1 hour.
+    await expect(badge).toContainText(/^\s*1 h\s*\/\s*bar\s*$/);
+    // Tooltip carries the long-form explanation so users hovering the badge
+    // get the "Each bar shows duty-cycle aggregated over …" hint.
+    await expect(badge).toHaveAttribute('title', /Each bar shows duty-cycle/);
+  });
+
+  test('updates the bucket label when the time range changes', async ({ page }) => {
+    await installMockWs(page);
+    await mockHistoryApi(page);
+    await page.goto('/playground/', { waitUntil: 'domcontentloaded' });
+
+    await expect(page.locator('#connection-dot')).toHaveClass(/connected/, { timeout: 3000 });
+
+    const badge = page.locator('#chart-bucket-badge');
+    await expect(badge).toContainText(/1 h \/ bar/);
+
+    // Switch to the 1 h range — pickBucketSize(3600) returns 5 minutes.
+    await page.locator('.time-range-slider-step[data-range="3600"]').click();
+    await expect(badge).toContainText(/5 min \/ bar/);
+
+    // And to 6 h — pickBucketSize(21600) returns 30 min.
+    await page.locator('.time-range-slider-step[data-range="21600"]').click();
+    await expect(badge).toContainText(/30 min \/ bar/);
+  });
+});
+
 test.describe('Live mode is the default data source', () => {
   test('app starts in live mode on localhost (simulation is secondary)', async ({ page }) => {
     await installMockWs(page);


### PR DESCRIPTION
## Summary

- Adds a `<bucket> / bar` badge in the corner of the history chart so users can tell what each duty-cycle bar represents at the current zoom — `5 min / bar` at the 1 h range, `1 h / bar` at 24 h, `7 days / bar` at the 4 mo range. Without it, pinch-zooming changes the bar resolution invisibly.
- New pure helper `formatBucketLabel(bucketSec)` in `playground/js/ui.js`; `drawHistoryGraph()` calls `updateBucketBadge()` after `pickBucketSize()` so the label tracks both the time-range slider and pinch-zoom.
- Long-form explanation `Each bar shows duty-cycle aggregated over <bucket>` lives in the badge's `title` attribute (issue's suggested bonus tooltip).

Closes #132.

## Test plan

- [x] Unit: `tests/chart-axis.test.mjs` — minute/hour/day formatting + round-trip across every `pickBucketSize` candidate.
- [x] Frontend: `tests/frontend/live-display.spec.js` — badge renders `1 h / bar` at the default 24 h range and updates to `5 min / bar` and `30 min / bar` when the user clicks 1 h / 6 h on the time-range slider.
- [x] `npm run lint` / `npm run knip` / `npm run check:file-size -- --strict` / `npm run check:assets -- --strict` pass.
- [x] Full unit suite (1007 tests) and Playwright suite (270 tests) green.
- [x] `node scripts/coverage-check.mjs` — frontend coverage gate stays green for the touched files (`ui.js` ≈ 89%, `history-graph.js` unchanged).

https://claude.ai/code/session_01NkhZ4zH5eDCnjSH5bwMNbc

---
_Generated by [Claude Code](https://claude.ai/code/session_01NkhZ4zH5eDCnjSH5bwMNbc)_