### PR TITLE
forecast: full 48 h overlay + outdoor temp + pannable forecast region

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -317,6 +317,7 @@
             <div class="graph-legend-item"><div class="graph-legend-line" style="background:#42a5f5;"></div>Outside<span class="graph-legend-stats" id="legend-stats-outdoor"></span></div>
             <div class="graph-legend-item forecast-legend" style="display:none;"><div class="graph-legend-line graph-legend-line-dashed" style="background:#e9c349;"></div>Tank (forecast)</div>
             <div class="graph-legend-item forecast-legend" style="display:none;"><div class="graph-legend-line graph-legend-line-dashed" style="background:#69d0c5;"></div>Greenhouse (forecast)</div>
+            <div class="graph-legend-item forecast-legend" style="display:none;"><div class="graph-legend-line graph-legend-line-dashed" style="background:#42a5f5;"></div>Outside (forecast)</div>
             <div class="graph-legend-item forecast-legend" style="display:none;"><div class="graph-legend-dot" style="background:#ee7d77;opacity:0.45;"></div>Charging (projected)</div>
             <div class="graph-legend-item forecast-legend" style="display:none;"><div class="graph-legend-dot" style="background:#e9c349;opacity:0.45;"></div>Heating (projected)</div>
             <div class="graph-legend-item forecast-legend" style="display:none;"><div class="graph-legend-dot" style="background:#ff7043;opacity:0.55;"></div>Emergency (projected)</div>

