### PR TITLE
logs: add Tunings line + collapse forecast overlay rows

### DIFF
--- a/playground/js/main/logs-clipboard.js
+++ b/playground/js/main/logs-clipboard.js
@@ -191,6 +191,26 @@ function formatWatchdogEnabled(we) {
   return on.length ? on.join(', ') : 'none';
 }
 
+// Canonical render order — mirrors TUNING_FIELDS in device-config.js
+// (grouped greenhouse → emergency → fan-cool → safety). Hardcoded to
+// avoid an import cycle and pin the export's column order.
+const TUNING_DISPLAY_ORDER = ['geT', 'gxT', 'gmD', 'gxD', 'ehE', 'ehX', 'fcE', 'fcX', 'frT', 'ohT'];
+
+function formatTunings(tu) {
+  if (!tu) return '(firmware defaults)';
+  const parts = [];
+  const known = new Set(TUNING_DISPLAY_ORDER);
+  for (let i = 0; i < TUNING_DISPLAY_ORDER.length; i++) {
+    const k = TUNING_DISPLAY_ORDER[i];
+    if (typeof tu[k] === 'number') parts.push(k + '=' + tu[k]);
+  }
+  // Any future tunable shows up at the end before TUNING_DISPLAY_ORDER catches up.
+  Object.keys(tu).forEach(k => {
+    if (!known.has(k) && typeof tu[k] === 'number') parts.push(k + '=' + tu[k]);
+  });
+  return parts.length ? parts.join(' ') : '(firmware defaults)';
+}
+
 function formatWatchdogSnoozed(wz, nowSec) {
   const out = [];
   Object.keys(wz || {}).forEach(id => {
@@ -372,6 +392,10 @@ function appendControllerState(lines) {
   lines.push('Watchdogs enabled:  ' + formatWatchdogEnabled(snap.we));
   lines.push('Watchdogs snoozed:  ' + formatWatchdogSnoozed(snap.wz, nowSec));
   lines.push('Mode bans (wb):     ' + formatBanList(snap.wb, nowSec));
+  // User-tuned thresholds gate every mode decision; surfacing them here
+  // means a reader doesn't have to open the device-config UI to compare
+  // sensor values against the active hysteresis bounds.
+  lines.push('Tunings:            ' + formatTunings(snap.tu));
   lines.push('Config version:     ' + (typeof snap.v === 'number' ? snap.v : '(unknown)'));
   const heldLines = formatHeldLines(result && result.held, nowSec);
   if (heldLines.length) {
@@ -477,27 +501,48 @@ function appendForecast(lines) {
     }
   }
 
-  // Hourly projection — joins weather + price + projected mode + projected
-  // tank/greenhouse on the modeForecast timestamps (one row per forecast
-  // hour). The trajectory arrays have an extra leading "now" row that the
-  // mode list doesn't, so iterating modeForecast is the right axis.
+  // Hourly projection — joins weather + price + mode + trajectory on the
+  // modeForecast timestamps. The engine emits a separate solar_charging
+  // entry when charging overlays a pump mode, so multiple entries can
+  // share a ts; we collapse them into one row per hour with "+SC" in
+  // the Solar column when the overlay applies (pre-collapse the export
+  // emitted duplicate adjacent rows the reader had to pair manually).
   const modes = Array.isArray(fc.modeForecast) ? fc.modeForecast : [];
   if (modes.length) {
-    // Trajectory rows share their timestamps with modeForecast (built in
-    // the same loop), so exact-key indexing works. Weather/prices come
-    // from the database aligned to the hour boundary while modeForecast
-    // carries the request-time minute offset — match by nearest-within-
-    // 90 min instead.
+    // Trajectory rows share modeForecast timestamps (built in the same
+    // loop) so exact-key works; weather/prices are hour-aligned while
+    // modeForecast carries the request-time offset, so match by nearest.
     const tankByTs = indexByIso(fc.tankTrajectory, 'ts');
     const ghByTs   = indexByIso(fc.greenhouseTrajectory, 'ts');
     const NEAREST_WINDOW_MS = 90 * 60 * 1000;
 
-    lines.push('');
-    lines.push('Hourly projection:');
-    lines.push('Time                  TempOut    Rad   Wind  Precip   Price  Mode               Duty  TankAvg     GH');
+    // Group modeForecast entries by ts (first-seen order). Each group's
+    // primary is the pump mode if present, else the standalone solar.
+    const order = [];
+    const groups = {};
     for (let i = 0; i < modes.length; i++) {
       const m = modes[i];
       const ts = m.ts;
+      if (!groups[ts]) { groups[ts] = { ts, primary: null, hasSolar: false, duty: null }; order.push(ts); }
+      const g = groups[ts];
+      if (m.mode === 'solar_charging') {
+        if (g.primary === null) g.primary = 'solar_charging';
+        else g.hasSolar = true;
+      } else {
+        // A pump-mode entry overrides a previously-seen solar_charging
+        // primary (engine emits in either order; pump mode wins).
+        if (g.primary === 'solar_charging') g.hasSolar = true;
+        g.primary = m.mode || 'idle';
+        if (typeof m.duty === 'number') g.duty = m.duty;
+      }
+    }
+
+    lines.push('');
+    lines.push('Hourly projection:');
+    lines.push('Time                  TempOut    Rad   Wind  Precip   Price  Mode                Solar  Duty  TankAvg     GH');
+    for (let i = 0; i < order.length; i++) {
+      const g = groups[order[i]];
+      const ts = g.ts;
       const wx = nearestRow(forecastData.weather, ts, 'validAt', NEAREST_WINDOW_MS) || {};
       const px = nearestRow(forecastData.prices,  ts, 'validAt', NEAREST_WINDOW_MS) || {};
       const tk = tankByTs[ts] || {};
@@ -509,8 +554,9 @@ function appendForecast(lines) {
         fmtNum(wx.windSpeed, 1, 4) + '  ' +
         fmtNum(wx.precipitation, 1, 5) + '  ' +
         fmtNum(px.priceCKwh, 2, 6) + 'c  ' +
-        (m.mode || 'idle').padEnd(17) + '  ' +
-        (typeof m.duty === 'number' ? m.duty.toFixed(2) : '   —') + '  ' +
+        (g.primary || 'idle').padEnd(18) + '  ' +
+        (g.hasSolar ? '+SC  ' : '     ') + '  ' +
+        (typeof g.duty === 'number' ? g.duty.toFixed(2) : '   —') + '  ' +
         fmtNum(tk.avg, 1, 6) + '  ' +
         fmtNum(gh.temp, 1, 6)
       );

--- a/server/lib/anomaly-manager.js
+++ b/server/lib/anomaly-manager.js
@@ -97,6 +97,11 @@ function updateSnapshot(cfg) {
     we: cfg.we || {},
     wz: cfg.wz || {},
     wb: cfg.wb || {},
+    // Sparse map of user-tuned thresholds (geT/gxT/gmD/gxD/ehE/ehX/…).
+    // Mirrored so the System Logs export can render the active control
+    // thresholds — an operator comparing live sensor values against the
+    // hysteresis bounds the device is using needs them in one place.
+    tu: cfg.tu || {},
     v: typeof cfg.v === 'number' ? cfg.v : null,
   };
 }

--- a/tests/anomaly-manager.test.js
+++ b/tests/anomaly-manager.test.js
@@ -396,6 +396,7 @@ describe('anomaly-manager setEnabled / getState / getHistory', () => {
       we: { ggr: 1, sng: 1, scs: 1 },
       wz: { ggr: 1840003600 },
       wb: { GH: 1840014400 },
+      tu: { geT: 13, gxT: 14, ehE: 11, ehX: 13 },
       v: 42,
     });
 
@@ -407,5 +408,10 @@ describe('anomaly-manager setEnabled / getState / getHistory', () => {
     assert.deepStrictEqual(state.snapshot.we, { ggr: 1, sng: 1, scs: 1 });
     assert.deepStrictEqual(state.snapshot.wz, { ggr: 1840003600 });
     assert.deepStrictEqual(state.snapshot.wb, { GH: 1840014400 });
+    // tu (sparse user-tunable thresholds) is mirrored too — the System
+    // Logs export reads it to render the active control thresholds, which
+    // an operator needs to compare sensor values against to figure out
+    // why the device is in its current mode.
+    assert.deepStrictEqual(state.snapshot.tu, { geT: 13, gxT: 14, ehE: 11, ehX: 13 });
   });
 });

--- a/tests/frontend/copy-logs.spec.js
+++ b/tests/frontend/copy-logs.spec.js
@@ -337,6 +337,7 @@ test.describe('Copy System Logs — live mode', () => {
       we: { sng: 1, scs: 1, ggr: 1 },
       wz: {},
       wb: { GH: banUntil },
+      tu: { geT: 13, gxT: 14, ehE: 11, ehX: 13 },
       v: 42,
     });
 
@@ -360,6 +361,29 @@ test.describe('Copy System Logs — live mode', () => {
     // Current sensor readings — answers "what does the controller see right
     // now?" without forcing the reader to skim the 24 h history table.
     expect(text).toContain('Current sensors:    collector=25.0°C tank=40.0°C/35.0°C greenhouse=18.0°C outdoor=10.0°C');
+    // Tunings line — compact list of user-tuned thresholds (sparse: only
+    // values the operator has overridden, in canonical order).
+    expect(text).toContain('Tunings:            geT=13 gxT=14 ehE=11 ehX=13');
+  });
+
+  test('Tunings line shows "(defaults)" when no thresholds are tuned', async ({ page }) => {
+    await installMockWs(page);
+    await mockHistoryApi(page);
+    await mockEventsApi(page, []);
+    await mockWatchdogStateApi(page, {
+      ce: true, ea: 31, mo: null,
+      we: {}, wz: {}, wb: {}, tu: {}, v: 1,
+    });
+
+    await page.goto('/playground/', { waitUntil: 'domcontentloaded' });
+    await expect(page.locator('#connection-dot')).toHaveClass(/connected/, { timeout: 5000 });
+    await waitForTestHook(page);
+
+    const text = await getClipboardText(page);
+    // Empty tu → operator hasn't overridden anything → firmware defaults
+    // are in effect. Rendered explicitly so the line never silently
+    // disappears (a missing line reads as "feature broken, not deployed").
+    expect(text).toContain('Tunings:            (firmware defaults)');
   });
 
   test('clipboard export renders config events (ea / wb) with friendly labels', async ({ page }) => {
@@ -524,6 +548,117 @@ test.describe('Copy System Logs — live mode', () => {
     expect(hour1Lines.some(l => l.includes('12.3') && l.includes('650') && l.includes('8.21') && l.includes('62.5') && l.includes('18.2'))).toBe(true);
     const hour2Lines = lines.filter(l => /\bgreenhouse_heating\b/.test(l));
     expect(hour2Lines.some(l => l.includes('0.45') && l.includes('11.8') && l.includes('61.5') && l.includes('17.8'))).toBe(true);
+  });
+
+  test('forecast hourly projection collapses overlay rows into a single line per hour', async ({ page }) => {
+    // The engine emits a separate modeForecast entry when solar_charging
+    // overlays a pump mode (greenhouse_heating, emergency_heating). Pre-
+    // reshape the export rendered two rows with the same timestamp:
+    //
+    //   2026-05-05 10:21:08  …  greenhouse_heating
+    //   2026-05-05 10:21:08  …  solar_charging
+    //
+    // which forced the reader to mentally pair adjacent rows by timestamp.
+    // After reshape the export emits one row per hour with the pump mode
+    // in the Mode column and "+SC" in a dedicated Solar column when the
+    // overlay applies.
+    const generatedAt = '2026-05-05T07:00:00.000Z';
+    const hour0 = '2026-05-05T08:00:00.000Z';   // greenhouse_heating + solar overlay
+    const hour1 = '2026-05-05T09:00:00.000Z';   // emergency_heating  + solar overlay
+    const hour2 = '2026-05-05T10:00:00.000Z';   // solar_charging only (no pump mode)
+    const hour3 = '2026-05-05T11:00:00.000Z';   // greenhouse_heating only (no overlay)
+
+    const forecastPayload = {
+      generatedAt,
+      weather: [
+        { validAt: hour0, temperature: 5, radiationGlobal: 200, windSpeed: 1, precipitation: 0 },
+        { validAt: hour1, temperature: 6, radiationGlobal: 300, windSpeed: 1, precipitation: 0 },
+        { validAt: hour2, temperature: 7, radiationGlobal: 500, windSpeed: 1, precipitation: 0 },
+        { validAt: hour3, temperature: 8, radiationGlobal: 100, windSpeed: 1, precipitation: 0 },
+      ],
+      prices: [
+        { validAt: hour0, priceCKwh: 10, source: 'sahkotin' },
+        { validAt: hour1, priceCKwh: 11, source: 'sahkotin' },
+        { validAt: hour2, priceCKwh: 12, source: 'sahkotin' },
+        { validAt: hour3, priceCKwh: 13, source: 'sahkotin' },
+      ],
+      forecast: {
+        generatedAt, horizonHours: 48,
+        hoursUntilBackupNeeded: 1, electricKwh: 1.5, electricCostEur: 0.30,
+        modelConfidence: 'medium',
+        modeForecast: [
+          { ts: hour0, mode: 'greenhouse_heating' },
+          { ts: hour0, mode: 'solar_charging' },
+          { ts: hour1, mode: 'emergency_heating', duty: 0.55 },
+          { ts: hour1, mode: 'solar_charging' },
+          { ts: hour2, mode: 'solar_charging' },
+          { ts: hour3, mode: 'greenhouse_heating' },
+        ],
+        tankTrajectory: [
+          { ts: hour0, top: 30, bottom: 28, avg: 29 },
+          { ts: hour1, top: 28, bottom: 26, avg: 27 },
+          { ts: hour2, top: 32, bottom: 29, avg: 30.5 },
+          { ts: hour3, top: 31, bottom: 28, avg: 29.5 },
+        ],
+        greenhouseTrajectory: [
+          { ts: hour0, temp: 12 }, { ts: hour1, temp: 11 },
+          { ts: hour2, temp: 13 }, { ts: hour3, temp: 12 },
+        ],
+      },
+    };
+
+    await installMockWs(page);
+    await mockHistoryApi(page);
+    await mockEventsApi(page, []);
+    await mockForecastApi(page, forecastPayload);
+
+    await page.goto('/playground/', { waitUntil: 'domcontentloaded' });
+    await expect(page.locator('#connection-dot')).toHaveClass(/connected/, { timeout: 5000 });
+    await expect(page.locator('#forecast-val-eur')).toHaveText('€0.30', { timeout: 5000 });
+    await waitForTestHook(page);
+
+    const text = await getClipboardText(page);
+    const lines = text.split('\n');
+
+    // Header should have a dedicated Solar column.
+    const headerIdx = lines.findIndex(l => l.includes('Hourly projection:'));
+    expect(headerIdx).toBeGreaterThan(-1);
+    expect(lines[headerIdx + 1]).toMatch(/Mode\s+Solar\s+Duty/);
+
+    // Find rows by tank-avg (unique per hour) so timestamp formatting
+    // doesn't matter.
+    const ghHeatRow      = lines.find(l => l.includes('greenhouse_heating') && l.includes('29.0'));
+    const emergencyRow   = lines.find(l => l.includes('emergency_heating')  && l.includes('27.0'));
+    const solarOnlyRow   = lines.find(l => l.includes('solar_charging')     && l.includes('30.5'));
+    const ghHeatNoOvl    = lines.find(l => l.includes('greenhouse_heating') && l.includes('29.5'));
+
+    expect(ghHeatRow).toBeTruthy();
+    expect(emergencyRow).toBeTruthy();
+    expect(solarOnlyRow).toBeTruthy();
+    expect(ghHeatNoOvl).toBeTruthy();
+
+    // Hours with overlay carry "+SC"; the solar-only hour and the
+    // heating-without-overlay hour do NOT (the overlay marker exists to
+    // distinguish concurrent solar charging from the primary mode).
+    expect(ghHeatRow).toMatch(/\+SC/);
+    expect(emergencyRow).toMatch(/\+SC/);
+    expect(solarOnlyRow).not.toMatch(/\+SC/);
+    expect(ghHeatNoOvl).not.toMatch(/\+SC/);
+
+    // Emergency row keeps its duty fraction in the Duty column.
+    expect(emergencyRow).toMatch(/0\.55/);
+
+    // Critically: no two projection rows share the same wall-clock
+    // timestamp (the duplicate-timestamp pattern is what the reshape
+    // exists to remove).
+    const projStart = headerIdx + 2;
+    const projLines = [];
+    for (let i = projStart; i < lines.length && lines[i] !== ''; i++) projLines.push(lines[i]);
+    const tsCol = projLines
+      .map(l => (l.match(/^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})/) || [])[1])
+      .filter(Boolean);
+    const dupes = tsCol.filter((t, i) => tsCol.indexOf(t) !== i);
+    expect(dupes).toEqual([]);
   });
 
   test('forecast hourly projection joins weather/price even when modeForecast ts is offset from hour boundary', async ({ page }) => {


### PR DESCRIPTION
## Summary

Two follow-ups to #155 that came out of the same debug session:

**Tunings line in Controller State.** User-tuned thresholds gate every mode decision, so the export now shows them at a glance:

```
Tunings:            geT=13 gxT=14 ehE=11 ehX=13
```

Sparse (only fields the operator has overridden), falling back to `(firmware defaults)` when nothing is tuned. Required adding `tu` to the anomaly-manager snapshot the playground subscribes to.

**Collapse forecast overlay rows.** The engine emits a separate `solar_charging` entry whenever charging overlays a pump mode, so the hourly projection rendered two rows with the same wall-clock timestamp:

```
2026-05-05 10:21:08  …  greenhouse_heating
2026-05-05 10:21:08  …  solar_charging
```

Reshaped to one row per hour with the pump mode in the Mode column and `+SC` in a new Solar overlay column when the overlay applies. The header gains a `Solar` column between `Mode` and `Duty`.

## Test plan

- [x] `npx playwright test tests/frontend/copy-logs.spec.js` — 19/19 pass (2 new)
- [x] `node --test tests/anomaly-manager.test.js` — 17/17 pass (existing test extended for `tu`)
- [x] `npm run lint` — clean
- [x] `npm run knip` — clean
- [x] `npm run check:file-size -- --strict` — within hard cap
- [x] `npm run check:assets -- --strict` — clean
- [x] `node --test 'tests/**/*.test.js'` — 1095/1097 pass (2 pre-existing skips)
- [x] `npx playwright test` — 290/290 pass

https://claude.ai/code/session_01X8oitNctrQ4WRFKcVpnGKe

---
_Generated by [Claude Code](https://claude.ai/code/session_01X8oitNctrQ4WRFKcVpnGKe)_