### PR TITLE
forecast: gate projected greenhouse_heating on tank-vs-greenhouse delta

### DIFF
--- a/server/lib/forecast-handler.js
+++ b/server/lib/forecast-handler.js
@@ -292,6 +292,11 @@ function createForecastHandler(opts) {
           transferFeeCKwh: configFromYaml.transferFeeCKwh,
           greenhouseEnterC: tuning.geT,
           greenhouseExitC:  tuning.gxT,
+          // Tank-vs-greenhouse delta gates so the projection skips
+          // greenhouse_heating bars when the tank is too cold to drive
+          // the radiator (matches control-logic.js entry/exit checks).
+          greenhouseMinTankDeltaC:  tuning.gmD,
+          greenhouseExitTankDeltaC: tuning.gxD,
           emergencyEnterC:  tuning.ehE,
           emergencyExitC:   tuning.ehX,
           fitBucketCount: coeff.fitBucketCount || 0,

--- a/server/lib/sustain-forecast.js
+++ b/server/lib/sustain-forecast.js
@@ -36,6 +36,10 @@ const DEFAULT_CONFIG = {
   // defaults match shelly/control-logic.js when no user tuning is set.
   greenhouseEnterC:         10,   // controller enters heating when gh < this
   greenhouseExitC:          12,   // controller exits heating when gh > this
+  // Tank-side gates: enter requires tank_top > gh + gmD, stay requires
+  // tank_top >= gh + gxD (mirrors control-logic.js; tu.gmD / tu.gxD).
+  greenhouseMinTankDeltaC:  5,
+  greenhouseExitTankDeltaC: 2,
   // Emergency heating (space heater) thresholds — gh < emergencyEnterC turns
   // the space heater on; gh > emergencyExitC turns it off. The real device
   // is driven by tu.ehE / tu.ehX; defaults here mirror control-logic.js
@@ -224,16 +228,13 @@ function computeSustainForecast(opts) {
     const priceCKwh = typeof px.priceCKwh === 'number' ? px.priceCKwh : 10;
 
     // ── 1. Decide simulation mode for this hour ──
-    // Mirror the real device's hysteresis exactly:
-    //   greenhouse_heating  enters when gh < geT, exits when gh > gxT
-    //   emergency_heating   enters when gh < ehE, exits when gh > ehX
-    // Critically, the device triggers emergency_heating on the GREENHOUSE
-    // temperature (gh < ehE), NOT on tank state. Tank getting cold doesn't
-    // immediately turn the space heater on — the greenhouse first has to
-    // cool because the radiator stops being able to deliver useful heat.
-    // The radiator-effectiveness model below makes the greenhouse cool
-    // realistically when the tank gets too close to greenhouse temp, so
-    // this hits the right hour for backup.
+    // Mirror control-logic.js hysteresis: greenhouse_heating needs both
+    // gh < geT AND tank_top > gh + gmD; emergency triggers on gh < ehE
+    // alone. The tank gates suppress "heating" projection when the tank
+    // can't drive the radiator, so gh cools naturally and emergency
+    // fires at the right hour instead of behind painted heating bars.
+    const tankCanEnter   = tankTopC >  curGhTemp + cfg.greenhouseMinTankDeltaC;
+    const tankCanSustain = tankTopC >= curGhTemp + cfg.greenhouseExitTankDeltaC;
     if (curGhTemp < cfg.emergencyEnterC) {
       if (simMode !== 'emergency_heating' && hoursUntilBackupNeeded === null) {
         hoursUntilBackupNeeded = h;
@@ -241,10 +242,12 @@ function computeSustainForecast(opts) {
       simMode = 'emergency_heating';
     } else if (simMode === 'emergency_heating' && curGhTemp > cfg.emergencyExitC) {
       // Backup exits when gh > ehX (matches the device's exit hysteresis).
-      simMode = curGhTemp < cfg.greenhouseEnterC ? 'greenhouse_heating' : 'idle';
-    } else if (curGhTemp < cfg.greenhouseEnterC && simMode === 'idle') {
+      simMode = (curGhTemp < cfg.greenhouseEnterC && tankCanEnter)
+        ? 'greenhouse_heating' : 'idle';
+    } else if (curGhTemp < cfg.greenhouseEnterC && simMode === 'idle' && tankCanEnter) {
       simMode = 'greenhouse_heating';
-    } else if (curGhTemp > cfg.greenhouseExitC && simMode === 'greenhouse_heating') {
+    } else if (simMode === 'greenhouse_heating' &&
+               (curGhTemp > cfg.greenhouseExitC || !tankCanSustain)) {
       simMode = 'idle';
     }
 
@@ -272,9 +275,6 @@ function computeSustainForecast(opts) {
 
     if (simMode === 'greenhouse_heating') {
       modeForecast.push({ ts: hourDate, mode: simMode });
-    }
-
-    if (simMode === 'greenhouse_heating') {
       const radDeliveredW = Math.min(radPeakW, radUaWPerK * radDeltaT);
       tankDeltaJ -= radDeliveredW * SECONDS_PER_HOUR;
       // Greenhouse evolution: when the radiator's delivered W matches the

--- a/tests/sustain-forecast.test.js
+++ b/tests/sustain-forecast.test.js
@@ -547,6 +547,74 @@ describe('computeSustainForecast — emergency heater duty cycle', () => {
       'expected at least one emergency hour to project < 95% heater duty');
   });
 
+  // Regression: cold tank shouldn't project greenhouse_heating mode.
+  // Field report 2026-05-05: tank top 14.3 / bottom 11.8 (avg ~13), greenhouse
+  // 12.4, geT/gxT=13/14, ehE/ehX=11/13. Forecast painted 1–2 hours of yellow
+  // "heating (projected)" bars before the emergency took over. The real
+  // device requires tank_top > greenhouse + greenhouseMinTankDelta (default 5K)
+  // to enter, and tank_top >= greenhouse + greenhouseExitTankDelta (default 2K)
+  // to stay — so with that tank state the controller would never run the
+  // pump, and emergency would kick in directly when gh crossed ehE.
+  it('skips greenhouse_heating projection when tank is too cold to drive the radiator', () => {
+    const result = computeSustainForecast({
+      now:            Date.now(),
+      tankTop:        14.3, tankBottom: 11.8, greenhouseTemp: 12.4,
+      currentMode:    'idle',
+      emergencyRecentlyActive: true,
+      weather48h:     makeWeather48h({ temperature: 6, radiationGlobal: 0 }),
+      prices48h:      makePrices48h(10),
+      coefficients:   {},
+      config: {
+        spaceHeaterKw: 1, transferFeeCKwh: 5,
+        greenhouseEnterC: 13, greenhouseExitC: 14,
+        emergencyEnterC: 11, emergencyExitC: 13,
+        greenhouseMinTankDeltaC: 5, greenhouseExitTankDeltaC: 2,
+        greenhouseLossWPerK: 120,
+      },
+    });
+    const heatingEntries = (result.modeForecast || []).filter(function (e) {
+      return e.mode === 'greenhouse_heating';
+    });
+    assert.equal(heatingEntries.length, 0,
+      'expected no greenhouse_heating projection with tank avg 13°C and gh 12.4°C; got ' +
+        heatingEntries.length + ' entries: ' +
+        JSON.stringify(heatingEntries.slice(0, 3)));
+    // And emergency_heating must take over (gh will drift below ehE without
+    // the radiator running).
+    const emergencyEntries = (result.modeForecast || []).filter(function (e) {
+      return e.mode === 'emergency_heating';
+    });
+    assert.ok(emergencyEntries.length > 0,
+      'expected emergency_heating to cover the cold-tank shortfall; got 0 entries');
+  });
+
+  // Once the tank is hot enough to deliver useful radiator power the
+  // forecast must STILL project greenhouse_heating — the gating only
+  // suppresses the mode when the tank-greenhouse delta is below the
+  // device's entry threshold.
+  it('projects greenhouse_heating when tank is hot enough', () => {
+    const result = computeSustainForecast({
+      now:            Date.now(),
+      tankTop:        25, tankBottom: 22, greenhouseTemp: 12,
+      currentMode:    'idle',
+      weather48h:     makeWeather48h({ temperature: 4, radiationGlobal: 0 }),
+      prices48h:      makePrices48h(10),
+      coefficients:   {},
+      config: {
+        spaceHeaterKw: 1, transferFeeCKwh: 5,
+        greenhouseEnterC: 13, greenhouseExitC: 14,
+        emergencyEnterC: 11, emergencyExitC: 13,
+        greenhouseMinTankDeltaC: 5, greenhouseExitTankDeltaC: 2,
+        greenhouseLossWPerK: 120,
+      },
+    });
+    const heatingEntries = (result.modeForecast || []).filter(function (e) {
+      return e.mode === 'greenhouse_heating';
+    });
+    assert.ok(heatingEntries.length > 0,
+      'expected at least one greenhouse_heating projection with hot tank; got 0');
+  });
+
   it('zero heater kWh when outdoor is warmer than the target', () => {
     // Outdoor 15 > target 12 → no heat needed even though gh starts cold.
     const result = computeSustainForecast({


### PR DESCRIPTION
The simulator picked greenhouse_heating purely on greenhouse temperature
crossing geT, ignoring whether the tank could actually drive the
radiator. With tank avg ~13 °C and greenhouse 12.4 °C the device would
in fact go straight to emergency, but the projection painted 1–2 hours
of yellow "heating" bars first.

Mirror control-logic.js by requiring tank_top > gh + greenhouseMinTankDelta
to enter and tank_top >= gh + greenhouseExitTankDelta to stay. Thread
tu.gmD / tu.gxD through forecast-handler so live tunings are honored.

https://claude.ai/code/session_01X8oitNctrQ4WRFKcVpnGKe