### PR TITLE
control: drop noisy min_duration held entry, surface live evaluator reason

### DIFF
--- a/playground/js/data-source.js
+++ b/playground/js/data-source.js
@@ -224,6 +224,12 @@ export class LiveSource extends DataSource {
       // describing wanted-but-blocked decisions. Consumed by the
       // Status view's "held by …" banner and the System Logs export.
       held: data.held || null,
+      // Live per-tick evaluator reason (greenhouse_active, solar_stall,
+      // …). Distinct from `reason` above which is the LAST TRANSITION'S
+      // reason — eval_reason refreshes every 30 s tick. Consumed by
+      // the mode-card status line so the operator sees "Greenhouse
+      // still cold" instead of the generic "System Active".
+      eval_reason: data.eval_reason || null,
     };
 
     this._emitUpdate(state, result);

--- a/playground/js/main/display-update.js
+++ b/playground/js/main/display-update.js
@@ -10,6 +10,7 @@ import { drawHistoryGraph, toSchematicState } from './history-graph.js';
 import { appendBalanceLivePoint } from './balance-card.js';
 import { modeAt } from './mode-events.js';
 import { formatHeldLines } from './logs-clipboard.js';
+import { formatReasonLabel } from './time-format.js';
 
 // Live data may have null sensors when a role is unassigned — show "—".
 const TEMP_PLACEHOLDER = '—';
@@ -150,7 +151,23 @@ export function updateDisplay(state, result) {
     pulseSpan.className = 'pulse';
     statusEl.insertBefore(pulseSpan, statusEl.firstChild);
   }
-  const statusText = document.createTextNode(running ? ' System Active' : ' System Ready');
+  // Status line shows the live evaluator reason ("Greenhouse still
+  // cold", "Tank still gaining heat", …) when one is published, so the
+  // operator gets a meaningful one-line "why is the system in this
+  // mode?" answer instead of the generic "System Active". Falls back
+  // to the generic when eval_reason is missing (sim mode, pre-first-
+  // tick, legacy snapshots). The reason label is title-cased so it
+  // reads as a standalone sentence next to the mode title.
+  let liveReasonText = '';
+  if (result && typeof result.eval_reason === 'string' && result.eval_reason) {
+    const label = formatReasonLabel(result.eval_reason);
+    if (label && label !== result.eval_reason) {
+      liveReasonText = ' ' + label.charAt(0).toUpperCase() + label.slice(1);
+    }
+  }
+  const statusText = document.createTextNode(
+    liveReasonText || (running ? ' System Active' : ' System Ready')
+  );
   statusEl.appendChild(statusText);
 
   // Exit override link — admin only, visible when override is active

