### PR TITLE
history graph: per-series legend stats follow visible window

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -257,10 +257,6 @@
         <!-- History Graph (2 cols) + Critical Components (1 col, vertical) -->
         <div class="card bento-span-2 graph-card">
           <div class="graph-header">
-            <div style="display:flex;align-items:center;gap:16px;">
-              <h3 style="margin-bottom:0;">24h History</h3>
-              <span class="graph-peak" id="graph-peak-label">Yesterday's High: --</span>
-            </div>
             <div class="time-range-slider" id="time-range-slider" role="slider" tabindex="0" aria-label="Timeframe"
                  aria-valuemin="0" aria-valuemax="6" aria-valuenow="3" aria-valuetext="24h">
               <div class="time-range-slider-track">
@@ -309,12 +305,12 @@
             <div class="graph-legend-item"><div class="graph-legend-dot" style="background:#ee7d77;"></div>Charging</div>
             <div class="graph-legend-item"><div class="graph-legend-dot" style="background:#e9c349;"></div>Heating</div>
             <div class="graph-legend-item" id="legend-emergency" style="display:none;"><div class="graph-legend-dot" style="background:#ff7043;"></div>Emergency</div>
-            <div class="graph-legend-item"><div class="graph-legend-line" style="background:#ef5350;"></div>Collector</div>
-            <div class="graph-legend-item"><div class="graph-legend-line" style="background:#e9c349;"></div>Tank</div>
-            <div class="graph-legend-item sensor-detail" id="legend-tank-top" style="display:none;"><div class="graph-legend-line" style="background:#ff9f43;"></div>Tank Top</div>
-            <div class="graph-legend-item sensor-detail" id="legend-tank-bottom" style="display:none;"><div class="graph-legend-line" style="background:#b088d6;"></div>Tank Bottom</div>
-            <div class="graph-legend-item"><div class="graph-legend-line" style="background:#69d0c5;"></div>Greenhouse</div>
-            <div class="graph-legend-item"><div class="graph-legend-line" style="background:#42a5f5;"></div>Outside</div>
+            <div class="graph-legend-item"><div class="graph-legend-line" style="background:#ef5350;"></div>Collector<span class="graph-legend-stats" id="legend-stats-collector"></span></div>
+            <div class="graph-legend-item"><div class="graph-legend-line" style="background:#e9c349;"></div>Tank<span class="graph-legend-stats" id="legend-stats-tank"></span></div>
+            <div class="graph-legend-item sensor-detail" id="legend-tank-top" style="display:none;"><div class="graph-legend-line" style="background:#ff9f43;"></div>Tank Top<span class="graph-legend-stats" id="legend-stats-tank-top"></span></div>
+            <div class="graph-legend-item sensor-detail" id="legend-tank-bottom" style="display:none;"><div class="graph-legend-line" style="background:#b088d6;"></div>Tank Bottom<span class="graph-legend-stats" id="legend-stats-tank-bottom"></span></div>
+            <div class="graph-legend-item"><div class="graph-legend-line" style="background:#69d0c5;"></div>Greenhouse<span class="graph-legend-stats" id="legend-stats-greenhouse"></span></div>
+            <div class="graph-legend-item"><div class="graph-legend-line" style="background:#42a5f5;"></div>Outside<span class="graph-legend-stats" id="legend-stats-outdoor"></span></div>
           </div>
         </div>
 

