### PR TITLE
logs: surface current sensors + fix forecast hourly join

### DIFF
--- a/playground/js/main/logs-clipboard.js
+++ b/playground/js/main/logs-clipboard.js
@@ -334,6 +334,18 @@ function appendControllerState(lines) {
 
   const flags = (result && result.flags) || {};
   lines.push('Mode:               ' + ((result && result.mode) || 'idle'));
+  // Snapshot what the controller is actually seeing right now. Mirrors
+  // the transition-log "sensors:" row format so a reader can compare
+  // current values against the values at the most recent transition
+  // without skimming the 24 h history table.
+  if (result && result.temps) {
+    const t = result.temps;
+    const fmt = (v) => (typeof v === 'number' ? v.toFixed(1) + '°C' : '—');
+    lines.push('Current sensors:    collector=' + fmt(t.collector) +
+               ' tank=' + fmt(t.tank_top) + '/' + fmt(t.tank_bottom) +
+               ' greenhouse=' + fmt(t.greenhouse) +
+               ' outdoor=' + fmt(t.outdoor));
+  }
   // Live evaluator reason — refreshed every tick, distinct from the
   // transition-tied reason on transition log rows. Surfaces the same
   // sentence the mode-card status line shows ("Greenhouse still cold")
@@ -403,6 +415,25 @@ function indexByIso(rows, key) {
   return out;
 }
 
+// Find the row in `rows` whose ISO `key` is closest to `targetIso`, within
+// `maxDeltaMs`. Returns null when nothing is in range. Used to join
+// modeForecast (timestamps at `now + h*3600s`, e.g. 09:21:08.459Z) against
+// weather rows aligned to the hour boundary (09:00:00.000Z) — the strict-
+// equality `indexByIso` lookup misses every hour in that case.
+function nearestRow(rows, targetIso, key, maxDeltaMs) {
+  if (!Array.isArray(rows) || rows.length === 0) return null;
+  const target = new Date(targetIso).getTime();
+  let best = null;
+  let bestDelta = Infinity;
+  for (let i = 0; i < rows.length; i++) {
+    const ts = rows[i] && rows[i][key];
+    if (typeof ts !== 'string') continue;
+    const delta = Math.abs(new Date(ts).getTime() - target);
+    if (delta < bestDelta) { bestDelta = delta; best = rows[i]; }
+  }
+  return bestDelta <= maxDeltaMs ? best : null;
+}
+
 function appendForecast(lines) {
   lines.push('--- Forecast (Next 48 h) ---');
   if (!forecastData || !forecastData.forecast) {
@@ -452,10 +483,14 @@ function appendForecast(lines) {
   // mode list doesn't, so iterating modeForecast is the right axis.
   const modes = Array.isArray(fc.modeForecast) ? fc.modeForecast : [];
   if (modes.length) {
-    const wxByTs   = indexByIso(forecastData.weather, 'validAt');
-    const pxByTs   = indexByIso(forecastData.prices, 'validAt');
+    // Trajectory rows share their timestamps with modeForecast (built in
+    // the same loop), so exact-key indexing works. Weather/prices come
+    // from the database aligned to the hour boundary while modeForecast
+    // carries the request-time minute offset — match by nearest-within-
+    // 90 min instead.
     const tankByTs = indexByIso(fc.tankTrajectory, 'ts');
     const ghByTs   = indexByIso(fc.greenhouseTrajectory, 'ts');
+    const NEAREST_WINDOW_MS = 90 * 60 * 1000;
 
     lines.push('');
     lines.push('Hourly projection:');
@@ -463,8 +498,8 @@ function appendForecast(lines) {
     for (let i = 0; i < modes.length; i++) {
       const m = modes[i];
       const ts = m.ts;
-      const wx = wxByTs[ts] || {};
-      const px = pxByTs[ts] || {};
+      const wx = nearestRow(forecastData.weather, ts, 'validAt', NEAREST_WINDOW_MS) || {};
+      const px = nearestRow(forecastData.prices,  ts, 'validAt', NEAREST_WINDOW_MS) || {};
       const tk = tankByTs[ts] || {};
       const gh = ghByTs[ts] || {};
       lines.push(

--- a/tests/frontend/copy-logs.spec.js
+++ b/tests/frontend/copy-logs.spec.js
@@ -357,6 +357,9 @@ test.describe('Copy System Logs — live mode', () => {
     expect(text).toContain('Watchdogs snoozed:  none');
     expect(text).toMatch(/Mode bans \(wb\): {5}GH=[34]h\d{2}m/);
     expect(text).toContain('Config version:     42');
+    // Current sensor readings — answers "what does the controller see right
+    // now?" without forcing the reader to skim the 24 h history table.
+    expect(text).toContain('Current sensors:    collector=25.0°C tank=40.0°C/35.0°C greenhouse=18.0°C outdoor=10.0°C');
   });
 
   test('clipboard export renders config events (ea / wb) with friendly labels', async ({ page }) => {
@@ -521,6 +524,84 @@ test.describe('Copy System Logs — live mode', () => {
     expect(hour1Lines.some(l => l.includes('12.3') && l.includes('650') && l.includes('8.21') && l.includes('62.5') && l.includes('18.2'))).toBe(true);
     const hour2Lines = lines.filter(l => /\bgreenhouse_heating\b/.test(l));
     expect(hour2Lines.some(l => l.includes('0.45') && l.includes('11.8') && l.includes('61.5') && l.includes('17.8'))).toBe(true);
+  });
+
+  test('forecast hourly projection joins weather/price even when modeForecast ts is offset from hour boundary', async ({ page }) => {
+    // Real-world data: weather DB rows are aligned to the hour
+    // (12:00:00.000Z) while modeForecast timestamps come from
+    // `now + h*3600s` — the request-time minute offset survives the loop
+    // (12:21:08.459Z, 13:21:08.459Z, …). With strict ISO-equality joins
+    // every weather/price/trajectory column came out as "—" in the
+    // export and the projection was unusable for debugging. Match by
+    // nearest timestamp instead.
+    const generatedAt = '2026-05-05T08:21:08.459Z';
+    const modeTs0 = '2026-05-05T09:21:08.459Z';   // sub-hour offset
+    const modeTs1 = '2026-05-05T10:21:08.459Z';
+    const wxTs0   = '2026-05-05T09:00:00.000Z';   // hour-aligned
+    const wxTs1   = '2026-05-05T10:00:00.000Z';
+
+    const forecastPayload = {
+      generatedAt,
+      weather: [
+        { validAt: wxTs0, temperature: 7.4, radiationGlobal: 410, windSpeed: 2.1, precipitation: 0 },
+        { validAt: wxTs1, temperature: 8.2, radiationGlobal: 530, windSpeed: 2.8, precipitation: 0 },
+      ],
+      prices: [
+        { validAt: wxTs0, priceCKwh: 11.50, source: 'sahkotin' },
+        { validAt: wxTs1, priceCKwh: 12.75, source: 'sahkotin' },
+      ],
+      forecast: {
+        generatedAt,
+        horizonHours: 48,
+        hoursUntilBackupNeeded: 0,
+        electricKwh: 19.7,
+        electricCostEur: 2.52,
+        modelConfidence: 'high',
+        modeForecast: [
+          { ts: modeTs0, mode: 'greenhouse_heating' },
+          { ts: modeTs1, mode: 'emergency_heating', duty: 0.38 },
+        ],
+        tankTrajectory: [
+          { ts: modeTs0, top: 14.3, bottom: 11.8, avg: 13.05 },
+          { ts: modeTs1, top: 14.0, bottom: 11.5, avg: 12.75 },
+        ],
+        greenhouseTrajectory: [
+          { ts: modeTs0, temp: 12.4 },
+          { ts: modeTs1, temp: 11.7 },
+        ],
+      },
+    };
+
+    await installMockWs(page);
+    await mockHistoryApi(page);
+    await mockEventsApi(page, []);
+    await mockForecastApi(page, forecastPayload);
+
+    await page.goto('/playground/', { waitUntil: 'domcontentloaded' });
+    await expect(page.locator('#connection-dot')).toHaveClass(/connected/, { timeout: 5000 });
+    await expect(page.locator('#forecast-val-eur')).toHaveText('€2.52', { timeout: 5000 });
+    await waitForTestHook(page);
+
+    const text = await getClipboardText(page);
+    const lines = text.split('\n');
+
+    // Hour 1: greenhouse_heating row should carry weather (7.4°C, 410 W/m²),
+    // price (11.50 c), tank avg (13.0/13.1) and gh (12.4) — no "—" placeholders
+    // for the joined fields.
+    const hour1 = lines.find(l => l.includes('greenhouse_heating'));
+    expect(hour1).toBeTruthy();
+    expect(hour1).toMatch(/7\.4°C/);
+    expect(hour1).toMatch(/\b410\b/);
+    expect(hour1).toMatch(/11\.50c/);
+    expect(hour1).toMatch(/12\.4/);
+
+    // Hour 2: emergency_heating with duty 0.38, weather 8.2°C, price 12.75 c.
+    const hour2 = lines.find(l => l.includes('emergency_heating'));
+    expect(hour2).toBeTruthy();
+    expect(hour2).toMatch(/8\.2°C/);
+    expect(hour2).toMatch(/12\.75c/);
+    expect(hour2).toMatch(/0\.38/);
+    expect(hour2).toMatch(/11\.7/);
   });
 
   test('forecast section renders graceful fallback when forecast unavailable', async ({ page }) => {


### PR DESCRIPTION
## Summary

Two small fixes that came out of a recent live-debug session where the System Logs export was harder to read than it should have been:

- **Add `Current sensors:` line under `Mode`.** The export showed mode + flags but not the actual sensor values, so figuring out "what does the controller see right now?" required skimming the 24 h history table. Now mirrors the transition log's `sensors:` format (`collector=… tank=…/… greenhouse=… outdoor=…`) so the reader can compare current state against the most recent transition at a glance.
- **Fix the Hourly projection join so weather/price columns actually populate.** `modeForecast` timestamps are emitted as `now + h*3600s` and carry the request-time minute offset (e.g. `09:21:08.459Z`), but weather rows in the database are aligned to the hour boundary (`09:00:00.000Z`). The strict ISO-equality join missed every hour, so every weather/price/wind/precip cell rendered as `—`. Replaced with a nearest-within-90-min match, which is robust to either side rounding differently.

Both behaviours are guarded by frontend tests, including one that reproduces the exact pattern from the debug session (21-minute ts offset).

## Test plan

- [x] `npx playwright test tests/frontend/copy-logs.spec.js` — 17/17 pass (2 new)
- [x] `npm run lint` — clean
- [x] `npm run knip` — clean
- [x] `npm run check:file-size -- --strict` — within hard cap
- [x] `npm run check:assets -- --strict` — clean
- [x] `node --test 'tests/**/*.test.js'` — 1095/1097 pass (2 pre-existing skips)
- [x] `npx playwright test` — 288/288 pass

https://claude.ai/code/session_01X8oitNctrQ4WRFKcVpnGKe

---
_Generated by [Claude Code](https://claude.ai/code/session_01X8oitNctrQ4WRFKcVpnGKe)_