### PR TITLE
sync: periodic resync timer + fix forecast for_hour semantics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,14 @@ When adding a new mutating endpoint, add the same guard.
 
 The original bug (PR #64): aggregate was a MATERIALIZED VIEW refreshed from raw, so each refresh silently discarded everything older than 48 h and long-range graphs only ever showed ~2 days.
 
+### Data freshness in long-lived PWA sessions
+
+The PWA stays open for days; users (especially on mobile, where Add-to-Home turns it into a long-lived window) won't reload between visits. Every full-stack feature whose backend data updates over time MUST refresh on the client without a page reload, and the System Logs export MUST reflect the freshest data when the user copies it.
+
+The data-sync framework in `playground/js/sync/` handles `visibilitychange` / `pageshow` / `online` events, and runs a periodic resync timer (5 min by default — every active source's `fetch(signal)` re-runs in parallel and `applyToStore` writes the result). Both knobs together cover (a) the "phone resumed after being asleep all night" case and (b) the "tab has been visible the whole time but the operator hasn't interacted" case. Visibility alone is NOT sufficient — it doesn't fire when the tab was already in the foreground.
+
+When you add a new full-stack feature: register a source in the sync framework (see `playground/js/sync/README.md`). No new feature-local timers — the coordinator handles cadence centrally.
+
 ## Testing Policy
 
 **Bug fixes and behavior changes follow test-first:**

--- a/playground/js/sync/coordinator.js
+++ b/playground/js/sync/coordinator.js
@@ -37,10 +37,18 @@
 import { _registeredSources } from './registry.js';
 import { store } from '../app-state.js';
 
+// Default cadence for the periodic resync timer. 5 min strikes a
+// reasonable balance for the long-lived PWA case: short enough that
+// data on screen stays close to the server's view, long enough that an
+// idle tab doesn't waste battery. Server-side caches (forecast = 60 s,
+// history endpoints = unlimited) absorb the request rate.
+const DEFAULT_PERIODIC_MS = 5 * 60 * 1000;
+
 let currentController = null;
 let _onResyncStart = function () {};
 let _onResyncComplete = function () {};
 let _listeners = null;
+let _periodicHandle = null;
 
 export function initSyncCoordinator(opts) {
   const { onResyncStart, onResyncComplete } = opts || {};
@@ -67,6 +75,28 @@ export function initSyncCoordinator(opts) {
   window.addEventListener('online', onOnline);
 
   _listeners = { onVisibility, onPageShow, onOnline };
+
+  // Periodic timer. Takes opts.periodicIntervalMs if supplied (lets
+  // tests force a tighter cadence and tests-or-config disable by
+  // passing 0); production gets the default.
+  const periodicMs = (opts && typeof opts.periodicIntervalMs === 'number')
+    ? opts.periodicIntervalMs : DEFAULT_PERIODIC_MS;
+  if (periodicMs > 0) startPeriodicResync(periodicMs);
+}
+
+export function startPeriodicResync(intervalMs) {
+  stopPeriodicResync();
+  const ms = (typeof intervalMs === 'number' && intervalMs > 0) ? intervalMs : DEFAULT_PERIODIC_MS;
+  _periodicHandle = setInterval(function () {
+    triggerResync('periodic');
+  }, ms);
+}
+
+export function stopPeriodicResync() {
+  if (_periodicHandle !== null) {
+    clearInterval(_periodicHandle);
+    _periodicHandle = null;
+  }
 }
 
 function triggerResync(reason) {
@@ -128,6 +158,7 @@ function finishResync(controller) {
 function _resetForTests() {
   if (currentController) currentController.abort();
   currentController = null;
+  stopPeriodicResync();
   store.set('syncing', false);
   store.set('syncReason', null);
   if (_listeners) {
@@ -147,4 +178,6 @@ if (typeof window !== 'undefined') {
   window.__sync = window.__sync || {};
   window.__sync.triggerResync = triggerResync;
   window.__sync._resetForTests = _resetForTests;
+  window.__sync._startPeriodicResync = startPeriodicResync;
+  window.__sync._stopPeriodicResync = stopPeriodicResync;
 }

--- a/server/lib/forecast/forecast-predictions.js
+++ b/server/lib/forecast/forecast-predictions.js
@@ -73,6 +73,14 @@ function create(opts) {
       ? fc.tankTrajectory[1] : null;
     const gh   = Array.isArray(fc.greenhouseTrajectory) && fc.greenhouseTrajectory.length > 1
       ? fc.greenhouseTrajectory[1] : null;
+    // for_hour names the wall clock when the predicted state will
+    // actually exist — i.e. trajectory[1].ts (one hour after generation).
+    // Pre-fix this carried modeForecast[0].ts (= generation time), which
+    // forced the operator to mentally add an hour to know which actual
+    // sensor reading to compare against. Falls back to firstTs if the
+    // trajectory is shorter than expected (engine bug / incomplete data),
+    // so we never write a NULL into the PK column.
+    const forHourTs = (tank && tank.ts) ? tank.ts : firstTs;
     // Weather rows are hour-aligned but firstTs carries a sub-hour offset
     // (now + h*3600s). Pick the closest row within ±90 min — same window
     // the export uses, same justification.
@@ -84,7 +92,7 @@ function create(opts) {
     // been wired to attach it (older tests, etc.).
     const tu = response.tu && typeof response.tu === 'object' ? response.tu : null;
     return {
-      forHour:        firstTs,
+      forHour:        forHourTs,
       generatedAt:    response.generatedAt || new Date().toISOString(),
       mode:           primary || 'idle',
       hasSolarOverlay: hasSolar,

--- a/tests/forecast-predictions.test.js
+++ b/tests/forecast-predictions.test.js
@@ -51,9 +51,16 @@ function makeForecastResponse(opts) {
 describe('forecast-predictions._buildRow', () => {
   const svc = forecastPredictions.create({ pool: null, log: makeLog() });
 
-  it('extracts the first-hour prediction with end-of-hour trajectory anchor', () => {
+  it('sets forHour to the END of the predicted hour (= time the actual reading will be taken)', () => {
+    // PRE-FIX: forHour was modeForecast[0].ts (= generation time). That
+    // made the export show the same timestamp in both "Predicted at" and
+    // "For hour" columns and forced the operator to mentally add 1 h to
+    // know which actual reading to compare against. forHour should be
+    // trajectory[1].ts — the wall clock when the predicted state will
+    // actually exist, so a row reads "for hour HOUR1, predicted X" and
+    // the operator can directly look up the sensor value at HOUR1.
     const row = svc._buildRow(makeForecastResponse());
-    assert.equal(row.forHour, HOUR0);
+    assert.equal(row.forHour, HOUR1);
     assert.equal(row.mode, 'greenhouse_heating');
     assert.equal(row.hasSolarOverlay, false);
     assert.equal(row.duty, null);
@@ -173,12 +180,15 @@ describe('forecast-predictions.captureFromForecast', () => {
       assert.ok(captured.sql.includes('ON CONFLICT (for_hour) DO UPDATE'));
       assert.ok(captured.sql.includes('algorithm_version'));
       assert.ok(captured.sql.includes('tu'));
-      assert.equal(captured.params[0], HOUR0);   // for_hour
+      // for_hour points at the END of the predicted hour (the wall-
+      // clock when the predicted state will actually exist), so a
+      // capture at HOUR0 carries for_hour=HOUR1.
+      assert.equal(captured.params[0], HOUR1);
       assert.equal(captured.params[2], 'greenhouse_heating'); // mode
       assert.equal(captured.params[10], 'cafef00d');          // algorithm_version
       // tu is JSON.stringified for the JSONB column.
       assert.deepStrictEqual(JSON.parse(captured.params[11]), tu);
-      assert.equal(row.forHour, HOUR0);
+      assert.equal(row.forHour, HOUR1);
       done();
     });
   });

--- a/tests/frontend/sync-registry.spec.js
+++ b/tests/frontend/sync-registry.spec.js
@@ -207,4 +207,35 @@ test.describe('sync registry + coordinator contract', () => {
     expect(result.bad).toBe(0);
     expect(result.good).toBe(1);
   });
+
+  test('startPeriodicResync re-runs sources at the configured interval', async ({ page }) => {
+    // Long-lived PWA sessions: visibility/focus/network events alone
+    // miss the "tab was foreground the whole time" case. The coordinator
+    // therefore offers a periodic timer; each tick calls triggerResync,
+    // which in turn invokes every active source's fetch.
+    const result = await page.evaluate(async () => {
+      let fetchCalls = 0;
+      window.__sync.registerDataSource({
+        id: 'periodic-src',
+        isActive: () => true,
+        fetch: () => { fetchCalls++; return Promise.resolve('ok'); },
+        applyToStore: () => {},
+      });
+      // 30 ms cadence: tight for the test, well above setInterval's
+      // ~4 ms minimum so we get distinct ticks.
+      window.__sync._startPeriodicResync(30);
+      // Wait long enough for ≥3 ticks plus the in-flight resync to settle.
+      await new Promise(r => setTimeout(r, 150));
+      const duringTick = fetchCalls;
+      window.__sync._stopPeriodicResync();
+      // Wait again — should NOT keep firing after stop.
+      await new Promise(r => setTimeout(r, 150));
+      const afterStop = fetchCalls;
+      return { duringTick, afterStop };
+    });
+    expect(result.duringTick).toBeGreaterThanOrEqual(3);
+    // After stop, no new ticks (small tolerance for any in-flight resync
+    // that may have already started just before stop fired).
+    expect(result.afterStop).toBeLessThanOrEqual(result.duringTick + 1);
+  });
 });


### PR DESCRIPTION
## Summary

Three changes addressing what we found in the latest System Logs export:

**Periodic resync timer in the data-sync coordinator.** A 5-min interval re-runs every active source's `fetch(signal)` alongside the existing visibility/pageshow/online triggers. Catches the "tab was foreground the whole time but the operator hasn't interacted" case — observed in the wild as a forecast in the export that was 2 h 13 min stale even though the page was open and visible. Server-side caches (forecast 60 s, history endpoints unbounded) absorb the request rate.

**Durable rule in CLAUDE.md.** Under Critical Rules → "Data freshness in long-lived PWA sessions": new full-stack features whose backend data updates over time MUST refresh on the client without a reload, and the System Logs export MUST reflect the freshest data when copied. Visibility alone is not sufficient. The data-sync framework handles cadence centrally — no feature-local timers.

**Fix `for_hour` semantics in captured predictions.** Was set to `modeForecast[0].ts` (= generation time), so the export rendered identical timestamps in "For hour" and "Predicted at" columns and forced the operator to mentally add 1 h to know which actual sensor reading to compare against. Now uses `trajectory[1].ts` — the wall clock when the predicted state will actually exist. A row reads "for hour 16:30, predicted X" and the operator can directly look up the sensor value at 16:30.

### Note on existing rows

Pre-fix captures already in prod have `for_hour` off-by-one. New captures with the same wall-clock `for_hour` overwrite via `ON CONFLICT DO UPDATE`; the few orphan old rows decay naturally over the next ~48 h, or can be cleared once with `DELETE FROM forecast_predictions;` for a clean slate.

## Test plan

- [x] `node --test tests/forecast-predictions.test.js` — 18 tests pass (existing tests updated to assert corrected `for_hour`)
- [x] `npx playwright test tests/frontend/sync-registry.spec.js` — 6 tests pass (1 new for periodic resync)
- [x] `npm run lint` — clean
- [x] `npm run knip` — clean
- [x] `npm run check:file-size -- --strict` — within hard cap
- [x] `npm run check:assets -- --strict` — clean
- [x] `node --test 'tests/**/*.test.js'` — 1118/1120 pass (2 pre-existing skips)
- [x] `npx playwright test` — 295/295 pass

https://claude.ai/code/session_01X8oitNctrQ4WRFKcVpnGKe

---
_Generated by [Claude Code](https://claude.ai/code/session_01X8oitNctrQ4WRFKcVpnGKe)_