--- a/playground/js/main.js
+++ b/playground/js/main.js
@@ -29,7 +29,7 @@ import { setupChartPinchZoom, resetChartZoom } from './main/chart-pinch-zoom.js'
 import { setupTimeRangeSlider } from './main/time-range-slider.js';
 import {
   updateDisplay, rerenderWithHistoryFallback,
-  setSchematicHandle, getLastFrame, resetYesterdayTracking,
+  setSchematicHandle, getLastFrame,
 } from './main/display-update.js';
 import {
   initConnection, initModeToggle, updateSidebarSubtitle, getLiveSource,
@@ -322,7 +322,6 @@ function resetSim() {
   trendStore.reset();
   transitionLog.length = 0;
   resetChartZoom();
-  resetYesterdayTracking();
   setRunning(false);
   resetSimulationTime();
   updateFABIcon();

--- a/playground/js/main/balance-card.js
+++ b/playground/js/main/balance-card.js
@@ -3,14 +3,11 @@
 // External API:
 //   initBalanceCard({ onRerender })
 //     onRerender: callback invoked after the 48-hour history fetch
-//       resolves, so the rest of the status view can pick up the
-//       freshly-computed yesterdayHigh without waiting for the next
-//       WS frame.
+//       resolves, so the rest of the status view can re-render with
+//       the freshly-loaded points without waiting for the next WS frame.
 //   fetchBalanceHistory() — call when entering live mode.
 //   appendBalanceLivePoint(state, result) — call from each WS frame.
 //   renderBalanceCard() — re-render (also called internally).
-//   getLiveYesterdayHigh() / resetLiveYesterdayHigh() — accessors the
-//     display layer and mode-switch code use for the peak-temp label.
 
 import { store } from '../app-state.js';
 import {
@@ -47,24 +44,12 @@ let balanceLiveLastMode = null;
 let balanceLastAppendTs = 0;
 const BALANCE_APPEND_MIN_INTERVAL_MS = 5 * 60 * 1000;
 
-// Peak tank average across yesterday's local calendar day, computed
-// from the 48h history fetch. null when no qualifying points.
-let liveYesterdayHigh = null;
-
 let _onRerender = () => {};
 
 function isNum(v) { return typeof v === 'number' && !Number.isNaN(v); }
 
 export function initBalanceCard({ onRerender } = {}) {
   if (typeof onRerender === 'function') _onRerender = onRerender;
-}
-
-export function getLiveYesterdayHigh() {
-  return liveYesterdayHigh;
-}
-
-export function resetLiveYesterdayHigh() {
-  liveYesterdayHigh = null;
 }
 
 // Drop the 48h snapshot + live-point buffer + mode tracker. Called
@@ -75,7 +60,6 @@ export function resetBalanceState() {
   balanceLiveEvents = [];
   balanceLiveLastMode = null;
   balanceLastAppendTs = 0;
-  liveYesterdayHigh = null;
 }
 
 // Fetcher: returns Promise<data>. AbortSignal honoured so the sync
@@ -93,11 +77,10 @@ function applyBalanceHistory(data) {
   balanceLivePoints = [];
   balanceLiveEvents = [];
   balanceLiveLastMode = null;
-  liveYesterdayHigh = computeLiveYesterdayHigh(data && data.points);
   renderBalanceCard();
-  // Balance fetch completes independently of the WS state stream,
-  // so re-render so the peak label reflects the freshly-computed
-  // yesterdayHigh instead of waiting for the next state frame.
+  // Balance fetch completes independently of the WS state stream;
+  // re-render so the rest of the view picks up freshly-loaded points
+  // without waiting for the next state frame.
   _onRerender();
 }
 
@@ -118,27 +101,6 @@ export function registerBalanceHistorySource() {
     fetch: (signal) => balanceHistoryFetch(signal),
     applyToStore: (data) => applyBalanceHistory(data),
   });
-}
-
-// Peak tank average ((tank_top + tank_bottom) / 2) across points whose
-// timestamps fall within yesterday's local calendar day. Matches what
-// the graph's Tank line plots and the central tank gauge displays.
-// Returns null when no qualifying points exist.
-function computeLiveYesterdayHigh(points) {
-  if (!Array.isArray(points) || points.length === 0) return null;
-  const now = new Date();
-  const yStart = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 1).getTime();
-  const yEnd = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
-  let peak = null;
-  for (let i = 0; i < points.length; i++) {
-    const p = points[i];
-    if (!p || typeof p.ts !== 'number') continue;
-    if (p.ts < yStart || p.ts >= yEnd) continue;
-    if (!isNum(p.tank_top) || !isNum(p.tank_bottom)) continue;
-    const avg = (p.tank_top + p.tank_bottom) / 2;
-    if (peak === null || avg > peak) peak = avg;
-  }
-  return peak;
 }
 
 export function appendBalanceLivePoint(state, result) {

--- a/playground/js/main/connection.js
+++ b/playground/js/main/connection.js
@@ -19,7 +19,7 @@ import {
 } from './logs.js';
 import {
   fetchBalanceHistory, renderBalanceCard,
-  resetLiveYesterdayHigh, resetBalanceState,
+  resetBalanceState,
   registerBalanceHistorySource,
 } from './balance-card.js';
 import {
@@ -409,8 +409,6 @@ function clearLiveDisplay() {
   const ghTrendResetEl = document.getElementById('tank-stat-greenhouse-trend');
   if (ghTrendResetEl) ghTrendResetEl.innerHTML = '';
   document.getElementById('inactive-modes').innerHTML = '';
-  resetLiveYesterdayHigh();
-  document.getElementById('graph-peak-label').textContent = "Yesterday's High: --";
   const arc = document.getElementById('tank-gauge-arc');
   if (arc) arc.setAttribute('stroke-dashoffset', '628');
   // Clear component statuses

--- a/playground/js/main/display-update.js
+++ b/playground/js/main/display-update.js
@@ -7,7 +7,7 @@ import { tankStoredEnergyKwh } from '../physics.js';
 import { timeSeriesStore, trendStore, MODE_INFO, running, setLastLiveFrame } from './state.js';
 import { detectLiveTransition, renderLogsList } from './logs.js';
 import { drawHistoryGraph, toSchematicState } from './history-graph.js';
-import { appendBalanceLivePoint, getLiveYesterdayHigh } from './balance-card.js';
+import { appendBalanceLivePoint } from './balance-card.js';
 import { modeAt } from './mode-events.js';
 import { formatHeldLines } from './logs-clipboard.js';
 
@@ -99,10 +99,6 @@ let lastResult = null;
 // live mode).
 let liveFrameSeen = false;
 
-let yesterdayHigh = 0;
-let confirmedYesterdayHigh = 0;
-let lastDay = 0;
-
 export function setSchematicHandle(h) { schematicHandle = h; }
 export function getLastFrame() { return { state: lastState, result: lastResult }; }
 export function setLiveFrameSeen(v) { liveFrameSeen = v; }
@@ -110,11 +106,6 @@ export function setLiveFrameSeen(v) { liveFrameSeen = v; }
 // onResyncStart hook actually clears the flag, which is the seam
 // that fixes the Android wrong-direction-arrow bug.
 window.__getLiveFrameSeen = function () { return liveFrameSeen; };
-export function resetYesterdayTracking() {
-  yesterdayHigh = 0;
-  confirmedYesterdayHigh = 0;
-  lastDay = 0;
-}
 
 export function updateDisplay(state, result) {
   const mode = result.mode;
@@ -232,18 +223,6 @@ export function updateDisplay(state, result) {
   const ghTrendEl = document.getElementById('tank-stat-greenhouse-trend');
   if (ghTrendEl) ghTrendEl.innerHTML = renderTrendIcon(trendFor('t_greenhouse'));
 
-  // Track yesterday's high (peak from previous 24h simulated day)
-  // using the tank average so it stays consistent with the gauge.
-  if (isNum(tankAvg)) {
-    if (tankAvg > yesterdayHigh) yesterdayHigh = tankAvg;
-    const simDay = Math.floor(state.simTime / 86400);
-    if (simDay > lastDay) {
-      confirmedYesterdayHigh = yesterdayHigh;
-      yesterdayHigh = tankAvg;
-      lastDay = simDay;
-    }
-  }
-
   // Gauge arc: 0°C = empty, 100°C = full circle (628 circumference)
   const arc = document.getElementById('tank-gauge-arc');
   if (arc) {
@@ -275,13 +254,6 @@ export function updateDisplay(state, result) {
   else if (tankAvg > 50) msgEl.textContent = 'Tank is well charged.';
   else if (tankAvg > 25) msgEl.textContent = 'Moderate thermal storage.';
   else msgEl.textContent = 'Tank is cold — waiting for solar gain.';
-
-  // Graph yesterday's high label. Simulation tracks a per-sim-day
-  // peak via confirmedYesterdayHigh; live mode derives it from the
-  // 48h history fetch since state.simTime does not tick.
-  const peakVal = store.get('phase') === 'live' ? getLiveYesterdayHigh() : confirmedYesterdayHigh;
-  document.getElementById('graph-peak-label').textContent =
-    isNum(peakVal) && peakVal > 0 ? `Yesterday's High: ${peakVal.toFixed(0)}°C` : 'Yesterday\'s High: --';
 
   // Critical components
   updateComponent('comp-pump', result.actuators.pump, 'ACTIVE', 'OFF');

--- a/playground/js/main/history-graph.js
+++ b/playground/js/main/history-graph.js
@@ -162,7 +162,10 @@ export function drawHistoryGraph() {
     ctx.fillText(label, x, dh - 4);
   }
 
-  if (timeSeriesStore.times.length < 2) return;
+  if (timeSeriesStore.times.length < 2) {
+    updateLegendStats(tMin, tMax);
+    return;
+  }
 
   // ── Duty cycle bars ──
   // Bucket granularity scales with the visible range — see pickBucketSize
@@ -214,8 +217,7 @@ export function drawHistoryGraph() {
   document.getElementById('legend-emergency').style.display = hasEmergency ? 'flex' : 'none';
 
   // ── Temperature line (gold, matching Stitch design) ──
-  // Tank line plots the top/bottom average — matches the central gauge
-  // and keeps "Yesterday's High" consistent with the visible peak.
+  // Tank line plots the top/bottom average — matches the central gauge.
   // collectSeriesPts carries a pre-window sample forward as an
   // interpolated point at tMin so the line meets the chart's left edge
   // even when a real sensor-reading gap straddles the boundary.
@@ -280,6 +282,75 @@ export function drawHistoryGraph() {
 
   // ── Outside line (blue) ──
   drawTempLine(ctx, timeSeriesStore, tMin, tMax, visibleRange, pad, pw, ph, yMin, yMax, 't_outdoor', '#42a5f5', 1);
+
+  updateLegendStats(tMin, tMax);
+}
+
+// Pure: walk the time-series store once and pull min / max / latest for
+// each requested key inside [tMin, tMax]. Returns null entries for series
+// with no in-window samples so the caller can blank the label cleanly.
+export function computeSeriesStats(store, tMin, tMax, keys) {
+  const acc = {};
+  for (let k = 0; k < keys.length; k++) {
+    acc[keys[k].id] = { min: Infinity, max: -Infinity, latest: null, latestT: -Infinity };
+  }
+  for (let i = 0; i < store.times.length; i++) {
+    const t = store.times[i];
+    if (t < tMin || t > tMax) continue;
+    const row = store.values[i];
+    for (let k = 0; k < keys.length; k++) {
+      const def = keys[k];
+      const v = typeof def.extract === 'function' ? def.extract(row) : row[def.id];
+      if (!isNum(v)) continue;
+      const a = acc[def.id];
+      if (v < a.min) a.min = v;
+      if (v > a.max) a.max = v;
+      if (t >= a.latestT) { a.latest = v; a.latestT = t; }
+    }
+  }
+  const out = {};
+  for (let k = 0; k < keys.length; k++) {
+    const a = acc[keys[k].id];
+    out[keys[k].id] = a.latest === null
+      ? null
+      : { min: a.min, max: a.max, latest: a.latest };
+  }
+  return out;
+}
+
+function fmtTempStat(v) { return Math.round(v).toString(); }
+
+function renderLegendStats(el, stats) {
+  if (!el) return;
+  if (!stats) { el.textContent = ''; return; }
+  // Latest value (with °) + a muted range span "(min–max°)". Single
+  // unit at the tail of the range matches the issue's design ("15.8
+  // → 68.2 °C") and keeps the legend line short on narrow viewports.
+  el.textContent = fmtTempStat(stats.latest) + '°';
+  const range = document.createElement('span');
+  range.className = 'graph-legend-stats-range';
+  range.textContent = '(' + fmtTempStat(stats.min) + '–' + fmtTempStat(stats.max) + '°)';
+  el.appendChild(range);
+}
+
+// Per-series legend keys. tankAvgOf collapses top+bottom for the main
+// Tank line; the individual sub-sensors are only shown when "All sensors"
+// is on, but their stats still update so toggling reveals fresh numbers.
+const LEGEND_SERIES = [
+  { id: 't_collector',  domId: 'legend-stats-collector' },
+  { id: 'tank',         domId: 'legend-stats-tank',         extract: tankAvgOf },
+  { id: 't_tank_top',   domId: 'legend-stats-tank-top' },
+  { id: 't_tank_bottom',domId: 'legend-stats-tank-bottom' },
+  { id: 't_greenhouse', domId: 'legend-stats-greenhouse' },
+  { id: 't_outdoor',    domId: 'legend-stats-outdoor' },
+];
+
+function updateLegendStats(tMin, tMax) {
+  const stats = computeSeriesStats(timeSeriesStore, tMin, tMax, LEGEND_SERIES);
+  for (let i = 0; i < LEGEND_SERIES.length; i++) {
+    const def = LEGEND_SERIES[i];
+    renderLegendStats(document.getElementById(def.domId), stats[def.id]);
+  }
 }
 
 // Collect visible plot points for a single series, carrying a leading-edge

--- a/playground/public/style.css
+++ b/playground/public/style.css
@@ -635,12 +635,6 @@ select, input, textarea { max-width: 100%; }
   box-shadow: 0 0 0 2px var(--primary, #69d0c5);
 }
 
-.graph-peak {
-  font-size: 12px;
-  color: var(--secondary);
-  font-weight: 600;
-}
-
 .graph-option-toggle {
   display: flex;
   align-items: center;
@@ -698,6 +692,26 @@ select, input, textarea { max-width: 100%; }
   height: 2px;
   background: var(--on-surface);
   border-radius: 1px;
+}
+
+/* Per-series stats follow each temperature label: "42° (39–62°)" where
+ * the leading number is the latest in-window sample and the parenthesised
+ * pair is the visible-range min/max. Updated on every drawHistoryGraph
+ * call so pan/zoom keeps the numbers in sync with the visible window. */
+.graph-legend-stats {
+  margin-left: 4px;
+  color: var(--on-surface);
+  font-weight: 700;
+  text-transform: none;
+  letter-spacing: 0;
+}
+
+.graph-legend-stats:empty { display: none; }
+
+.graph-legend-stats .graph-legend-stats-range {
+  color: var(--on-surface-variant);
+  font-weight: 500;
+  margin-left: 4px;
 }
 
 /* ── Graph Inspector ── */

--- a/tests/frontend/live-display.spec.js
+++ b/tests/frontend/live-display.spec.js
@@ -255,46 +255,68 @@ test.describe('Live mode is the default data source', () => {
   });
 });
 
-test.describe("Yesterday's High label in live mode", () => {
-  test("shows peak tank-average from yesterday's history points (matching the graph)", async ({ page }) => {
-    const yAt = (h) => {
-      const d = new Date();
-      d.setDate(d.getDate() - 1);
-      d.setHours(h, 0, 0, 0);
-      return d.getTime();
-    };
+test.describe('Per-series legend stats (latest + min/max for the visible window)', () => {
+  // Issue #133 — replaces the old "Yesterday's High" header with
+  // latest + visible-range min/max labels per temperature series, so
+  // the chart line reads as magnitude as well as shape. Numbers must
+  // follow pan/zoom: switch to a narrower range and the min/max should
+  // collapse to the samples actually visible.
+  test('renders latest + visible-range min/max next to each temperature series', async ({ page }) => {
     const now = Date.now();
     const points = [
-      // Yesterday's readings — peak tank avg = (80 + 60) / 2 = 70°C at 15:00
-      { ts: yAt(9),  collector: 40.0, tank_top: 50.0, tank_bottom: 40.0, greenhouse: 18.0, outdoor: 10.0 },
-      { ts: yAt(12), collector: 55.0, tank_top: 70.0, tank_bottom: 50.0, greenhouse: 22.0, outdoor: 12.0 },
-      { ts: yAt(15), collector: 62.0, tank_top: 80.0, tank_bottom: 60.0, greenhouse: 24.0, outdoor: 14.0 },
-      // Today's readings — must not count toward yesterday's high
-      { ts: now - 3600_000, collector: 50.0, tank_top: 90.0, tank_bottom: 70.0, greenhouse: 20.0, outdoor: 11.0 },
+      // Three samples within the last hour so even the 1h range covers them.
+      { ts: now - 1800_000, collector: 30.0, tank_top: 40.0, tank_bottom: 30.0, greenhouse: 18.0, outdoor: 9.0 },
+      { ts: now - 900_000,  collector: 55.0, tank_top: 50.0, tank_bottom: 36.0, greenhouse: 20.0, outdoor: 10.5 },
+      { ts: now - 60_000,   collector: 62.0, tank_top: 56.0, tank_bottom: 40.0, greenhouse: 22.0, outdoor: 11.0 },
     ];
-    await installMockWs(page);
+    // Pin the live WS frame to the same values as the most recent history
+    // point so the latest sample appended by recordLiveHistoryPoint doesn't
+    // shift the min/max under the test.
+    await installMockWs(page, {
+      temps: { collector: 62.0, tank_top: 56.0, tank_bottom: 40.0, greenhouse: 22.0, outdoor: 11.0 },
+    });
     await mockHistoryApi(page, points);
     await page.goto('/playground/', { waitUntil: 'domcontentloaded' });
 
     await expect(page.locator('#connection-dot')).toHaveClass(/connected/, { timeout: 3000 });
 
-    await expect(page.locator('#graph-peak-label')).toHaveText(/Yesterday's High: 70°C/, { timeout: 5000 });
+    // Latest is the value at the rightmost in-window sample; min/max
+    // are the in-window extrema. Collector: latest 62°, min 30°, max 62°.
+    const collector = page.locator('#legend-stats-collector');
+    await expect(collector).toContainText('62°', { timeout: 5000 });
+    await expect(collector).toContainText('(30–62°)');
+
+    // Tank line plots (top + bottom) / 2: 35, 43, 48 → latest 48°, range 35°–48°.
+    const tank = page.locator('#legend-stats-tank');
+    await expect(tank).toContainText('48°');
+    await expect(tank).toContainText('(35–48°)');
   });
 
-  test("stays at -- when history has no points from yesterday", async ({ page }) => {
+  test('stats follow the visible window when the timeframe changes', async ({ page }) => {
     const now = Date.now();
-    // All points are from today (within the last 2 hours).
+    // Old sample (3 h ago) carries the historical max — it must drop
+    // out of the min/max once the user switches to the 1 h range.
     const points = [
-      { ts: now - 7200_000, collector: 50.0, tank_top: 60.0, tank_bottom: 40.0, greenhouse: 20.0, outdoor: 11.0 },
-      { ts: now - 1800_000, collector: 55.0, tank_top: 65.0, tank_bottom: 45.0, greenhouse: 21.0, outdoor: 12.0 },
+      { ts: now - 3 * 3600_000, collector: 90.0, tank_top: 80.0, tank_bottom: 60.0, greenhouse: 25.0, outdoor: 14.0 },
+      { ts: now - 1800_000,     collector: 30.0, tank_top: 40.0, tank_bottom: 30.0, greenhouse: 18.0, outdoor: 9.0 },
+      { ts: now - 60_000,       collector: 40.0, tank_top: 44.0, tank_bottom: 32.0, greenhouse: 19.0, outdoor: 10.0 },
     ];
-    await installMockWs(page);
+    await installMockWs(page, {
+      temps: { collector: 40.0, tank_top: 44.0, tank_bottom: 32.0, greenhouse: 19.0, outdoor: 10.0 },
+    });
     await mockHistoryApi(page, points);
     await page.goto('/playground/', { waitUntil: 'domcontentloaded' });
 
     await expect(page.locator('#connection-dot')).toHaveClass(/connected/, { timeout: 3000 });
 
-    await expect(page.locator('#graph-peak-label')).toHaveText("Yesterday's High: --");
+    // Default 24 h range — old 90° sample is in window, so collector max is 90°.
+    const collector = page.locator('#legend-stats-collector');
+    await expect(collector).toContainText('(30–90°)', { timeout: 5000 });
+
+    // Switch to the 1 h range. The 3 h-ago sample drops out, so collector
+    // max collapses to the most recent two: 30°–40°.
+    await page.locator('.time-range-slider-step[data-range="3600"]').click();
+    await expect(collector).toContainText('(30–40°)');
   });
 });
 

--- a/tests/series-stats.test.mjs
+++ b/tests/series-stats.test.mjs
@@ -1,0 +1,80 @@
+/**
+ * Unit tests for computeSeriesStats — the pure helper that backs the
+ * per-series legend labels (latest + min/max for the visible window,
+ * issue #133). It walks the timeSeriesStore once and pulls the
+ * latest in-window sample plus min/max for each requested key, so the
+ * legend line "Collector 62° (30–62°)" updates in step with pan/zoom.
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { computeSeriesStats, tankAvgOf } from '../playground/js/main/history-graph.js';
+
+const baseKeys = [
+  { id: 't_collector' },
+  { id: 'tank', extract: tankAvgOf },
+];
+
+function makeStore(rows) {
+  return {
+    times: rows.map(r => r.t),
+    values: rows.map(r => r.v),
+  };
+}
+
+describe('computeSeriesStats', () => {
+  it('returns min / max / latest for keys with samples in the window', () => {
+    const store = makeStore([
+      { t: 100, v: { t_collector: 30, t_tank_top: 40, t_tank_bottom: 30 } },
+      { t: 200, v: { t_collector: 55, t_tank_top: 50, t_tank_bottom: 36 } },
+      { t: 300, v: { t_collector: 62, t_tank_top: 56, t_tank_bottom: 40 } },
+    ]);
+    const stats = computeSeriesStats(store, 0, 1000, baseKeys);
+    assert.deepEqual(stats.t_collector, { min: 30, max: 62, latest: 62 });
+    // Tank avg: 35, 43, 48 → latest 48, range 35–48.
+    assert.deepEqual(stats.tank, { min: 35, max: 48, latest: 48 });
+  });
+
+  it('respects the [tMin, tMax] window — out-of-window samples are skipped', () => {
+    const store = makeStore([
+      { t: 100, v: { t_collector: 90 } }, // out
+      { t: 250, v: { t_collector: 30 } }, // in
+      { t: 350, v: { t_collector: 40 } }, // in
+      { t: 500, v: { t_collector: 99 } }, // out
+    ]);
+    const stats = computeSeriesStats(store, 200, 400, [{ id: 't_collector' }]);
+    assert.deepEqual(stats.t_collector, { min: 30, max: 40, latest: 40 });
+  });
+
+  it('returns null for series with no in-window samples', () => {
+    const store = makeStore([
+      { t: 100, v: { t_collector: 30 } },
+    ]);
+    const stats = computeSeriesStats(store, 1000, 2000, [{ id: 't_collector' }, { id: 'tank', extract: tankAvgOf }]);
+    assert.equal(stats.t_collector, null);
+    assert.equal(stats.tank, null);
+  });
+
+  it('skips non-numeric / null values without poisoning min/max', () => {
+    const store = makeStore([
+      { t: 100, v: { t_collector: null,    t_tank_top: 50, t_tank_bottom: 40 } },
+      { t: 200, v: { t_collector: 30,      t_tank_top: 50, t_tank_bottom: 40 } },
+      { t: 300, v: { t_collector: NaN,     t_tank_top: null, t_tank_bottom: 40 } },
+      { t: 400, v: { t_collector: 'oops',  t_tank_top: 60, t_tank_bottom: 50 } },
+    ]);
+    const stats = computeSeriesStats(store, 0, 1000, baseKeys);
+    // Only the t=200 sample contributes a numeric collector reading.
+    assert.deepEqual(stats.t_collector, { min: 30, max: 30, latest: 30 });
+    // Tank avg only valid at t=200 (45) and t=400 (55); t=300 has a null half.
+    assert.deepEqual(stats.tank, { min: 45, max: 55, latest: 55 });
+  });
+
+  it('latest tracks the most recent in-window timestamp, not the largest value', () => {
+    const store = makeStore([
+      { t: 100, v: { t_collector: 80 } }, // largest, but earliest
+      { t: 200, v: { t_collector: 50 } },
+      { t: 300, v: { t_collector: 20 } }, // most recent
+    ]);
+    const stats = computeSeriesStats(store, 0, 1000, [{ id: 't_collector' }]);
+    assert.deepEqual(stats.t_collector, { min: 20, max: 80, latest: 20 });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #133.

- Drops the static "24h History" heading + "Yesterday's High" badge from the chart header — the timeframe slider already shows what's visible, and the badge silently lied at any range other than 24 h.
- Each temperature series in the legend now carries a latest-value label and a min/max-for-the-visible-window range, e.g. `Collector 62° (30–62°)`. Computed once per `drawHistoryGraph` call so pan, pinch-zoom, and the timeframe slider all keep the numbers in step with what's actually drawn.
- Removed the entire yesterday-high pipeline (`yesterdayHigh` / `confirmedYesterdayHigh` / `resetYesterdayTracking` / `liveYesterdayHigh` / `getLiveYesterdayHigh` / `resetLiveYesterdayHigh` / `computeLiveYesterdayHigh`) — `display-update.js`, `balance-card.js`, `connection.js`, `main.js`.

The new pure helper `computeSeriesStats(store, tMin, tMax, keys)` is exported from `history-graph.js` and unit-tested directly; the in-window walk is O(n) over `timeSeriesStore` and runs alongside the existing draw loop.

## Test plan

- [x] `npm run lint` — 0 errors
- [x] `npm run knip` — clean (only the pre-existing `shelly/**` config hint)
- [x] `npm run check:file-size -- --strict` — 0 over hard cap
- [x] `npm run check:assets -- --strict` — all 14 assets referenced
- [x] `npm run test:unit` — 1043 tests pass (incl. new `tests/series-stats.test.mjs`, 5 cases)
- [x] `npx playwright test` — 270 tests pass (incl. two new specs replacing the old "Yesterday's High" coverage: latest+range render, and pan/zoom collapses the min/max to the visible samples)
- [ ] Smoke-check on the preview deploy: chart legend renders the new stats, slider 1h ↔ 24h ↔ 14d updates them live, pinch-zoom on the canvas (mobile) does the same.

---
_Generated by [Claude Code](https://claude.ai/code/session_017geq8pm3kA6kPmHxznes9N)_