### PR TITLE
logs: include current 48 h forecast in System Logs export

### DIFF
--- a/playground/js/main/logs-clipboard.js
+++ b/playground/js/main/logs-clipboard.js
@@ -8,7 +8,7 @@ import {
   formatTimeOfDay, formatFullTimeHelsinki, formatConfigEntry,
   formatConfigSourceLabel, formatReasonLabel, formatOverlayEntry,
 } from './time-format.js';
-import { model, params, MODE_INFO, timeSeriesStore, transitionLog, lastLiveFrame } from './state.js';
+import { model, params, MODE_INFO, timeSeriesStore, transitionLog, lastLiveFrame, forecastData } from './state.js';
 import { getWatchdogSnapshot } from './watchdog-ui.js';
 import { modeAt } from './mode-events.js';
 
@@ -41,6 +41,11 @@ function buildLogsClipboardText() {
   // Controller-state snapshot (live mode only — captures the evaluator-
   // visible flags / device config that gate mode transitions).
   if (isLive) appendControllerState(lines);
+
+  // Forecast snapshot (live mode only — sim mode never fetches forecast).
+  // Included so an exported log captures what the algorithm "thought" the
+  // next 48 h looked like at copy time, for offline algorithm tuning.
+  if (isLive) appendForecast(lines);
 
   if (isLive) {
     lines.push('--- Sensor Readings (24h, 20-min resolution) ---');
@@ -370,6 +375,114 @@ function appendControllerState(lines) {
 function fmtTempCol(v) {
   if (typeof v !== 'number' || Number.isNaN(v)) return '    —   ';
   return String(v.toFixed(1)).padStart(8);
+}
+
+function fmtNum(v, digits, width) {
+  if (typeof v !== 'number' || Number.isNaN(v)) return '—'.padStart(width);
+  return v.toFixed(digits).padStart(width);
+}
+
+function fmtHoursLabel(h) {
+  if (h === null || h === undefined) return '48+ h (no backup needed)';
+  if (h === 0) return 'Engaged now';
+  const rounded = Math.round(h * 2) / 2;
+  return '~' + rounded + ' h';
+}
+
+// Build a key→row map from an ISO-timestamp list so the hourly projection
+// table can join weather, prices, mode, and trajectory rows even when the
+// arrays disagree on length (e.g. weather DB hasn't fetched yet).
+function indexByIso(rows, key) {
+  const out = {};
+  if (!Array.isArray(rows)) return out;
+  for (let i = 0; i < rows.length; i++) {
+    const r = rows[i];
+    const ts = r && r[key];
+    if (typeof ts === 'string') out[ts] = r;
+  }
+  return out;
+}
+
+function appendForecast(lines) {
+  lines.push('--- Forecast (Next 48 h) ---');
+  if (!forecastData || !forecastData.forecast) {
+    lines.push('(forecast not loaded)');
+    lines.push('');
+    return;
+  }
+
+  const fc = forecastData.forecast;
+  lines.push('Generated:          ' + (forecastData.generatedAt || '(unknown)'));
+  lines.push('Model confidence:   ' + (fc.modelConfidence || '(unknown)'));
+  lines.push('Tank lasts:         ' + fmtHoursLabel(fc.hoursUntilBackupNeeded));
+  if (typeof fc.hoursUntilFloor === 'number') {
+    lines.push('Hours until floor:  ' + fc.hoursUntilFloor.toFixed(1) + ' h');
+  }
+  if (typeof fc.electricKwh === 'number') {
+    lines.push('Backup heat:        ' + fc.electricKwh.toFixed(2) + ' kWh');
+  }
+  if (typeof fc.electricCostEur === 'number') {
+    lines.push('Backup cost:        €' + fc.electricCostEur.toFixed(2));
+  }
+  if (typeof fc.solarChargingHours === 'number') {
+    lines.push('Solar charging:     ' + fc.solarChargingHours + ' h');
+  }
+  if (typeof fc.greenhouseHeatingHours === 'number') {
+    lines.push('Greenhouse heating: ' + fc.greenhouseHeatingHours + ' h');
+  }
+
+  if (Array.isArray(fc.solarGainByDay) && fc.solarGainByDay.length) {
+    lines.push('Solar gain by day:');
+    for (let i = 0; i < fc.solarGainByDay.length; i++) {
+      const d = fc.solarGainByDay[i];
+      lines.push('  ' + d.date + ': ' + (typeof d.kWh === 'number' ? d.kWh.toFixed(1) : '—') + ' kWh');
+    }
+  }
+
+  if (Array.isArray(fc.notes) && fc.notes.length) {
+    lines.push('Notes:');
+    for (let i = 0; i < fc.notes.length; i++) {
+      lines.push('  - ' + fc.notes[i]);
+    }
+  }
+
+  // Hourly projection — joins weather + price + projected mode + projected
+  // tank/greenhouse on the modeForecast timestamps (one row per forecast
+  // hour). The trajectory arrays have an extra leading "now" row that the
+  // mode list doesn't, so iterating modeForecast is the right axis.
+  const modes = Array.isArray(fc.modeForecast) ? fc.modeForecast : [];
+  if (modes.length) {
+    const wxByTs   = indexByIso(forecastData.weather, 'validAt');
+    const pxByTs   = indexByIso(forecastData.prices, 'validAt');
+    const tankByTs = indexByIso(fc.tankTrajectory, 'ts');
+    const ghByTs   = indexByIso(fc.greenhouseTrajectory, 'ts');
+
+    lines.push('');
+    lines.push('Hourly projection:');
+    lines.push('Time                  TempOut    Rad   Wind  Precip   Price  Mode               Duty  TankAvg     GH');
+    for (let i = 0; i < modes.length; i++) {
+      const m = modes[i];
+      const ts = m.ts;
+      const wx = wxByTs[ts] || {};
+      const px = pxByTs[ts] || {};
+      const tk = tankByTs[ts] || {};
+      const gh = ghByTs[ts] || {};
+      lines.push(
+        formatFullTimeHelsinki(new Date(ts).getTime()) + '  ' +
+        fmtNum(wx.temperature, 1, 6) + '°C  ' +
+        fmtNum(wx.radiationGlobal, 0, 5) + '  ' +
+        fmtNum(wx.windSpeed, 1, 4) + '  ' +
+        fmtNum(wx.precipitation, 1, 5) + '  ' +
+        fmtNum(px.priceCKwh, 2, 6) + 'c  ' +
+        (m.mode || 'idle').padEnd(17) + '  ' +
+        (typeof m.duty === 'number' ? m.duty.toFixed(2) : '   —') + '  ' +
+        fmtNum(tk.avg, 1, 6) + '  ' +
+        fmtNum(gh.temp, 1, 6)
+      );
+    }
+  }
+
+  lines.push('');
 }
 
 // Down-sample timeSeriesStore to a given interval (in seconds). Mode is

--- a/tests/frontend/copy-logs.spec.js
+++ b/tests/frontend/copy-logs.spec.js
@@ -230,6 +230,14 @@ async function mockHistoryApi(page, points, events) {
   }));
 }
 