--- a/playground/js/main/logs-clipboard.js
+++ b/playground/js/main/logs-clipboard.js
@@ -329,6 +329,15 @@ function appendControllerState(lines) {
 
   const flags = (result && result.flags) || {};
   lines.push('Mode:               ' + ((result && result.mode) || 'idle'));
+  // Live evaluator reason — refreshed every tick, distinct from the
+  // transition-tied reason on transition log rows. Surfaces the same
+  // sentence the mode-card status line shows ("Greenhouse still cold")
+  // so an exported log answers "why is the system in this mode right
+  // now?" without forcing the reader to skim the transition log for
+  // the entry reason.
+  if (result && typeof result.eval_reason === 'string' && result.eval_reason) {
+    lines.push('Reason:             ' + formatReasonLabel(result.eval_reason));
+  }
   lines.push('Collectors drained: ' + (flags.collectors_drained ? 'yes' : 'no'));
   lines.push('Emergency heating:  ' + (flags.emergency_heating_active ? 'on' : 'off'));
   lines.push('Fan cooling:        ' + (flags.greenhouse_fan_cooling_active ? 'on' : 'off'));

--- a/shelly/control-logic.js
+++ b/shelly/control-logic.js
@@ -662,24 +662,27 @@ function evaluate(state, config, deviceConfig) {
   // seconds before allowing automation to switch away. Runs AFTER
   // pump-mode selection so we know what the natural choice would have
   // been — that gets stashed on held.pumpMode as { wanted, wantedReason }
-  // so the playground can render "change to Idle pending — tank stopped
+  // so the playground can render "Change to Idle pending — tank stopped
   // gaining heat. Hold 3m remaining."
+  //
+  // The hold is only surfaced (and the reason swapped to "min_duration")
+  // when the natural pick differs from the current mode. If the natural
+  // pick is the same mode we're already in, the hold is innocuous —
+  // nothing is being held back, and surfacing "Pump mode held — 5-min
+  // minimum mode duration" would be pure noise. In that case keep the
+  // natural reason ("greenhouse_active" / "solar_active" / …) so the
+  // mode card status can read "Greenhouse still cold" instead.
+  //
   // Skipped for IDLE (no transition cost to escape) and EMERGENCY_HEATING
   // (heater overlay is purely hysteresis-driven, no entry/exit ceremony).
   // Drain modes (ACTIVE_DRAIN, freeze_drain, overheat_drain) early-return
   // above this block so they bypass the hold.
   if (state.currentMode !== MODES.IDLE &&
       state.currentMode !== MODES.EMERGENCY_HEATING &&
-      elapsed < getMinDuration(state, cfg)) {
-    if (pumpMode !== state.currentMode) {
-      held.pumpMode = heldEntry("min_duration", pumpMode, reason,
-        state.modeEnteredAt + getMinDuration(state, cfg));
-    } else {
-      // Natural choice is to stay put — still surface the hold so the
-      // operator sees the countdown, but no "would change to" framing.
-      held.pumpMode = heldEntry("min_duration", null, null,
-        state.modeEnteredAt + getMinDuration(state, cfg));
-    }
+      elapsed < getMinDuration(state, cfg) &&
+      pumpMode !== state.currentMode) {
+    held.pumpMode = heldEntry("min_duration", pumpMode, reason,
+      state.modeEnteredAt + getMinDuration(state, cfg));
     pumpMode = state.currentMode;
     reason = "min_duration";
   }
@@ -1043,6 +1046,14 @@ function buildSnapshotFromState(st, dc, now) {
     // drain_complete, failed. Written to state_events.reason on mode
     // change. See REASON_LABELS in playground/js/main.js for UI mapping.
     reason: st.lastTransitionReason || null,
+    // Live per-tick evaluator reason — refreshed every control loop
+    // regardless of mode transitions. Distinct from `reason` above
+    // (which is the transition-tied reason consumed by mqtt-bridge to
+    // populate state_events.reason on mode changes). The playground's
+    // mode-card status reads this so the line under the mode title
+    // shows "Greenhouse still cold" instead of the generic "System
+    // Active". Null on first boot before evaluate() has run a tick.
+    eval_reason: st.last_eval_reason || null,
     // Live diagnostic — see attachHeld() / pruneHeld() in evaluate().
     // Populated from state.last_held, refreshed every control tick.
     // Null when no guard is suppressing a wanted action this tick.

--- a/shelly/control.js
+++ b/shelly/control.js
@@ -94,6 +94,14 @@ var state = {
   // live. Per-tick (not persisted across boots) and refreshed every
   // control loop, regardless of whether the tick ended in a transition.
   last_held: null,
+  // Latest result.reason from evaluate(), refreshed every tick. Sibling
+  // of last_held, distinct from lastTransitionReason (which only
+  // updates at mode changes). Published as snapshot.eval_reason so the
+  // playground mode-card status text can read "Greenhouse still cold"
+  // instead of the generic "System Active". Decoupled from the
+  // transition-tied snapshot.reason field so the System Logs row
+  // stays semantically "this is why we transitioned to mode X".
+  last_eval_reason: null,
   // Solar-charging tank-rise tracking (mirrors evaluate() flags). Tank
   // top temperature is tracked so we can keep pumping until the tank
   // stops accepting heat (no rise for 5 min, or 2°C drop from peak).
@@ -1054,6 +1062,11 @@ function controlLoop() {
       // buildSnapshotFromState so the playground can render
       // "held by X" without stale data.
       state.last_held = result.held || null;
+      // Same lifecycle for the live evaluator reason — refreshed every
+      // tick so the playground mode-card status text reflects the
+      // current decision ("greenhouse still cold") rather than the
+      // entry reason carried by snapshot.reason.
+      state.last_eval_reason = result.reason || null;
 
       if (result.nextMode !== state.mode) {
         if (result.safetyOverride) {

--- a/tests/control-logic-held.test.js
+++ b/tests/control-logic-held.test.js
@@ -141,12 +141,17 @@ describe('held field — pump mode', () => {
     assert.strictEqual(result.held.pumpMode.wantedReason, 'solar_stall');
   });
 
-  it('omits wanted/wantedReason on min_duration when current matches the natural pick', () => {
+  it('drops the min_duration held entry entirely when current matches the natural pick', () => {
     // GREENHOUSE_HEATING entered 60 s ago, greenhouse still cold + tank
     // still has delta — the natural pump mode is the same GH we're
-    // already in, so technically no transition is "pending". Still
-    // surface min_duration so the operator sees the hold, but skip the
-    // "would change to X" framing.
+    // already in, so the 5-min hold is innocuous: nothing is being
+    // "held back". Don't surface a held entry at all (it would just
+    // be noise saying "Pump mode held — 5-min minimum mode duration"
+    // when in fact the system is doing exactly what the evaluator
+    // wants). The result.reason must reflect the natural pick
+    // (greenhouse_active) so the live banner / mode card status can
+    // show "Greenhouse still cold" instead of "holding minimum run
+    // time".
     const result = evaluate(makeState({
       temps: { collector: 5, tank_top: 40, tank_bottom: 30, greenhouse: 8, outdoor: 5 },
       currentMode: MODES.GREENHOUSE_HEATING,
@@ -155,12 +160,10 @@ describe('held field — pump mode', () => {
       collectorsDrained: true,
     }), null, allEnabled);
     assert.strictEqual(result.nextMode, MODES.GREENHOUSE_HEATING);
-    assert.strictEqual(result.reason, 'min_duration');
-    assert.ok(result.held && result.held.pumpMode);
-    assert.strictEqual(result.held.pumpMode.blockedBy, 'min_duration');
-    assert.strictEqual(result.held.pumpMode.wanted, undefined,
-      'no wanted entry — would have stayed put anyway');
-    assert.strictEqual(result.held.pumpMode.wantedReason, undefined);
+    assert.strictEqual(result.reason, 'greenhouse_active',
+      'reason mirrors the natural pick — not the (innocuous) hold');
+    assert.ok(!result.held || !result.held.pumpMode,
+      'no pumpMode held entry when wanted == current');
   });
 });
 

--- a/tests/control-logic-overlay-independence.test.js
+++ b/tests/control-logic-overlay-independence.test.js
@@ -117,6 +117,14 @@ describe('overlays are independent of pump mode (drain + min-duration)', () => {
     // flag was false at entry (greenhouse was 11 °C). Now greenhouse
     // crashes to 4 °C mid-hold. The hold MUST NOT freeze the
     // hysteresis — heater must fire on this tick, not wait 3 min.
+    //
+    // Natural pump-mode pick is GREENHOUSE_HEATING (greenhouse still
+    // cold, tank still has delta) — same as currentMode — so the
+    // min-duration override is innocuous and the reason stays
+    // "greenhouse_active". The hold is still in effect (would block a
+    // mode swap if conditions tried to push us elsewhere), but
+    // intentionally not surfaced as held since nothing is being
+    // overridden.
     const result = evaluate(makeState({
       temps: { collector: 5, tank_top: 30, tank_bottom: 25, greenhouse: 4, outdoor: 5 },
       currentMode: MODES.GREENHOUSE_HEATING,
@@ -125,8 +133,9 @@ describe('overlays are independent of pump mode (drain + min-duration)', () => {
       emergencyHeatingActive: false,
       collectorsDrained: true,
     }), null);
-    assert.strictEqual(result.reason, 'min_duration',
-      'Still inside the hold');
+    assert.strictEqual(result.nextMode, MODES.GREENHOUSE_HEATING);
+    assert.strictEqual(result.reason, 'greenhouse_active',
+      'natural reason wins when wanted == current — hold is innocuous');
     assert.strictEqual(result.flags.emergencyHeatingActive, true,
       'Hysteresis must update during the hold — greenhouse is critically cold');
     assert.strictEqual(result.actuators.space_heater, true,
@@ -145,7 +154,9 @@ describe('overlays are independent of pump mode (drain + min-duration)', () => {
       emergencyHeatingActive: true,
       collectorsDrained: true,
     }), null, { ce: true, ea: 31, wb: { EH: 9999999999 } });
-    assert.strictEqual(result.reason, 'min_duration');
+    assert.strictEqual(result.nextMode, MODES.GREENHOUSE_HEATING);
+    assert.strictEqual(result.reason, 'greenhouse_active',
+      'natural reason wins — see sibling min-duration test');
     assert.strictEqual(result.flags.emergencyHeatingActive, false,
       'wb.EH ban clears the flag even mid-hold');
     assert.strictEqual(result.actuators.space_heater, false);


### PR DESCRIPTION
## Summary

Field feedback: when the system has just entered Greenhouse Heating because the greenhouse is still cold, the playground was showing this:

```
Current Mode
Heating Greenhouse
System Ready

Held this tick
Pump mode held — 5-min minimum mode duration. 3m remaining.
```

That's two unhelpful lines. The system isn't being "held back" — the natural pump-mode pick is the same Greenhouse Heating it's already in, so the 5-min hold is innocuous. And the status row (`System Ready`) is generic boilerplate that doesn't say *why* the mode is active.

After this PR, the same scenario shows:

```
Current Mode
Heating Greenhouse
Greenhouse still cold
```

Two changes wired together:

1. **Drop the redundant min_duration held entry when wanted == current.** The hold is only surfaced (and the result reason swapped to `min_duration`) when the natural pick *differs* from the current mode and the hold is genuinely overriding. When wanted == current, the hold is innocuous → no held entry, no reason override, the natural reason (`greenhouse_active` / `solar_active` / …) flows through.
2. **Publish a per-tick `eval_reason` on the state snapshot** (sibling of `last_held`, distinct from the transition-tied `reason` field). The mode-card status row reads it as "Greenhouse still cold" / "Tank still gaining heat" instead of "System Active". The System Logs export gains a "Reason: …" line in the controller-state block.

The held banner is unchanged for the cases that actually matter — refill cooldown, freeze guard, wb-ban, and min_duration with a *different* wanted mode all still surface the "Change to X pending — <reason>. Hold/Cool-off Xm." line so the operator sees what's being held back.

## Test plan

- [x] Updated `drops the min_duration held entry entirely when current matches the natural pick` (was: omits wanted/wantedReason)
- [x] Updated `emergency overlay re-evaluates hysteresis during min-duration hold` and `wb.EH disable mid-hold takes effect immediately` to assert the natural reason flows through (those tests were checking the incidental `reason === min_duration`; the actual overlay-update behaviour is preserved)
- [x] All 1043 unit tests pass
- [x] All 271 Playwright tests pass (4 new e2e + frontend baselines from main)
- [x] Lint, knip, file-size strict, assets strict
- [x] Coverage gate exit 0 (`logs-clipboard.js` 86 %, `display-update.js` 90 %)
- [x] STATE_BYTES + RUNTIME_PROXY_PEAK still under cap

## Manual UX check

Renderable expectations after merge + deploy:

| scenario | mode card status | held banner |
|---|---|---|
| GH heating, just entered, greenhouse still cold | `Greenhouse still cold` | hidden |
| SC running, tank still gaining heat | `Tank still gaining heat` | hidden |
| SC running, stalled, < 5 min into mode | `Holding minimum run time` | `Change to Idle pending — tank stopped gaining heat. Hold 3m remaining.` |
| Drained collectors + cold collector + warm outdoor | `No trigger active` | `Change to Solar Charging pending — refilling drained collectors. Cool-off 0m remaining.` (when delta met) |
| User-disabled mode that physics wants | `Mode disabled by user` | `Change to <Mode> pending — <natural reason>.` |

https://claude.ai/code/session_013U46J33XiqydDQXutyguFZ

---
_Generated by [Claude Code](https://claude.ai/code/session_013U46J33XiqydDQXutyguFZ)_