### PR TITLE
logs: surface space-heater overlay in System Logs, graph, and export

### DIFF
--- a/playground/js/main/live-history.js
+++ b/playground/js/main/live-history.js
@@ -18,7 +18,7 @@ import { timeSeriesStore, trendStore } from './state.js';
 import { drawHistoryGraph } from './history-graph.js';
 import { rerenderWithHistoryFallback } from './display-update.js';
 import { registerDataSource } from '../sync/registry.js';
-import { populateModeEvents } from './mode-events.js';
+import { populateModeEvents, populateSpaceHeaterEvents } from './mode-events.js';
 
 const RANGE_MAP = {
   3600: '1h', 21600: '6h', 43200: '12h', 86400: '24h',
@@ -94,6 +94,15 @@ function loadLiveHistoryIntoStore(data) {
     ts: typeof e.ts === 'number' ? Math.floor(e.ts / 1000) : e.ts,
   }));
   populateModeEvents(eventsSec);
+  // Space-heater on/off transitions feed the EMERGENCY band overlay
+  // and the clipboard SH annotation. The server returns them on every
+  // /api/history call (with leading edge), so the band is correct from
+  // the first paint without waiting for a separate fetch.
+  const rawShEvents = (data && Array.isArray(data.spaceHeaterEvents)) ? data.spaceHeaterEvents : [];
+  const shEventsSec = rawShEvents.map(e => Object.assign({}, e, {
+    ts: typeof e.ts === 'number' ? Math.floor(e.ts / 1000) : e.ts,
+  }));
+  populateSpaceHeaterEvents(shEventsSec);
   if (!data || !Array.isArray(data.points)) return;
 
   for (let i = 0; i < data.points.length; i++) {

--- a/playground/js/main/logs-clipboard.js
+++ b/playground/js/main/logs-clipboard.js
@@ -5,12 +5,12 @@
 
 import { store } from '../app-state.js';
 import {
-  formatTimeOfDay, formatFullTimeHelsinki, formatConfigEntry,
-  formatConfigSourceLabel, formatReasonLabel, formatOverlayEntry,
+  formatTimeOfDay, formatFullTimeHelsinki, formatConfigEntry, formatConfigSourceLabel,
+  formatReasonLabel, formatOverlayEntry, formatActuatorEntry,
 } from './time-format.js';
 import { model, params, MODE_INFO, timeSeriesStore, transitionLog, lastLiveFrame, forecastData } from './state.js';
 import { getWatchdogSnapshot } from './watchdog-ui.js';
-import { modeAt } from './mode-events.js';
+import { modeAt, spaceHeaterAt } from './mode-events.js';
 import { appendPredictionHistory } from './logs-predictions.js';
 import { appendTuningsHistory } from './logs-tunings-history.js';
 
@@ -51,19 +51,16 @@ function buildLogsClipboardText() {
 
   if (isLive) {
     lines.push('--- Sensor Readings (24h, 20-min resolution) ---');
-    lines.push('Time                  Collector  Tank Top  Tank Btm  Greenhouse  Outdoor  Mode');
+    lines.push('Time                  Collector  Tank Top  Tank Btm  Greenhouse  Outdoor  Mode                SH');
     const readings = downsampleHistory(1200);
     for (let i = 0; i < readings.length; i++) {
       const r = readings[i];
-      lines.push(
-        formatFullTimeHelsinki(r.time * 1000) + '  ' +
-        fmtTempCol(r.t_collector) + '  ' +
-        fmtTempCol(r.t_tank_top) + '  ' +
-        fmtTempCol(r.t_tank_bottom) + '  ' +
-        fmtTempCol(r.t_greenhouse) + '  ' +
+      lines.push(formatFullTimeHelsinki(r.time * 1000) + '  ' +
+        fmtTempCol(r.t_collector) + '  ' + fmtTempCol(r.t_tank_top) + '  ' +
+        fmtTempCol(r.t_tank_bottom) + '  ' + fmtTempCol(r.t_greenhouse) + '  ' +
         fmtTempCol(r.t_outdoor) + '  ' +
-        (r.mode || 'idle')
-      );
+        (r.mode || 'idle').padEnd(18) + '  ' +
+        (r.space_heater === 'on' ? 'on' : '  '));
     }
     if (readings.length === 0) lines.push('(no history data available)');
   } else {
@@ -127,9 +124,11 @@ function buildLogsClipboardText() {
         continue;
       }
 
-      if (t.eventType === 'overlay') {
-        const fmt = formatOverlayEntry(t);
-        lines.push(timeLabel + '  Overlay  ' + fmt.title + '  [overlay: ' + (t.overlayId || 'unknown') + ']');
+      if (t.eventType === 'overlay' || t.eventType === 'actuator') {
+        const ov = t.eventType === 'overlay';
+        const fmt = ov ? formatOverlayEntry(t) : formatActuatorEntry(t);
+        const id = (ov ? t.overlayId : t.actuatorId) || 'unknown';
+        lines.push(timeLabel + '  ' + (ov ? 'Overlay' : 'Actuator') + '  ' + fmt.title + '  [' + t.eventType + ': ' + id + ']');
         lines.push('    detail: ' + fmt.desc);
         continue;
       }
@@ -589,6 +588,7 @@ function downsampleHistory(intervalSec) {
         t_greenhouse: v.t_greenhouse,
         t_outdoor: v.t_outdoor,
         mode: modeAt(t),
+        space_heater: spaceHeaterAt(t),
       });
       nextBucket = t + intervalSec;
     }

--- a/playground/js/main/logs.js
+++ b/playground/js/main/logs.js
@@ -8,24 +8,30 @@ import { registerDataSource } from '../sync/registry.js';
 import {
   formatClockTime, formatCauseLabel, formatReasonLabel, formatSensorsLine,
   escapeHtml, formatTimeOfDay, formatConfigEntry, formatOverlayEntry,
+  formatActuatorEntry,
 } from './time-format.js';
 import { MODE_INFO, transitionLog } from './state.js';
-import { appendModeEvent } from './mode-events.js';
+import { appendModeEvent, appendSpaceHeaterEvent } from './mode-events.js';
 
 export { transitionLog };
 
 const EVENTS_PAGE_SIZE = 10;
-// Parallel cursors so the three feeds scroll independently. Overlay
+// Parallel cursors so the four feeds scroll independently. Overlay
 // events are fan-cool / future overlay flips written by mqtt-bridge.
+// Actuator events surface space-heater on/off so hybrid heating
+// (greenhouse_heating + heater overlay) shows up alongside the mode rows.
 let modeCursor = null;
 let modeHasMore = false;
 let configCursor = null;
 let configHasMore = false;
 let overlayCursor = null;
 let overlayHasMore = false;
+let actuatorCursor = null;
+let actuatorHasMore = false;
 let eventsLoading = false;
 let lastLiveMode = null;
 let lastLiveFanCool = null;
+let lastLiveSpaceHeater = null;
 
 // Drop pagination + mode-change state. fetchLiveEvents(null) repopulates.
 export function resetEventsState() {
@@ -35,8 +41,11 @@ export function resetEventsState() {
   configHasMore = false;
   overlayCursor = null;
   overlayHasMore = false;
+  actuatorCursor = null;
+  actuatorHasMore = false;
   lastLiveMode = null;
   lastLiveFanCool = null;
+  lastLiveSpaceHeater = null;
 }
 
 function fetchEventPage(type, before, signal) {
@@ -94,17 +103,39 @@ function overlayRowToLogEntry(e) {
   };
 }
 
+function actuatorRowToLogEntry(e) {
+  return {
+    kind: 'live',
+    eventType: 'actuator',
+    ts: e.ts,
+    actuatorId: e.id,
+    from: e.from,
+    to: e.to,
+  };
+}
+
+// Only space-heater on/off rows surface in the System Logs feed today.
+// Pump and fan transitions are mode-driven and the operator already
+// reads them from the mode rows; immersion_heater is unused. Filtering
+// at the render boundary keeps the database write-side untouched (still
+// records every actuator) while the UI stays focused on the events the
+// operator actually needs to see.
+function isUserVisibleActuator(id) {
+  return id === 'space_heater';
+}
+
 // Apply a paged fetch result into transitionLog + cursor state. Pulled
 // out of fetchLiveEvents so the sync-coordinator data source can reuse
 // the same write path on Android resume. `_skipped` data carries no
 // fresh rows or pagination info, so its cursor branch no-ops.
-function applyEventPages(modeData, configData, overlayData, isReset) {
+function applyEventPages(modeData, configData, overlayData, actuatorData, isReset) {
   // Only apply to the current phase — the user may have switched back
   // to simulation while the requests were in flight.
   if (store.get('phase') !== 'live') return;
   const modeEvents = (modeData && Array.isArray(modeData.events)) ? modeData.events : [];
   const configEvents = (configData && Array.isArray(configData.events)) ? configData.events : [];
   const overlayEvents = (overlayData && Array.isArray(overlayData.events)) ? overlayData.events : [];
+  const actuatorEvents = (actuatorData && Array.isArray(actuatorData.events)) ? actuatorData.events : [];
 
   if (isReset) transitionLog.length = 0;
 
@@ -116,6 +147,10 @@ function applyEventPages(modeData, configData, overlayData, isReset) {
   }
   for (let i = 0; i < overlayEvents.length; i++) {
     transitionLog.push(overlayRowToLogEntry(overlayEvents[i]));
+  }
+  for (let i = 0; i < actuatorEvents.length; i++) {
+    if (!isUserVisibleActuator(actuatorEvents[i].id)) continue;
+    transitionLog.push(actuatorRowToLogEntry(actuatorEvents[i]));
   }
   // Re-sort the merged list newest-first. Stable enough for our N (~30).
   transitionLog.sort((a, b) => (b.ts || 0) - (a.ts || 0));
@@ -131,6 +166,10 @@ function applyEventPages(modeData, configData, overlayData, isReset) {
   if (!overlayData._skipped) {
     if (overlayEvents.length > 0) overlayCursor = overlayEvents[overlayEvents.length - 1].ts;
     overlayHasMore = !!(overlayData && overlayData.hasMore);
+  }
+  if (!actuatorData._skipped) {
+    if (actuatorEvents.length > 0) actuatorCursor = actuatorEvents[actuatorEvents.length - 1].ts;
+    actuatorHasMore = !!(actuatorData && actuatorData.hasMore);
   }
 
   renderLogsList();
@@ -149,6 +188,7 @@ export function fetchLiveEvents(reset) {
   const modeBefore = isReset ? null : (modeHasMore ? modeCursor : null);
   const configBefore = isReset ? null : (configHasMore ? configCursor : null);
   const overlayBefore = isReset ? null : (overlayHasMore ? overlayCursor : null);
+  const actuatorBefore = isReset ? null : (actuatorHasMore ? actuatorCursor : null);
 
   // Skip a side that has no more rows AND it isn't a reset, to avoid
   // re-fetching identical pages.
@@ -161,10 +201,13 @@ export function fetchLiveEvents(reset) {
   const overlayPromise = (isReset || overlayHasMore)
     ? fetchEventPage('overlay', overlayBefore)
     : Promise.resolve({ events: [], hasMore: false, _skipped: true });
+  const actuatorPromise = (isReset || actuatorHasMore)
+    ? fetchEventPage('actuator', actuatorBefore)
+    : Promise.resolve({ events: [], hasMore: false, _skipped: true });
 
-  Promise.all([modePromise, configPromise, overlayPromise])
-    .then(([modeData, configData, overlayData]) =>
-      applyEventPages(modeData, configData, overlayData, isReset))
+  Promise.all([modePromise, configPromise, overlayPromise, actuatorPromise])
+    .then(([modeData, configData, overlayData, actuatorData]) =>
+      applyEventPages(modeData, configData, overlayData, actuatorData, isReset))
     .then(() => { eventsLoading = false; });
 }
 
@@ -253,6 +296,38 @@ export function detectLiveTransition(result) {
     }
   }
 
+  // Space-heater on/off — surfaces hybrid heating in real time so the
+  // operator doesn't have to wait for the next /api/events refresh.
+  // Mirrors the fan-cool logic above; the on-disk record still flows
+  // through mqtt-bridge → state_events.
+  const actuators = (result && result.actuators) || {};
+  if (typeof actuators.space_heater === 'boolean') {
+    const cur = actuators.space_heater;
+    if (lastLiveSpaceHeater === null) {
+      lastLiveSpaceHeater = cur;
+    } else if (lastLiveSpaceHeater !== cur) {
+      const tsMs = Date.now();
+      transitionLog.unshift({
+        kind: 'live', eventType: 'actuator', ts: tsMs,
+        actuatorId: 'space_heater',
+        from: lastLiveSpaceHeater ? 'on' : 'off',
+        to: cur ? 'on' : 'off',
+      });
+      // Mirror into the space-heater store so the EMERGENCY band on
+      // the bar chart updates without waiting for the next /api/history
+      // refresh (matches the appendModeEvent call above).
+      appendSpaceHeaterEvent({
+        ts: Math.floor(tsMs / 1000),
+        type: 'actuator',
+        id: 'space_heater',
+        from: lastLiveSpaceHeater ? 'on' : 'off',
+        to: cur ? 'on' : 'off',
+      });
+      lastLiveSpaceHeater = cur;
+      dirty = true;
+    }
+  }
+
   if (dirty) renderLogsList();
 }
 
@@ -290,6 +365,10 @@ export function renderLogsList() {
       html += renderMutedEntry(formatOverlayEntry(t), timeLabel);
       continue;
     }
+    if (t.eventType === 'actuator') {
+      html += renderMutedEntry(formatActuatorEntry(t), timeLabel);
+      continue;
+    }
 
     const mi = MODE_INFO[t.mode] || MODE_INFO.idle;
     const dotClass = t.mode === 'solar_charging' || t.mode === 'active_drain' ? 'log-dot-charging'
@@ -314,7 +393,7 @@ export function renderLogsList() {
     '</div>';
   }
 
-  if (isLive && (modeHasMore || configHasMore || overlayHasMore)) {
+  if (isLive && (modeHasMore || configHasMore || overlayHasMore || actuatorHasMore)) {
     html += '<div class="log-loading" data-log-loading="true" style="color:var(--on-surface-variant);font-size:12px;text-align:center;padding:8px 0;">' +
       (eventsLoading ? 'Loading older transitions…' : 'Scroll to load older transitions') +
     '</div>';
@@ -337,9 +416,11 @@ export function registerLogsSource() {
       fetchEventPage('mode', null, signal),
       fetchEventPage('config', null, signal),
       fetchEventPage('overlay', null, signal),
-    ]).then(([modeData, configData, overlayData]) => ({ modeData, configData, overlayData })),
-    applyToStore: ({ modeData, configData, overlayData }) =>
-      applyEventPages(modeData, configData, overlayData, true),
+      fetchEventPage('actuator', null, signal),
+    ]).then(([modeData, configData, overlayData, actuatorData]) =>
+      ({ modeData, configData, overlayData, actuatorData })),
+    applyToStore: ({ modeData, configData, overlayData, actuatorData }) =>
+      applyEventPages(modeData, configData, overlayData, actuatorData, true),
   });
 }
 
@@ -352,7 +433,7 @@ export function setupLogsScrollLoader() {
   container.addEventListener('scroll', function () {
     if (store.get('phase') !== 'live') return;
     if (eventsLoading) return;
-    if (!modeHasMore && !configHasMore && !overlayHasMore) return;
+    if (!modeHasMore && !configHasMore && !overlayHasMore && !actuatorHasMore) return;
     // Trigger when the scroll reaches within 40px of the bottom
     const remaining = container.scrollHeight - container.scrollTop - container.clientHeight;
     if (remaining < 40) {

--- a/playground/js/main/mode-events.js
+++ b/playground/js/main/mode-events.js
@@ -11,8 +11,20 @@
 // event" (the most recent transition before the visible window — see
 // db.getEvents) so the first sample's mode is well-defined.
 // `appendModeEvent` is called by detectLiveTransition for live deltas.
+//
+// A parallel `spaceHeaterEventsStore` tracks space-heater on/off
+// transitions. The space heater is an actuator that runs as an OVERLAY
+// on top of any pump-mode (typically greenhouse_heating when the tank
+// is too cold to drive the radiator), so EMERGENCY band coverage is
+// the OR-union of `mode === 'emergency_heating'` and
+// `space_heater === 'on'` — otherwise hybrid heating is invisible on
+// the graph.
 
 export const modeEventsStore = {
+  events: [],
+};
+
+export const spaceHeaterEventsStore = {
   events: [],
 };
 
@@ -20,8 +32,16 @@ export function resetModeEvents() {
   modeEventsStore.events = [];
 }
 
+export function resetSpaceHeaterEvents() {
+  spaceHeaterEventsStore.events = [];
+}
+
 function isModeEvent(e) {
   return e && typeof e.ts === 'number' && (e.type === 'mode' || e.type === undefined);
+}
+
+function isSpaceHeaterEvent(e) {
+  return e && typeof e.ts === 'number' && e.type === 'actuator' && e.id === 'space_heater';
 }
 
 export function populateModeEvents(events) {
@@ -37,9 +57,33 @@ export function populateModeEvents(events) {
   modeEventsStore.events = filtered;
 }
 
+// /api/events?type=actuator and /api/history's actuator stream both
+// carry events for every actuator (pump, fan, space_heater,
+// immersion_heater). This store keeps only space_heater rows.
+export function populateSpaceHeaterEvents(events) {
+  if (!Array.isArray(events)) {
+    spaceHeaterEventsStore.events = [];
+    return;
+  }
+  const filtered = [];
+  for (let i = 0; i < events.length; i++) {
+    if (isSpaceHeaterEvent(events[i])) filtered.push(events[i]);
+  }
+  filtered.sort((a, b) => a.ts - b.ts);
+  spaceHeaterEventsStore.events = filtered;
+}
+
 export function appendModeEvent(event) {
   if (!isModeEvent(event)) return;
-  const list = modeEventsStore.events;
+  appendInOrder(modeEventsStore.events, event);
+}
+
+export function appendSpaceHeaterEvent(event) {
+  if (!isSpaceHeaterEvent(event)) return;
+  appendInOrder(spaceHeaterEventsStore.events, event);
+}
+
+function appendInOrder(list, event) {
   for (let i = list.length - 1; i >= 0; i--) {
     if (list[i].ts === event.ts && list[i].to === event.to) return;
     if (list[i].ts < event.ts) {
@@ -53,46 +97,80 @@ export function appendModeEvent(event) {
 // Returns the mode active at `ts`, defaulting to 'idle' when no event
 // applies (no leading event seen, or `ts` predates every known event).
 export function modeAt(ts) {
-  const list = modeEventsStore.events;
-  if (list.length === 0) return 'idle';
+  return stateAt(modeEventsStore.events, ts, 'idle');
+}
+
+// Returns 'on' / 'off' for the space heater at `ts`, defaulting to
+// 'off' when no event applies.
+export function spaceHeaterAt(ts) {
+  return stateAt(spaceHeaterEventsStore.events, ts, 'off');
+}
+
+function stateAt(list, ts, fallback) {
+  if (list.length === 0) return fallback;
   let lo = 0, hi = list.length;
   while (lo < hi) {
     const mid = (lo + hi) >>> 1;
     if (list[mid].ts <= ts) lo = mid + 1;
     else hi = mid;
   }
-  if (lo === 0) return 'idle';
-  return list[lo - 1].to || 'idle';
+  if (lo === 0) return fallback;
+  return list[lo - 1].to || fallback;
 }
 
 // Per-mode wall-clock seconds covered by events that fall inside the
-// half-open interval [start, end). Walks events from one tick before
-// `start` (the leading-event lookup) and clamps each segment to the
-// bucket boundaries — so a 30-min bucket that starts mid-charge
-// contributes the partial overlap, not the full bucket.
+// half-open interval [start, end). Walks the merged timeline of mode
+// events AND space-heater on/off events from one tick before `start`
+// (the leading-event lookup) and clamps each segment to the bucket
+// boundaries — so a 30-min bucket that starts mid-charge contributes
+// the partial overlap, not the full bucket.
+//
+// Emergency coverage is the OR-union of `mode === 'emergency_heating'`
+// and `space_heater === 'on'` over the bucket. Charging and heating
+// are pure mode-driven and don't interact with the heater overlay.
 export function coverageInBucket(start, end) {
   const out = { charging: 0, heating: 0, emergency: 0 };
   if (end <= start) return out;
-  const list = modeEventsStore.events;
+  const modeList = modeEventsStore.events;
+  const heaterList = spaceHeaterEventsStore.events;
 
+  // Walking pointers through both lists in ts order. Between transition
+  // points the (mode, heater) tuple is constant, so we accumulate
+  // segments bounded by the next event from either timeline.
   let mode = modeAt(start);
+  let heater = spaceHeaterAt(start);
   let cursor = start;
-  for (let i = 0; i < list.length; i++) {
-    const e = list[i];
-    if (e.ts <= start) continue;
-    if (e.ts >= end) break;
-    addSegment(out, mode, cursor, e.ts);
-    mode = e.to || 'idle';
-    cursor = e.ts;
+
+  let mi = 0; while (mi < modeList.length && modeList[mi].ts <= start) mi++;
+  let hi = 0; while (hi < heaterList.length && heaterList[hi].ts <= start) hi++;
+
+  while (true) {
+    const nextModeTs = mi < modeList.length ? modeList[mi].ts : Infinity;
+    const nextHeaterTs = hi < heaterList.length ? heaterList[hi].ts : Infinity;
+    const nextTs = Math.min(nextModeTs, nextHeaterTs, end);
+    addSegment(out, mode, heater, cursor, nextTs);
+    if (nextTs >= end) break;
+    if (nextModeTs === nextTs) {
+      mode = modeList[mi].to || 'idle';
+      mi++;
+    }
+    if (nextHeaterTs === nextTs) {
+      heater = heaterList[hi].to || 'off';
+      hi++;
+    }
+    cursor = nextTs;
   }
-  addSegment(out, mode, cursor, end);
   return out;
 }
 
-function addSegment(out, mode, from, to) {
+function addSegment(out, mode, heater, from, to) {
   const dur = to - from;
   if (dur <= 0) return;
   if (mode === 'solar_charging') out.charging += dur;
   else if (mode === 'greenhouse_heating') out.heating += dur;
-  else if (mode === 'emergency_heating') out.emergency += dur;
+  // OR-union: emergency_heating mode OR space-heater on. The mode-only
+  // and heater-only cases each contribute their full duration; the
+  // overlap (heater on while mode === emergency_heating) contributes
+  // once, not twice.
+  if (mode === 'emergency_heating' || heater === 'on') out.emergency += dur;
 }

--- a/playground/js/main/time-format.js
+++ b/playground/js/main/time-format.js
@@ -246,6 +246,23 @@ export function formatOverlayEntry(t) {
   return { title: 'Overlay ' + (t.overlayId || ''), desc: (t.from || '?') + ' → ' + (t.to || '?') };
 }
 
+// Actuator on/off rows. Today only space_heater surfaces in the System
+// Logs feed (pump/fan flips are mode-driven and the operator already
+// reads them off the mode rows). Phrasing is symmetric with the overlay
+// entry so the muted-dot rows read consistently in the list.
+export function formatActuatorEntry(t) {
+  if (t.actuatorId === 'space_heater') {
+    return t.to === 'on'
+      ? { title: 'Space heater on', desc: 'Resistive heater started' }
+      : { title: 'Space heater off', desc: 'Resistive heater stopped' };
+  }
+  const label = EA_BIT_LABELS[t.actuatorId] || t.actuatorId || 'actuator';
+  return {
+    title: label + ' ' + (t.to === 'on' ? 'on' : 'off'),
+    desc: (t.from || '?') + ' → ' + (t.to || '?'),
+  };
+}
+
 // Render the temp snapshot as "coll 62.3° · tank 41/29° · gh 12° · out 8°"
 export function formatSensorsLine(sensors) {
   if (!sensors) return '';

--- a/server/lib/db.js
+++ b/server/lib/db.js
@@ -384,33 +384,41 @@ function getEventsPaginated(entityType, limit, before, callback) {
   });
 }
 
-function getEvents(range, entityType, callback) {
+// getEvents(range, entityType, [entityId,] callback). entityId narrows
+// to a single entity (e.g. just `space_heater`) for the /api/history
+// EMERGENCY-band feed.
+function getEvents(range, entityType, entityIdOrCallback, maybeCallback) {
+  const entityId = typeof entityIdOrCallback === 'function' ? null : (entityIdOrCallback || null);
+  const callback = typeof entityIdOrCallback === 'function' ? entityIdOrCallback : maybeCallback;
+
   const p = getPool();
   const interval = RANGE_INTERVALS[range];
   const hasWindow = !!interval && range !== 'all';
   const whereTime = hasWindow ? " WHERE ts > NOW() - INTERVAL '" + interval + "'" : '';
 
   const params = [];
-  let whereType = '';
-  if (entityType) {
-    whereType = (whereTime ? ' AND' : ' WHERE') + ' entity_type = $1';
-    params.push(entityType);
-  }
+  let filter = '';
+  const addClause = (col, val) => {
+    if (!val) return;
+    filter += (whereTime || filter ? ' AND' : ' WHERE') + ' ' + col + ' = $' + (params.length + 1);
+    params.push(val);
+  };
+  addClause('entity_type', entityType);
+  addClause('entity_id', entityId);
 
   const cols = 'ts, entity_type, entity_id, old_value, new_value';
-  const windowSql = 'SELECT ' + cols + ' FROM state_events' + whereTime + whereType;
+  const windowSql = 'SELECT ' + cols + ' FROM state_events' + whereTime + filter;
 
-  // Leading edge: the single most recent event of this entity type from
-  // before the window. Without it the client cannot resolve "what mode
-  // was active at window-start" — it would default to idle and mislabel
-  // the bar chart and clipboard table when the controller was already
-  // in another mode at the time.
+  // Leading edge: the single most recent event from before the window.
+  // Without it the client can't resolve "what mode was active at
+  // window-start" and defaults to idle, mislabelling the bar chart and
+  // clipboard table.
   let sql;
   if (hasWindow) {
-    let leadingType = '';
-    if (entityType) leadingType = ' AND entity_type = $1';
+    // Same filter clauses but anchored to the pre-window range.
+    const leading = filter.replace(/^ WHERE/, ' AND');
     const leadingSql = 'SELECT ' + cols + ' FROM state_events' +
-      " WHERE ts <= NOW() - INTERVAL '" + interval + "'" + leadingType +
+      " WHERE ts <= NOW() - INTERVAL '" + interval + "'" + leading +
       ' ORDER BY ts DESC LIMIT 1';
     sql = '(' + leadingSql + ') UNION ALL (' + windowSql + ') ORDER BY ts';
   } else {

--- a/server/lib/http-handlers.js
+++ b/server/lib/http-handlers.js
@@ -120,7 +120,19 @@ function createHandlers(deps) {
           log.error('events query failed', { error: evErr.message });
           events = [];
         }
-        jsonResponse(res, 200, { range, points, events });
+        // Space-heater on/off intervals feed the EMERGENCY band on the
+        // history graph (OR-unioned with `mode === 'emergency_heating'`)
+        // and the SH annotation in the clipboard export. Fetched here
+        // alongside mode events so a single /api/history round-trip
+        // gives the client everything the bar chart and the readings
+        // table need.
+        db.getEvents(range, 'actuator', 'space_heater', function (shErr, spaceHeaterEvents) {
+          if (shErr) {
+            log.error('space-heater events query failed', { error: shErr.message });
+            spaceHeaterEvents = [];
+          }
+          jsonResponse(res, 200, { range, points, events, spaceHeaterEvents });
+        });
       });
     });
   }

--- a/tests/frontend/copy-logs.spec.js
+++ b/tests/frontend/copy-logs.spec.js
@@ -299,6 +299,91 @@ test.describe('Copy System Logs — live mode', () => {
     expect(text).toContain('Heating Greenhouse');
   });
 
+  // Hybrid heating (greenhouse_heating + space heater overlay) was
+  // invisible in the export — Mode column showed "greenhouse_heating"
+  // and the transition log only carried mode rows, so an operator
+  // copying logs at 02:00 couldn't tell the heater was firing. Same
+  // story for the System Logs feed (covered by live-logs.spec.js).
+  test('Sensor Readings table annotates rows where the space heater was on', async ({ page }) => {
+    const now = Date.now();
+    const historyPoints = makeHistoryPoints(3, 20 * 60 * 1000, now - 60 * 60 * 1000);
+    // Mode events: greenhouse_heating throughout the window.
+    const historyEvents = [
+      { ts: now - 90 * 60 * 1000, type: 'mode', from: 'idle', to: 'greenhouse_heating' },
+    ];
+    // Space heater on across the window so every reading row should be
+    // annotated.
+    const spaceHeaterEvents = [
+      { ts: now - 90 * 60 * 1000, type: 'actuator', id: 'space_heater', from: 'off', to: 'on' },
+    ];
+
+    await installMockWs(page);
+    await page.route('**/api/history**', route => route.fulfill({
+      status: 200, contentType: 'application/json',
+      body: JSON.stringify({
+        range: '24h', points: historyPoints, events: historyEvents,
+        spaceHeaterEvents,
+      }),
+    }));
+    await mockEventsApi(page, []);
+
+    await page.goto('/playground/', { waitUntil: 'domcontentloaded' });
+    await expect(page.locator('#connection-dot')).toHaveClass(/connected/, { timeout: 5000 });
+    await waitForTestHook(page);
+
+    const text = await getClipboardText(page);
+    // Header carries the new SH column.
+    expect(text).toContain('Mode                SH');
+    // Sensor reading rows carry an SH marker when the heater was on.
+    expect(text).toMatch(/greenhouse_heating {2}on/);
+  });
+
+  test('Sensor Readings SH column is blank when the space heater was off', async ({ page }) => {
+    const now = Date.now();
+    const historyPoints = makeHistoryPoints(3, 20 * 60 * 1000, now - 60 * 60 * 1000);
+
+    await installMockWs(page);
+    await page.route('**/api/history**', route => route.fulfill({
+      status: 200, contentType: 'application/json',
+      body: JSON.stringify({
+        range: '24h', points: historyPoints, events: [], spaceHeaterEvents: [],
+      }),
+    }));
+    await mockEventsApi(page, []);
+
+    await page.goto('/playground/', { waitUntil: 'domcontentloaded' });
+    await expect(page.locator('#connection-dot')).toHaveClass(/connected/, { timeout: 5000 });
+    await waitForTestHook(page);
+
+    const text = await getClipboardText(page);
+    // Default mode is 'idle' (no events) and SH should be blank for
+    // every row, not 'on'.
+    expect(text).not.toMatch(/idle\s+on\b/);
+  });
+
+  test('Transition Log includes space-heater on/off entries', async ({ page }) => {
+    const now = Date.now();
+    const rows = [
+      // newest first
+      { ts: now - 30_000, type: 'actuator', id: 'space_heater', from: 'off', to: 'on' },
+      makeEvent(now - 60_000, 'idle', 'greenhouse_heating'),
+    ];
+
+    await installMockWs(page);
+    await mockHistoryApi(page);
+    await mockEventsApi(page, rows);
+
+    await page.goto('/playground/', { waitUntil: 'domcontentloaded' });
+    await expect(page.locator('#connection-dot')).toHaveClass(/connected/, { timeout: 5000 });
+    await expect(page.locator('#logs-list .log-item')).toHaveCount(2, { timeout: 5000 });
+    await waitForTestHook(page);
+
+    const text = await getClipboardText(page);
+    // The actuator row appears in the export's Transition Log section.
+    expect(text).toMatch(/Space heater on/);
+    expect(text).toMatch(/\[actuator: space_heater\]/);
+  });
+
   test('sensor readings table has data rows from history', async ({ page }) => {
     const now = Date.now();
     const historyPoints = makeHistoryPoints(3, 20 * 60 * 1000, now - 60 * 60 * 1000);

--- a/tests/frontend/live-logs.spec.js
+++ b/tests/frontend/live-logs.spec.js
@@ -317,6 +317,82 @@ test.describe('System Logs card is backed by live state events', () => {
     await expect(items.nth(3)).toContainText('Idle');
   });
 
+  test('space-heater actuator on/off renders in the System Logs feed', async ({ page }) => {
+    // The space heater fires as an OVERLAY on top of greenhouse_heating
+    // when the tank is too cold to drive the radiator. The mode-only
+    // log feed previously hid that — operators saw "Heating Greenhouse"
+    // for hours with no indication that the resistive heater was
+    // actually doing the work. /api/events?type=actuator carries the
+    // on/off transitions; the System Logs feed must fetch and render
+    // them alongside mode rows.
+    const now = Date.now();
+    const rows = [
+      {
+        ts: now - 30_000, type: 'actuator', id: 'space_heater',
+        from: 'off', to: 'on',
+      },
+      makeEvent(now - 60_000, 'idle', 'greenhouse_heating'),
+      {
+        ts: now - 90_000, type: 'actuator', id: 'space_heater',
+        from: 'on', to: 'off',
+      },
+    ];
+
+    await installMockWs(page);
+    await mockHistoryApi(page);
+    await mockEventsApi(page, rows);
+
+    await page.goto('/playground/', { waitUntil: 'domcontentloaded' });
+    await expect(page.locator('#connection-dot')).toHaveClass(/connected/, { timeout: 3000 });
+
+    const items = page.locator('#logs-list .log-item');
+    await expect(items).toHaveCount(3, { timeout: 3000 });
+
+    // Newest first — the heater turning on lands at the top.
+    await expect(items.nth(0)).toContainText('Space heater on');
+    await expect(items.nth(1)).toContainText('Heating Greenhouse');
+    await expect(items.nth(2)).toContainText('Space heater off');
+  });
+
+  test('detects live space-heater transitions from WS state frames', async ({ page }) => {
+    // Same eager-prepend pattern as fan-cool overlay flips: if the
+    // controller toggles the heater between mode transitions, the row
+    // should appear immediately without a /api/events round-trip.
+    // Initial WS frame is already in greenhouse_heating with the heater
+    // off; only the heater flip should generate a new entry.
+    const now = Date.now();
+    await installMockWs(page, {
+      mode: 'greenhouse_heating',
+      actuators: { pump: true, fan: true, space_heater: false },
+    });
+    await mockHistoryApi(page);
+    await mockEventsApi(page, [makeEvent(now - 60_000, 'idle', 'greenhouse_heating')]);
+
+    await page.goto('/playground/', { waitUntil: 'domcontentloaded' });
+    await expect(page.locator('#connection-dot')).toHaveClass(/connected/, { timeout: 3000 });
+    await expect(page.locator('#logs-list .log-item')).toHaveCount(1, { timeout: 3000 });
+
+    await page.evaluate(() => {
+      // @ts-ignore
+      const ws = window.__mockWs;
+      ws.onmessage({
+        data: JSON.stringify({
+          type: 'state',
+          data: {
+            mode: 'greenhouse_heating',
+            temps: { collector: 5, tank_top: 18, tank_bottom: 17, greenhouse: 9, outdoor: 1 },
+            valves: {}, actuators: { pump: true, fan: true, space_heater: true },
+            controls_enabled: true, manual_override: null,
+          },
+        }),
+      });
+    });
+
+    const items = page.locator('#logs-list .log-item');
+    await expect(items).toHaveCount(2, { timeout: 3000 });
+    await expect(items.first()).toContainText('Space heater on');
+  });
+
   test('ea bit-flip renders as "Enabled actuator: <name>"', async ({ page }) => {
     // A user toggling Fan on via Controller settings should appear in
     // the System Logs card as a config_events row with the friendly

--- a/tests/getevents-leading.test.js
+++ b/tests/getevents-leading.test.js
@@ -75,4 +75,19 @@ describe('db.getEvents — leading event', () => {
       done();
     });
   });
+
+  // Allows /api/history to fetch space-heater on/off events specifically
+  // (one of many actuators) without pulling pump/fan/immersion_heater
+  // rows that the EMERGENCY band doesn't care about.
+  it('accepts an optional entity_id filter alongside entity_type', (t, done) => {
+    db.getEvents('6h', 'actuator', 'space_heater', function (err) {
+      assert.ifError(err);
+      const eventsQ = capturedQueries.find(q => q.sql && q.sql.includes('state_events'));
+      assert.ok(eventsQ);
+      assert.match(eventsQ.sql, /entity_id = \$/, 'expected an entity_id filter in the query');
+      assert.ok(eventsQ.params.includes('actuator'), 'entity_type bound');
+      assert.ok(eventsQ.params.includes('space_heater'), 'entity_id bound');
+      done();
+    });
+  });
 });

--- a/tests/mode-events.test.mjs
+++ b/tests/mode-events.test.mjs
@@ -24,12 +24,17 @@ import {
   appendModeEvent,
   modeAt,
   coverageInBucket,
+  spaceHeaterEventsStore,
+  resetSpaceHeaterEvents,
+  populateSpaceHeaterEvents,
+  appendSpaceHeaterEvent,
+  spaceHeaterAt,
 } from '../playground/js/main/mode-events.js';
 
 const SEC = 1000;
 
 describe('mode-events store', () => {
-  beforeEach(() => resetModeEvents());
+  beforeEach(() => { resetModeEvents(); resetSpaceHeaterEvents(); });
 
   it('modeAt defaults to idle when the store is empty', () => {
     assert.equal(modeAt(0), 'idle');
@@ -149,6 +154,104 @@ describe('mode-events store', () => {
       assert.equal(c.emergency, 60 * SEC);
       assert.equal(c.charging, 0);
       assert.equal(c.heating, 0);
+    });
+
+    // Space-heater is a separate actuator that can run AS AN OVERLAY on
+    // top of greenhouse_heating (the radiator circuit handles the
+    // primary heat, space heater fills in when the tank is too cold to
+    // drive the radiator). The EMERGENCY band on the history graph
+    // should fill whenever the heater is firing, regardless of which
+    // pump-mode is active — otherwise hybrid heating is invisible.
+    it('OR-unions space-heater intervals into emergency coverage', () => {
+      populateModeEvents([
+        { ts: 0, type: 'mode', from: 'idle', to: 'greenhouse_heating' },
+      ]);
+      populateSpaceHeaterEvents([
+        { ts: 20 * SEC, type: 'actuator', id: 'space_heater', from: 'off', to: 'on' },
+        { ts: 50 * SEC, type: 'actuator', id: 'space_heater', from: 'on', to: 'off' },
+      ]);
+      // Bucket [0, 60): heating mode for full 60s, but space heater on
+      // for [20, 50) = 30s. Heating coverage stays at 60s; emergency
+      // coverage rises to 30s.
+      const c = coverageInBucket(0, 60 * SEC);
+      assert.equal(c.heating, 60 * SEC, 'heating coverage covers the full bucket');
+      assert.equal(c.emergency, 30 * SEC, 'space-heater overlay paints emergency for 30s');
+    });
+
+    it('does not double-count emergency_heating mode + space-heater on', () => {
+      // Belt-and-braces: when the device IS in emergency_heating mode
+      // AND the heater relay is on (the typical case), the emergency
+      // band should still cover the actual on-time, not 2x it.
+      populateModeEvents([
+        { ts: 0, type: 'mode', from: 'idle', to: 'emergency_heating' },
+        { ts: 60 * SEC, type: 'mode', from: 'emergency_heating', to: 'idle' },
+      ]);
+      populateSpaceHeaterEvents([
+        { ts: 0, type: 'actuator', id: 'space_heater', from: 'off', to: 'on' },
+        { ts: 60 * SEC, type: 'actuator', id: 'space_heater', from: 'on', to: 'off' },
+      ]);
+      const c = coverageInBucket(0, 60 * SEC);
+      assert.equal(c.emergency, 60 * SEC, 'OR-union must not exceed bucket length');
+    });
+
+    it('space-heater on with no mode events still paints emergency', () => {
+      // Mode events may be missing in the very early seconds of a fresh
+      // install, but if the heater is firing the band should reflect it.
+      populateSpaceHeaterEvents([
+        { ts: 10 * SEC, type: 'actuator', id: 'space_heater', from: 'off', to: 'on' },
+        { ts: 40 * SEC, type: 'actuator', id: 'space_heater', from: 'on', to: 'off' },
+      ]);
+      const c = coverageInBucket(0, 60 * SEC);
+      assert.equal(c.emergency, 30 * SEC);
+      assert.equal(c.heating, 0);
+      assert.equal(c.charging, 0);
+    });
+  });
+
+  describe('space-heater events store', () => {
+    it('spaceHeaterAt defaults to off when the store is empty', () => {
+      assert.equal(spaceHeaterAt(0), 'off');
+      assert.equal(spaceHeaterAt(Date.now()), 'off');
+    });
+
+    it('populateSpaceHeaterEvents sorts by ts and dedupes via append', () => {
+      populateSpaceHeaterEvents([
+        { ts: 200 * SEC, type: 'actuator', id: 'space_heater', from: 'on', to: 'off' },
+        { ts: 100 * SEC, type: 'actuator', id: 'space_heater', from: 'off', to: 'on' },
+      ]);
+      assert.equal(spaceHeaterEventsStore.events.length, 2);
+      assert.equal(spaceHeaterEventsStore.events[0].ts, 100 * SEC);
+      assert.equal(spaceHeaterEventsStore.events[1].ts, 200 * SEC);
+
+      // Same (ts, to) ignored; new (ts, to) appended in chronological order.
+      appendSpaceHeaterEvent({ ts: 100 * SEC, type: 'actuator', id: 'space_heater', from: 'off', to: 'on' });
+      assert.equal(spaceHeaterEventsStore.events.length, 2);
+      appendSpaceHeaterEvent({ ts: 300 * SEC, type: 'actuator', id: 'space_heater', from: 'off', to: 'on' });
+      assert.equal(spaceHeaterEventsStore.events.length, 3);
+    });
+
+    it('spaceHeaterAt walks events forward', () => {
+      populateSpaceHeaterEvents([
+        { ts: 100 * SEC, type: 'actuator', id: 'space_heater', from: 'off', to: 'on' },
+        { ts: 200 * SEC, type: 'actuator', id: 'space_heater', from: 'on', to: 'off' },
+      ]);
+      assert.equal(spaceHeaterAt(50 * SEC), 'off');
+      assert.equal(spaceHeaterAt(100 * SEC), 'on');
+      assert.equal(spaceHeaterAt(150 * SEC), 'on');
+      assert.equal(spaceHeaterAt(200 * SEC), 'off');
+    });
+
+    it('populateSpaceHeaterEvents ignores non-space_heater actuator events', () => {
+      // /api/events?type=actuator returns ALL actuator transitions
+      // (pump, fan, immersion_heater); this store only cares about
+      // space_heater, so the filter happens at the store boundary.
+      populateSpaceHeaterEvents([
+        { ts: 100 * SEC, type: 'actuator', id: 'pump', from: 'off', to: 'on' },
+        { ts: 150 * SEC, type: 'actuator', id: 'space_heater', from: 'off', to: 'on' },
+        { ts: 200 * SEC, type: 'actuator', id: 'fan', from: 'off', to: 'on' },
+      ]);
+      assert.equal(spaceHeaterEventsStore.events.length, 1);
+      assert.equal(spaceHeaterEventsStore.events[0].id, 'space_heater');
     });
   });
 });


### PR DESCRIPTION
## Summary

The space heater is an actuator that runs as an overlay on top of any pump-mode (typically `greenhouse_heating` when the tank is too cold to drive the radiator), but every UI surface previously assumed it only ran when `mode === 'emergency_heating'`. So when the device was in hybrid heating — radiator + heater simultaneously — the operator saw the heater status correctly in Critical Components, but no trace of it in the System Logs feed, the EMERGENCY band on the history graph, or the copied diagnostic export.

This change wires the space-heater on/off transitions through to all three views:

- `mode-events.js`: parallel `spaceHeaterEvents` store; `coverageInBucket` OR-unions space-heater intervals into the emergency coverage so the band fills during overlay use, not just full `emergency_heating` mode
- `/api/history`: returns a `spaceHeaterEvents` array (with leading edge) alongside mode events; `getEvents` accepts an optional `entity_id` filter
- System Logs feed: fetches `type=actuator` as a fourth feed and renders space-heater on/off rows with a muted dot; live WS frames detect the flip and prepend immediately (mirrors the fan-cool overlay pattern)
- Clipboard export: `SH` column on Sensor Readings rows + `Actuator` entries in the Transition Log section

Tests cover the OR-union math, the actuator-events fetch + render, the clipboard `SH` column, and the optional `entity_id` filter on `getEvents`.

## Test plan

- [x] `npm run test:unit` — all 1128 unit tests pass (3 new tests added for `coverageInBucket` OR-union, `spaceHeaterEvents` store, and `getEvents` `entity_id` filter)
- [x] `npm test` — all 300 Playwright tests pass (4 new tests added: actuator events render in feed, live-frame heater detection, SH column, Transition Log actuator entries)
- [x] `npm run lint` — clean
- [x] `npm run knip` — clean
- [x] `npm run check:file-size -- --strict` — 0 over hard cap
- [x] `npm run check:assets -- --strict` — clean

https://claude.ai/code/session_01Kf8fA3sEJANTfxGArhrAhD

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kf8fA3sEJANTfxGArhrAhD)_