+async function mockForecastApi(page, payload) {
+  await page.route('**/api/forecast', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify(payload),
+  }));
+}
+
 async function mockWatchdogStateApi(page, snapshot) {
   await page.route('**/api/watchdog/state', route => route.fulfill({
     status: 200,
@@ -426,6 +434,109 @@ test.describe('Copy System Logs — live mode', () => {
     expect(text).toContain('Watchdogs enabled:  ggr');
     expect(text).toMatch(/Watchdogs snoozed: {2}ggr=\d+m/);
     expect(text).toContain('Mode bans (wb):     SC=disabled');
+  });
+
+  test('forecast section is included in live mode export', async ({ page }) => {
+    // The forecast section captures what the algorithm "thought" the next
+    // 48 h looked like at copy time, so an exported log can be replayed
+    // offline against algorithm changes.
+    const generatedAt = '2026-05-05T10:00:00.000Z';
+    const hour0 = '2026-05-05T11:00:00.000Z';
+    const hour1 = '2026-05-05T12:00:00.000Z';
+
+    const forecastPayload = {
+      generatedAt,
+      weather: [
+        { validAt: hour0, temperature: 12.3, radiationGlobal: 650, windSpeed: 3.5, precipitation: 0 },
+        { validAt: hour1, temperature: 11.8, radiationGlobal: 620, windSpeed: 4.0, precipitation: 0.2 },
+      ],
+      prices: [
+        { validAt: hour0, priceCKwh: 8.21, source: 'sahkotin' },
+        { validAt: hour1, priceCKwh: 9.45, source: 'sahkotin' },
+      ],
+      forecast: {
+        generatedAt,
+        horizonHours: 48,
+        hoursUntilBackupNeeded: 12.5,
+        hoursUntilFloor: 24.0,
+        electricKwh: 4.2,
+        electricCostEur: 0.83,
+        solarChargingHours: 8,
+        greenhouseHeatingHours: 14,
+        modelConfidence: 'medium',
+        notes: ['Greenhouse stays above 10 °C through tomorrow morning.', 'Tank coasts ~12 h before backup engages.'],
+        solarGainByDay: [
+          { date: '2026-05-05', kWh: 12.3 },
+          { date: '2026-05-06', kWh: 14.5 },
+        ],
+        modeForecast: [
+          { ts: hour0, mode: 'solar_charging' },
+          { ts: hour1, mode: 'greenhouse_heating', duty: 0.45 },
+        ],
+        tankTrajectory: [
+          { ts: hour0, top: 65.0, bottom: 60.0, avg: 62.5 },
+          { ts: hour1, top: 64.0, bottom: 59.0, avg: 61.5 },
+        ],
+        greenhouseTrajectory: [
+          { ts: hour0, temp: 18.2 },
+          { ts: hour1, temp: 17.8 },
+        ],
+      },
+    };
+
+    await installMockWs(page);
+    await mockHistoryApi(page);
+    await mockEventsApi(page, []);
+    await mockForecastApi(page, forecastPayload);
+
+    await page.goto('/playground/', { waitUntil: 'domcontentloaded' });
+    await expect(page.locator('#connection-dot')).toHaveClass(/connected/, { timeout: 5000 });
+    // Wait for forecast card to populate so forecastData is in shared state.
+    await expect(page.locator('#forecast-val-eur')).toHaveText('€0.83', { timeout: 5000 });
+    await waitForTestHook(page);
+
+    const text = await getClipboardText(page);
+
+    expect(text).toContain('--- Forecast (Next 48 h) ---');
+    expect(text).toContain('Generated:          ' + generatedAt);
+    expect(text).toContain('Model confidence:   medium');
+    expect(text).toContain('Tank lasts:         ~12.5 h');
+    expect(text).toContain('Hours until floor:  24.0 h');
+    expect(text).toContain('Backup heat:        4.20 kWh');
+    expect(text).toContain('Backup cost:        €0.83');
+    expect(text).toContain('Solar charging:     8 h');
+    expect(text).toContain('Greenhouse heating: 14 h');
+    expect(text).toContain('Solar gain by day:');
+    expect(text).toContain('  2026-05-05: 12.3 kWh');
+    expect(text).toContain('  2026-05-06: 14.5 kWh');
+    expect(text).toContain('Notes:');
+    expect(text).toContain('  - Greenhouse stays above 10 °C through tomorrow morning.');
+    expect(text).toContain('Hourly projection:');
+    // The hourly row should join weather + price + mode + trajectory on
+    // the same timestamp. We don't pin the wall-clock format (TZ-dependent)
+    // but every projection field must show up on the same line.
+    const lines = text.split('\n');
+    const hour1Lines = lines.filter(l => /\bsolar_charging\b/.test(l));
+    expect(hour1Lines.length).toBeGreaterThan(0);
+    expect(hour1Lines.some(l => l.includes('12.3') && l.includes('650') && l.includes('8.21') && l.includes('62.5') && l.includes('18.2'))).toBe(true);
+    const hour2Lines = lines.filter(l => /\bgreenhouse_heating\b/.test(l));
+    expect(hour2Lines.some(l => l.includes('0.45') && l.includes('11.8') && l.includes('61.5') && l.includes('17.8'))).toBe(true);
+  });
+
+  test('forecast section renders graceful fallback when forecast unavailable', async ({ page }) => {
+    await installMockWs(page);
+    await mockHistoryApi(page);
+    await mockEventsApi(page, []);
+    // 500 → forecast.js _showError, forecastData stays null.
+    await page.route('**/api/forecast', route => route.fulfill({ status: 500, body: '' }));
+
+    await page.goto('/playground/', { waitUntil: 'domcontentloaded' });
+    await expect(page.locator('#connection-dot')).toHaveClass(/connected/, { timeout: 5000 });
+    await waitForTestHook(page);
+
+    const text = await getClipboardText(page);
+    expect(text).toContain('--- Forecast (Next 48 h) ---');
+    expect(text).toContain('(forecast not loaded)');
   });
 
   test('fan-cool overlay flips render in transition log + controller state', async ({ page }) => {


### PR DESCRIPTION
## Summary

- Added a `--- Forecast (Next 48 h) ---` block to the System Logs clipboard export (live mode only — sim mode never fetches forecast). Dumps `generatedAt`, model confidence, headline tiles (tank lasts / hours-until-floor / backup heat / backup cost), solar-charging + greenhouse-heating hour totals, per-day solar gain, narrative notes, and an hourly projection table joining `weather` (temp / radiation / wind / precip), `prices` (c/kWh), `modeForecast` (mode + heater duty), and tank/greenhouse trajectory points on the same forecast hour.
- Reads `forecastData` straight from shared state (`playground/js/main/state.js`) — already populated by `forecast.js`, no new fetch path needed.
- Two new Playwright specs cover (1) the populated path with a mocked `/api/forecast`, asserting every section and joined-row content; (2) the 500-response fallback rendering `(forecast not loaded)`.

Motivates offline replay of the forecast algorithm against real operational snapshots — copy logs from the device, paste the projection table into a notebook, tune.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run knip` — clean
- [x] `npm run check:file-size -- --strict` — 0 over hard cap
- [x] `npm run check:assets -- --strict` — clean
- [x] `npm run test:unit` — 1095/1095
- [x] `npx playwright test` — 287/287
- [x] `npx playwright test tests/frontend/copy-logs.spec.js` — 16/16, including the two new forecast specs

https://claude.ai/code/session_019Rc1ppnD4begJwFy9QPZH8

---
_Generated by [Claude Code](https://claude.ai/code/session_019Rc1ppnD4begJwFy9QPZH8)_