### PR TITLE
tests: make live-network tests opt-in (fixes flaky CI)

### DIFF
--- a/tests/fmi-client.test.js
+++ b/tests/fmi-client.test.js
@@ -51,7 +51,7 @@ describe('fmi-client parseWfsResponse', () => {
 });
 
 describe('fmi-client live HTTPS call', () => {
-  it('live FMI call', { skip: process.env.SKIP_NETWORK_TESTS === '1' }, async () => {
+  it('live FMI call', { skip: process.env.RUN_LIVE_NETWORK_TESTS !== '1' }, async () => {
     const rows = await fetchForecast({ lat: 60.41, lon: 22.37, hours: 3 });
     assert.ok(rows.length >= 1, 'expected at least one row');
     const first = rows[0];

--- a/tests/spot-price-client.test.js
+++ b/tests/spot-price-client.test.js
@@ -67,7 +67,7 @@ describe('spot-price-client', () => {
   });
 
   describe('fetchPrices (live network)', () => {
-    const skip = process.env.SKIP_NETWORK_TESTS === '1';
+    const skip = process.env.RUN_LIVE_NETWORK_TESTS !== '1';
     it('returns at least 12 rows with valid structure' + (skip ? ' [SKIPPED]' : ''), { skip }, async () => {
       const rows = await fetchPrices({ horizonHours: 24 });
       assert.ok(rows.length >= 12, 'expected at least 12 rows, got ' + rows.length);


### PR DESCRIPTION
## Summary

Two unit tests perform live HTTPS calls to external services and were gated as opt-out via `SKIP_NETWORK_TESTS=1`, so CI ran them by default and inherited every TLS / DNS / rate-limit hiccup those upstreams produce:

- `tests/fmi-client.test.js` → FMI WFS (HARMONIE forecast)
- `tests/spot-price-client.test.js` → sahkotin.fi + nordpool-predict-fi

The most recently observed flake was `CERT_NOT_YET_VALID` during the TLS handshake against sahkotin (originally surfaced in #146's investigation: 2 / 5 fails on `--test-concurrency=8` pre-fix, 0 / 10 post-fix).

Flip the gate to opt-in: `RUN_LIVE_NETWORK_TESTS=1` to run the live calls.

```diff
-    const skip = process.env.SKIP_NETWORK_TESTS === '1';
+    const skip = process.env.RUN_LIVE_NETWORK_TESTS !== '1';
```

The fixture-based parsing tests above each `live network` block (`parseWfsResponse`, `parseSahkotinCsv`, `parseNordpoolPredict`, `mergePrices`, VAT math) still run on every CI build — coverage is unchanged.

## Why a fresh PR

This is the same fix originally proposed in #146; that branch is unmergeable (forked before #144 landed, shows 4421 phantom additions for the forecast feature; `mergeable_state: dirty`). Closed #146 and redid the 2-line patch off current `main`.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run knip` — clean (1 hint, exit 0)
- [x] `npm run check:file-size -- --strict` — 0 over hard cap
- [x] `npm run check:assets -- --strict` — clean
- [x] `npm run test:unit` — 1093 / 1095 pass, 2 skipped (the 2 live tests, now opt-in by default)
- [x] Playwright (frontend + e2e) — green via pre-push gate
- [ ] CI green

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qxnw3SHhiDS3ecbchhyE2h)_