--- a/playground/js/forecast.js
+++ b/playground/js/forecast.js
@@ -142,7 +142,7 @@ export function renderForecastCard(data) {
   const status = document.getElementById('forecast-status');
   if (status) {
     status.textContent = fc
-      ? 'Toggle "Forecast" above the chart to overlay the next 12 h.'
+      ? 'Toggle "Forecast" above the chart to overlay the next 48 h.'
       : '';
   }
 

--- a/playground/js/main/chart-pinch-zoom.js
+++ b/playground/js/main/chart-pinch-zoom.js
@@ -15,7 +15,10 @@
 // Desktop hover uses mousemove via setupInspector and bypasses this
 // disambiguator entirely.
 
-import { graphRange, chartZoom, setChartZoom, timeSeriesStore } from './state.js';
+import {
+  graphRange, chartZoom, setChartZoom, timeSeriesStore,
+  showForecast, FORECAST_OVERLAY_SEC,
+} from './state.js';
 import { drawHistoryGraph, getChartWindow } from './history-graph.js';
 import { showInspector, hideInspector } from './graph-inspector.js';
 import { store } from '../app-state.js';
@@ -75,13 +78,30 @@ export function resetChartZoom() {
   if (chartZoom) setChartZoom(null);
 }
 
+// Pure: compute the pannable/scrollable bound for the chart in seconds.
+// When showForecast is true and the chart is in live mode, the right edge
+// extends by forecastSec so a zoomed user can pan into the projected
+// region. tMin always sits graphRange seconds before the historical right
+// edge so the historical span never grows just because the forecast is on.
+export function computeDefaultBound({ isLive, latestSampleT, nowSec, graphRange, showForecast, forecastSec }) {
+  const baseRight = isLive ? nowSec : Math.max(graphRange, latestSampleT || 0);
+  const tMax = (isLive && showForecast) ? baseRight + forecastSec : baseRight;
+  return { tMin: baseRight - graphRange, tMax };
+}
+
 function defaultBound() {
   const isLive = store.get('phase') === 'live';
   const latest = timeSeriesStore.times.length > 0
     ? timeSeriesStore.times[timeSeriesStore.times.length - 1]
     : 0;
-  const tMax = isLive ? Math.floor(Date.now() / 1000) : Math.max(graphRange, latest);
-  return { tMin: tMax - graphRange, tMax };
+  return computeDefaultBound({
+    isLive,
+    latestSampleT: latest,
+    nowSec: Math.floor(Date.now() / 1000),
+    graphRange,
+    showForecast,
+    forecastSec: FORECAST_OVERLAY_SEC,
+  });
 }
 
 export function setupChartPinchZoom() {
@@ -130,12 +150,17 @@ export function setupChartPinchZoom() {
     const d = Math.abs(pts[0].x - pts[1].x);
     if (d < 1) return;
     e.preventDefault();
+    const bound = defaultBound();
     const next = pinchZoomWindow({
       initialRange: pinch.range0,
       initialFracOfPinchCenter: pinch.f0,
       initialTimeAtPinchCenter: pinch.tMid,
       distanceRatio: d / pinch.d0,
-      maxRange: graphRange,
+      // maxRange = the full default window (history + forecast horizon when
+      // the overlay is on). Without this, pinch-out would snap back the
+      // moment the zoom width grew past graphRange — even if the user is
+      // still inside the chart's visible span.
+      maxRange: bound.tMax - bound.tMin,
       minRange: MIN_RANGE_SEC,
     });
     setChartZoom(next);

--- a/playground/js/main/forecast-overlay.js
+++ b/playground/js/main/forecast-overlay.js
@@ -8,21 +8,23 @@
 
 import { pickBucketSize } from '../ui.js';
 
-// Forecast overlay rendering: tank avg + greenhouse trajectories (dashed)
-// past "now", predicted mode bands (charging/heating/emergency) past
-// "now", and a vertical "now" divider line. All clipped to
+// Forecast overlay rendering: tank avg + greenhouse + outdoor trajectories
+// (dashed) past "now", predicted mode bands (charging/heating/emergency)
+// past "now", and a vertical "now" divider line. All clipped to
 // [now, cutoffSec] AND the visible chart window.
 export function drawForecastOverlay(ctx, data, nowSec, cutoffSec, tMin, tMax, visibleRange, barAreaH, barY0, pad, pw, ph, yMin, yMax) {
   const fc = data && data.forecast;
   if (!fc) return;
 
-  // Trajectory points come from the engine as ISO strings; convert to
+  // Trajectory points come from the engine as ISO strings (`ts` for
+  // engine output, `validAt` for the raw weather array). Convert to
   // seconds and clip to [nowSec, cutoffSec] AND the chart window.
-  function toPts(traj, valOf) {
+  function toPts(traj, valOf, tsKey) {
     if (!Array.isArray(traj)) return [];
+    const key = tsKey || 'ts';
     const pts = [];
     for (let i = 0; i < traj.length; i++) {
-      const t = Math.floor(new Date(traj[i].ts).getTime() / 1000);
+      const t = Math.floor(new Date(traj[i][key]).getTime() / 1000);
       if (t < nowSec || t > cutoffSec) continue;
       if (t < tMin || t > tMax) continue;
       const v = valOf(traj[i]);
@@ -47,9 +49,13 @@ export function drawForecastOverlay(ctx, data, nowSec, cutoffSec, tMin, tMax, vi
     ctx.restore();
   }
 
-  // Tank avg + greenhouse — match historical line colours, dashed.
+  // Tank avg + greenhouse + outdoor — match historical line colours, dashed.
+  // Outdoor lives in the raw weather array (top-level of the response,
+  // alongside `forecast`), not in the engine's projection — the engine
+  // consumes it as an input to compute tank/greenhouse cooling.
   drawDashed(toPts(fc.tankTrajectory, p => (typeof p.avg === 'number' ? p.avg : (p.top + p.bottom) / 2)), '#e9c349', 1.5);
   drawDashed(toPts(fc.greenhouseTrajectory, p => p.temp), '#69d0c5', 1.5);
+  drawDashed(toPts(data.weather, p => p.temperature, 'validAt'), '#42a5f5', 1);
 
   // Predicted mode bands (charging / heating / emergency) past "now",
   // bucketed at the same bucketSec as the historical duty bars on the

--- a/playground/js/main/graph-inspector.js
+++ b/playground/js/main/graph-inspector.js
@@ -78,7 +78,7 @@ function updateInspectorData(x) {
 
   let v, t;
   if (inForecast) {
-    v = forecastValuesAt(fc, simTime);
+    v = forecastValuesAt(fc, simTime, forecastData && forecastData.weather);
     t = simTime;
   } else {
     let bestIdx = 0, bestDist = Infinity;
@@ -158,36 +158,40 @@ function updateInspectorData(x) {
 
 // Linearly interpolate a forecast trajectory at simTime (Unix seconds)
 // and return a row shaped like timeSeriesStore.values so the inspector's
-// downstream rendering doesn't branch. Collector and outdoor aren't part
-// of the forecast — they fall through as null and render as the placeholder.
-function forecastValuesAt(fc, simTime) {
-  const tank = interpTrajPoint(fc.tankTrajectory, simTime);
-  const gh   = interpTrajPoint(fc.greenhouseTrajectory, simTime);
+// downstream rendering doesn't branch. Outdoor is interpolated from the
+// weather array (top-level of the API response). Collector isn't part of
+// the forecast — it stays null and renders as the placeholder.
+function forecastValuesAt(fc, simTime, weather) {
+  const tank = interpTrajPoint(fc.tankTrajectory, simTime, 'ts');
+  const gh   = interpTrajPoint(fc.greenhouseTrajectory, simTime, 'ts');
+  const wx   = interpTrajPoint(weather, simTime, 'validAt');
   return {
     t_collector:   null,
     t_tank_top:    tank ? tank.top : null,
     t_tank_bottom: tank ? tank.bottom : null,
     t_greenhouse:  gh ? gh.temp : null,
-    t_outdoor:     null,
+    t_outdoor:     wx ? wx.temperature : null,
   };
 }
 
-function interpTrajPoint(traj, simTime) {
+function interpTrajPoint(traj, simTime, tsKey) {
   if (!Array.isArray(traj) || traj.length === 0) return null;
+  const key = tsKey || 'ts';
   for (let i = 0; i < traj.length; i++) {
-    const t = Math.floor(new Date(traj[i].ts).getTime() / 1000);
+    const t = Math.floor(new Date(traj[i][key]).getTime() / 1000);
     if (t >= simTime) {
       if (i === 0) return traj[0];
       const prev = traj[i - 1];
-      const pT = Math.floor(new Date(prev.ts).getTime() / 1000);
+      const pT = Math.floor(new Date(prev[key]).getTime() / 1000);
       if (t === pT) return traj[i];
       const f = (simTime - pT) / (t - pT);
-      const out = { ts: traj[i].ts };
-      const keys = ['top', 'bottom', 'avg', 'temp'];
-      for (let k = 0; k < keys.length; k++) {
-        const key = keys[k];
-        if (typeof traj[i][key] === 'number' && typeof prev[key] === 'number') {
-          out[key] = prev[key] + (traj[i][key] - prev[key]) * f;
+      const out = {};
+      out[key] = traj[i][key];
+      const valKeys = ['top', 'bottom', 'avg', 'temp', 'temperature'];
+      for (let k = 0; k < valKeys.length; k++) {
+        const vk = valKeys[k];
+        if (typeof traj[i][vk] === 'number' && typeof prev[vk] === 'number') {
+          out[vk] = prev[vk] + (traj[i][vk] - prev[vk]) * f;
         }
       }
       return out;

--- a/playground/js/main/history-graph.js
+++ b/playground/js/main/history-graph.js
@@ -98,12 +98,13 @@ export function getChartWindow() {
   return { tMin: baseRight - graphRange, tMax };
 }
 
-// Forecast horizon for the current view: capped at FORECAST_OVERLAY_SEC
-// (12 h) but never larger than the historical range. At narrow ranges
-// (1 h, 6 h) this keeps history and forecast at equal width so the
-// detail you zoomed in for doesn't get squished into a tiny strip.
+// Forecast horizon for the current view: the full FORECAST_OVERLAY_SEC
+// (48 h). Independent of graphRange — when the user turns the overlay on
+// they want the entire projected window visible at once, even if it makes
+// the historical pane narrow. To regain historical detail, either widen
+// graphRange or turn the overlay off.
 function effectiveForecastSec() {
-  return Math.min(FORECAST_OVERLAY_SEC, graphRange);
+  return FORECAST_OVERLAY_SEC;
 }
 
 // Wall-clock "now" in chart-x-axis units (Unix seconds in live mode).
@@ -308,7 +309,7 @@ export function drawHistoryGraph() {
   // ── Outside line (blue) ──
   drawTempLine(ctx, timeSeriesStore, tMin, tMax, visibleRange, pad, pw, ph, yMin, yMax, 't_outdoor', '#42a5f5', 1);
 
-  // ── Forecast overlay (next 12 h, dashed, only with the "Forecast" toggle) ──
+  // ── Forecast overlay (next 48 h, dashed, only with the "Forecast" toggle) ──
   // Live-only (chartNowSec returns null in sim mode → overlay no-ops).
   if (showForecast && forecastData) {
     const nowSec = chartNowSec();

--- a/playground/js/main/state.js
+++ b/playground/js/main/state.js
@@ -57,11 +57,12 @@ export function setShowForecast(v) { showForecast = v; }
 export let forecastData = null;
 export function setForecastData(v) { forecastData = v; }
 
-// 12 hours, shown when the forecast overlay is on. The engine itself returns
-// 48 h, but for the at-a-glance status overlay 12 h is the operationally
-// useful horizon (covers the upcoming night without making historical detail
-// shrink too far).
-export const FORECAST_OVERLAY_SEC = 12 * 3600;
+// Full engine horizon, shown when the forecast overlay is on. The
+// physics/cost engine returns 48 h of trajectory + weather, and the
+// overlay surfaces all of it so the user can see the entire projected
+// window without having to reason about which slice is being displayed.
+// The historical pane shrinks to make room — the trade-off is intentional.
+export const FORECAST_OVERLAY_SEC = 48 * 3600;
 
 // Input parameters for the simulation. Mutated by slider
 // callbacks in setupControls — properties change, but the object

--- a/tests/frontend/forecast-tooltip.spec.js
+++ b/tests/frontend/forecast-tooltip.spec.js
@@ -21,24 +21,26 @@ const LIVE_POINTS = [
   { ts: NOW - 60_000,   collector: 60.0, tank_top: 44.0, tank_bottom: 36.0, greenhouse: 19.0, outdoor: 11.0 },
 ];
 
-// 12 hourly forecast points (covers FORECAST_OVERLAY_SEC). The tank
-// trajectory descends from 30 → 18°C, the greenhouse from 14 → 8°C — both
-// well below the last live values so a forecast-region tooltip can't be
-// confused with a "stale live" reading.
+// 49 hourly forecast points (covers the full 48 h FORECAST_OVERLAY_SEC).
+// The tank trajectory descends from 30 → ~18°C over 48 h, the greenhouse
+// from 14 → ~6°C — both well below the last live values so a forecast-
+// region tooltip can't be confused with a "stale live" reading.
+// Weather temperature descends from 11 → ~1.2°C, distinct from the last
+// live outdoor sample (11°C exactly) only after a few hours.
 const FORECAST_PAYLOAD = {
   generatedAt: new Date(NOW).toISOString(),
   forecast: {
     generatedAt: new Date(NOW).toISOString(),
-    horizonHours: 12,
-    tankTrajectory: Array.from({ length: 13 }, (_, i) => ({
+    horizonHours: 48,
+    tankTrajectory: Array.from({ length: 49 }, (_, i) => ({
       ts: new Date(NOW + i * 3600_000).toISOString(),
-      top: 32 - i,
-      bottom: 28 - i,
-      avg: 30 - i,
+      top: 32 - i * 0.25,
+      bottom: 28 - i * 0.25,
+      avg: 30 - i * 0.25,
     })),
-    greenhouseTrajectory: Array.from({ length: 13 }, (_, i) => ({
+    greenhouseTrajectory: Array.from({ length: 49 }, (_, i) => ({
       ts: new Date(NOW + i * 3600_000).toISOString(),
-      temp: 14 - i * 0.5,
+      temp: 14 - i * 0.16,
     })),
     // Hours 0,1,2 = solar_charging. Hours 6,7,8 = greenhouse_heating.
     // Hour 10 = emergency_heating. Default 1-h bucket means whichever
@@ -52,7 +54,7 @@ const FORECAST_PAYLOAD = {
       { ts: new Date(NOW + 8 * 3600_000).toISOString(), mode: 'greenhouse_heating' },
       { ts: new Date(NOW + 10 * 3600_000).toISOString(), mode: 'emergency_heating' },
     ],
-    hoursUntilFloor: 12,
+    hoursUntilFloor: 48,
     hoursUntilBackupNeeded: 10,
     electricKwh: 1.0,
     electricCostEur: 0.15,
@@ -62,7 +64,16 @@ const FORECAST_PAYLOAD = {
     modelConfidence: 'medium',
     notes: [],
   },
-  weather: [],
+  // Weather array is what the outside-temperature forecast line reads
+  // from. Linear drop 11 → 1.4°C over 48 h gives ~7.7°C at hour ~21
+  // (where the forecast-region hover lands at frac 0.625 below).
+  weather: Array.from({ length: 49 }, (_, i) => ({
+    validAt:         new Date(NOW + i * 3600_000).toISOString(),
+    temperature:     11 - i * 0.2,
+    radiationGlobal: 0,
+    windSpeed:       2,
+    precipitation:   0,
+  })),
   prices: [],
 };
 
@@ -168,32 +179,39 @@ test.describe('Inspector tooltip on the forecast side of the history graph', () 
     await page.locator('#graph-show-forecast-toggle').click();
     await expect(page.locator('#graph-show-forecast')).toHaveAttribute('aria-checked', 'true');
 
-    // Hover ~6.6 h into the forecast region. The window spans 24 h of
-    // history + 12 h of forecast (36 h total); 0.85 of the width lands
-    // around now + 6.6 h, which is hour-bucket 6 of the modeForecast
-    // (greenhouse_heating).
-    await hoverChartAt(page, 0.85);
+    // Hover ~21.6 h into the forecast region. The window spans 24 h of
+    // history + 48 h of forecast (72 h total); 0.625 of the width lands
+    // around now + 21.6 h. Picked to fall well past hour 8 (the last
+    // greenhouse_heating slot) and well before hour 48 (last sample), so
+    // none of the trajectory edges interfere with the assertions.
+    await hoverChartAt(page, 0.625);
 
     const tankText = await page.locator('#inspector-tank').textContent();
     // Last live tank avg is (44+36)/2 = 40.0°C. Forecast tank avg at
-    // hour ~6.6 is 30 - 6.6 ≈ 23.4°C. Anything > 30°C means we're still
-    // reading the live nearest-neighbor — fail loudly.
+    // hour ~21.6 is 30 - 21.6*0.25 ≈ 24.6°C. Anything > 30°C means we're
+    // still reading the live nearest-neighbor — fail loudly.
     const tankNum = parseFloat((tankText || '').replace('°C', ''));
     expect(tankNum).toBeGreaterThan(0);
     expect(tankNum).toBeLessThan(30); // forecast value, not the 40°C live
     expect(tankNum).toBeGreaterThan(18); // sanity: within forecast range
 
-    // Greenhouse forecast at hour 6.6 ≈ 14 - 6.6*0.5 = 10.7°C; live is
+    // Greenhouse forecast at hour 21.6 ≈ 14 - 21.6*0.16 = 10.5°C; live is
     // 19°C. Same shape of assertion.
     const ghText = await page.locator('#inspector-gh').textContent();
     const ghNum = parseFloat((ghText || '').replace('°C', ''));
     expect(ghNum).toBeLessThan(15);
     expect(ghNum).toBeGreaterThan(7);
 
-    // Collector and Outdoor are not part of the forecast — show the
-    // placeholder rather than carrying live values forward.
+    // Outdoor IS part of the forecast (weather array). At hour ~21.6 the
+    // forecast outdoor is 11 - 21.6*0.2 ≈ 6.7°C — well below the last
+    // live sample of 11°C, so a live-fallback would assert >10.
+    const outText = await page.locator('#inspector-out').textContent();
+    const outNum = parseFloat((outText || '').replace('°C', ''));
+    expect(outNum).toBeLessThan(10);
+    expect(outNum).toBeGreaterThan(2);
+
+    // Collector is not part of the forecast — keeps showing the placeholder.
     await expect(page.locator('#inspector-coll')).toHaveText('—');
-    await expect(page.locator('#inspector-out')).toHaveText('—');
   });
 
   test('forecast-region hover shows the forecast mode-band percentages', async ({ page }) => {
@@ -207,21 +225,17 @@ test.describe('Inspector tooltip on the forecast side of the history graph', () 
 
     await page.locator('#graph-show-forecast-toggle').click();
 
-    // Hover at frac 0.85 — simTime ≈ now+6.6h. With a 3-h bucket and
-    // greenhouse_heating slots at hours 6/7/8, the bucket containing
-    // simTime will contain 1, 2, or 3 of those slots depending on how
-    // the wall-clock now lands relative to a 3-h boundary. Charging
-    // (hours 0/1/2) and emergency (hour 10) sit outside any bucket
-    // that can contain hour 6.6, so those stay at 0%. With the buggy
-    // code the bucket reflects historical mode (idle → 0% heating).
-    await hoverChartAt(page, 0.85);
+    // Hover at frac 0.43 — visible window spans 72 h (24 h history +
+    // 48 h forecast), so simTime ≈ tMin + 0.43·72h = now + ~7 h. With
+    // pickBucketSize for a 72 h range stepping up to 6-h buckets, the
+    // bucket containing hour 7 always overlaps at least one of the
+    // greenhouse_heating slots at hours 6/7/8. Charging (hours 0/1/2)
+    // and emergency (hour 10) may also share a bucket depending on
+    // alignment, so we only assert heating > 0 here.
+    await hoverChartAt(page, 0.43);
 
     const ht = await page.locator('#inspector-heating').textContent();
-    const ch = await page.locator('#inspector-charging').textContent();
-    const em = await page.locator('#inspector-emergency').textContent();
     expect(parseInt(ht, 10)).toBeGreaterThan(0);
-    expect(ch).toBe('0%');
-    expect(em).toBe('0%');
   });
 
   test('forecast-region hover shows a future time, not the last live timestamp', async ({ page }) => {

--- a/tests/pinch-zoom.test.mjs
+++ b/tests/pinch-zoom.test.mjs
@@ -9,7 +9,7 @@
  */
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
-import { pinchZoomWindow, panZoomWindow } from '../playground/js/main/chart-pinch-zoom.js';
+import { pinchZoomWindow, panZoomWindow, computeDefaultBound } from '../playground/js/main/chart-pinch-zoom.js';
 
 const HOUR = 3600;
 
@@ -119,5 +119,37 @@ describe('panZoomWindow', () => {
     const r = panZoomWindow({ tMin: 5 * HOUR, tMax: 9 * HOUR }, 0, BOUND);
     assert.equal(r.tMin, 5 * HOUR);
     assert.equal(r.tMax, 9 * HOUR);
+  });
+});
+
+describe('computeDefaultBound', () => {
+  const NOW = 1000 * HOUR;
+
+  it('clamps right edge at "now" in live mode without forecast', () => {
+    const b = computeDefaultBound({
+      isLive: true, latestSampleT: NOW - 60, nowSec: NOW,
+      graphRange: 24 * HOUR, showForecast: false, forecastSec: 48 * HOUR,
+    });
+    assert.equal(b.tMax, NOW);
+    assert.equal(b.tMin, NOW - 24 * HOUR);
+  });
+
+  it('extends right edge by forecastSec when forecast overlay is on (live mode)', () => {
+    const b = computeDefaultBound({
+      isLive: true, latestSampleT: NOW - 60, nowSec: NOW,
+      graphRange: 24 * HOUR, showForecast: true, forecastSec: 48 * HOUR,
+    });
+    assert.equal(b.tMax, NOW + 48 * HOUR,
+      'pannable area must include the projected horizon so users can pan into it');
+    assert.equal(b.tMin, NOW - 24 * HOUR,
+      'historical left edge stays anchored to graphRange — turning forecast on does not stretch history');
+  });
+
+  it('ignores forecast in sim mode (forecast overlay is live-only)', () => {
+    const b = computeDefaultBound({
+      isLive: false, latestSampleT: 36 * HOUR, nowSec: NOW,
+      graphRange: 24 * HOUR, showForecast: true, forecastSec: 48 * HOUR,
+    });
+    assert.equal(b.tMax, 36 * HOUR);
   });
 });


### PR DESCRIPTION
## Summary
- Bump `FORECAST_OVERLAY_SEC` from 12 h → 48 h and drop the `graphRange` cap in `effectiveForecastSec()` so the entire engine horizon is visible whenever the toggle is on.
- Render a dashed outside-temperature line on the forecast side, sourced from the response's top-level `weather` array (already present, just not visualised). Inspector tooltip interpolates the value via a generalised `interpTrajPoint`.
- Extend the chart's pannable bound by `FORECAST_OVERLAY_SEC` (live mode + forecast on) so a pinch-zoomed user can pan into the forecast region. Pinch-out `maxRange` follows the same bound, gated on `showForecast` so historical-only behaviour is unchanged.

## Test plan
- [x] `npm run lint` — 0 errors
- [x] `npm run knip` — exit 0
- [x] `npm run check:file-size -- --strict` — 0 over hard cap
- [x] `npm run check:assets -- --strict` — exit 0
- [x] `npm run test:unit` — 1095 / 1095 (incl. new `computeDefaultBound` cases covering live-with-forecast, live-without-forecast, and sim-mode)
- [x] `npx playwright test` — 285 / 285 (forecast-tooltip rewritten around the 48 h horizon, asserts forecast outdoor value)
- [ ] Verify on the live dashboard that turning the Forecast toggle on stretches the chart to 48 h and that pinch-zoom + drag can pan into the forecast side

https://claude.ai/code/session_016S7FZy45ud5FCp6wYBVzJe

---
_Generated by [Claude Code](https://claude.ai/code/session_016S7FZy45ud5FCp6wYBVzJe)_