### PR TITLE
graph: forecast bars + lines render correctly at sub-hour zoom

### DIFF
--- a/playground/js/main/forecast-overlay.js
+++ b/playground/js/main/forecast-overlay.js
@@ -20,19 +20,41 @@ export function drawForecastOverlay(ctx, data, nowSec, cutoffSec, tMin, tMax, vi
   // Trajectory points come from the engine as ISO strings (`ts` for
   // engine output, `validAt` for the raw weather array). Convert to
   // seconds and clip to [nowSec, cutoffSec] AND the chart window.
+  // When the visible window falls between two forecast samples, the
+  // trailing edge gets a synthesized interpolated point at tMax so
+  // the line reaches the right edge of the chart instead of stopping
+  // at the last in-window sample (which can be visibly far short of
+  // the edge in zoomed-in views — e.g. 24h-range with forecast on
+  // shows hourly samples but the 1h granularity puts the last
+  // sample well before tMax).
   function toPts(traj, valOf, tsKey) {
     if (!Array.isArray(traj)) return [];
     const key = tsKey || 'ts';
     const pts = [];
+    let lastT = null, lastV = null;
     for (let i = 0; i < traj.length; i++) {
       const t = Math.floor(new Date(traj[i][key]).getTime() / 1000);
       if (t < nowSec || t > cutoffSec) continue;
-      if (t < tMin || t > tMax) continue;
       const v = valOf(traj[i]);
       if (typeof v !== 'number' || !isFinite(v)) continue;
-      const x = pad.left + ((t - tMin) / visibleRange) * pw;
-      const y = pad.top + ph - ((v - yMin) / (yMax - yMin)) * ph;
-      pts.push({ x, y });
+      if (t < tMin) { lastT = t; lastV = v; continue; }
+      if (t > tMax) {
+        // First post-window sample — interpolate to tMax and stop.
+        if (lastT !== null) {
+          const frac = (tMax - lastT) / (t - lastT);
+          const vAtMax = lastV + (v - lastV) * frac;
+          pts.push({
+            x: pad.left + ((tMax - tMin) / visibleRange) * pw,
+            y: pad.top + ph - ((vAtMax - yMin) / (yMax - yMin)) * ph,
+          });
+        }
+        return pts;
+      }
+      pts.push({
+        x: pad.left + ((t - tMin) / visibleRange) * pw,
+        y: pad.top + ph - ((v - yMin) / (yMax - yMin)) * ph,
+      });
+      lastT = t; lastV = v;
     }
     return pts;
   }
@@ -81,11 +103,45 @@ export function drawForecastOverlay(ctx, data, nowSec, cutoffSec, tMin, tMax, vi
   }
 }
 
+// Pure: aggregate the modeForecast hourly entries into bucket totals
+// for [segStart, segEnd). Each entry carries a single timestamp and
+// represents the mode active for the full [t, t+1h) interval, so a
+// bucket smaller than 1 h gets its overlap-fraction-of-an-hour rather
+// than 1.0 if the entry's timestamp happens to land inside it. The
+// previous "+1 if t is in bucket" math left every other 30-min bucket
+// empty when the forecast was at 1-hour resolution — see PR for the
+// 15min/30min-bar zoom screenshots that motivated the fix.
+//
+// emergency entries carry an optional `duty` (0..1); a partial duty
+// scales the per-hour contribution proportionally. So a 30-min bucket
+// fully inside an "emergency_heating duty 0.4" hour contributes
+// 0.4 × 0.5 h = 0.2 h of emergency, which divided by segHours = 0.5
+// renders as a 40%-tall bar — matching the underlying duty cycle.
+export function aggregateForecastBucket(modeForecast, segStart, segEnd) {
+  const HOUR_SEC = 3600;
+  let chargingHours = 0, heatingHours = 0, emergencyHours = 0;
+  for (let i = 0; i < modeForecast.length; i++) {
+    const e = modeForecast[i];
+    const t = Math.floor(new Date(e.ts).getTime() / 1000);
+    const eEnd = t + HOUR_SEC;
+    const overlap = Math.max(0, Math.min(eEnd, segEnd) - Math.max(t, segStart));
+    if (overlap <= 0) continue;
+    const oh = overlap / HOUR_SEC;
+    if (e.mode === 'solar_charging')          chargingHours += oh;
+    else if (e.mode === 'greenhouse_heating') heatingHours  += oh;
+    else if (e.mode === 'emergency_heating') {
+      const duty = typeof e.duty === 'number' ? e.duty : 1;
+      emergencyHours += duty * oh;
+    }
+  }
+  return { chargingHours, heatingHours, emergencyHours };
+}
+
 // Render predicted mode bars past "now" using the same x-bucketing AND
-// fractional y-heights as the historical duty bars. modeForecast is at
-// 1-hour resolution; bars stack charging (red, bottom), heating (gold,
-// middle), emergency (orange, top) — matching the historical stack
-// order, with slightly dimmer alphas so the eye reads "projection".
+// fractional y-heights as the historical duty bars. Bars stack
+// charging (red, bottom), heating (gold, middle), emergency (orange,
+// top) — matching the historical stack order, with slightly dimmer
+// alphas so the eye reads "projection".
 function drawForecastModeBars(ctx, modeForecast, nowSec, cutoffSec, tMin, tMax, visibleRange, barAreaH, barY0, pad, pw) {
   const bucketSec = pickBucketSize(visibleRange);
   // Align bucket boundaries the same way dutyBucketsIn does so the right-
@@ -106,21 +162,8 @@ function drawForecastModeBars(ctx, modeForecast, nowSec, cutoffSec, tMin, tMax, 
     const segEnd   = Math.min(hrEnd, cutoffSec);
     if (segEnd <= segStart) continue;
 
-    let chargingHours = 0, heatingHours = 0, emergencyHours = 0;
-    for (let i = 0; i < modeForecast.length; i++) {
-      const e = modeForecast[i];
-      const t = Math.floor(new Date(e.ts).getTime() / 1000);
-      if (t < segStart || t >= segEnd) continue;
-      if (e.mode === 'solar_charging')          chargingHours  += 1;
-      else if (e.mode === 'greenhouse_heating') heatingHours   += 1;
-      else if (e.mode === 'emergency_heating') {
-        // Emergency entries carry a `duty` field (0..1) — the fractional
-        // heater run-time in that hour. A duty of 0.30 means the bar
-        // reaches 30% of the bucket's height for that hour, matching how
-        // historical bars render observed duty cycles.
-        emergencyHours += typeof e.duty === 'number' ? e.duty : 1;
-      }
-    }
+    const { chargingHours, heatingHours, emergencyHours } =
+      aggregateForecastBucket(modeForecast, segStart, segEnd);
     // Per-bucket fraction = hours-on / hours-in-the-post-now slice of this
     // bucket. For the partial bucket straddling "now" we measure against
     // segLen (not bucketSec) — otherwise a single predicted hour in a 25-

--- a/playground/js/main/graph-inspector.js
+++ b/playground/js/main/graph-inspector.js
@@ -11,6 +11,7 @@ import { timeSeriesStore, showAllSensors, showForecast, forecastData } from './s
 import { tankAvgOf, getChartWindow } from './history-graph.js';
 import { formatClockTime } from './time-format.js';
 import { coverageInBucket } from './mode-events.js';
+import { aggregateForecastBucket } from './forecast-overlay.js';
 import { pickBucketSize } from '../ui.js';
 
 function isNum(v) { return typeof v === 'number' && !Number.isNaN(v); }
@@ -125,26 +126,18 @@ function updateInspectorData(x) {
   const bEnd = (bi + 1) * bucketSec;
   let chPct, htPct, emPct;
   if (inForecast) {
-    // Forecast modeForecast is at 1-hour resolution; mirror
-    // drawForecastModeBars by counting slots inside the post-now slice
-    // of the bucket, so the percentages line up visually with the
-    // dashed bars under the cursor.
+    // Forecast percentages share the bar renderer's aggregator so
+    // the tooltip values always agree with the visible bar heights —
+    // including the < 1 h zoom levels where each hourly forecast
+    // entry has to be split across multiple buckets.
     const segStart = Math.max(bStart, nowSec);
     const segEnd = bEnd;
     const segHours = Math.max(1 / 60, (segEnd - segStart) / 3600);
-    let chHours = 0, htHours = 0, emHours = 0;
     const list = Array.isArray(fc.modeForecast) ? fc.modeForecast : [];
-    for (let i = 0; i < list.length; i++) {
-      const e = list[i];
-      const ts = Math.floor(new Date(e.ts).getTime() / 1000);
-      if (ts < segStart || ts >= segEnd) continue;
-      if (e.mode === 'solar_charging') chHours += 1;
-      else if (e.mode === 'greenhouse_heating') htHours += 1;
-      else if (e.mode === 'emergency_heating') emHours += 1;
-    }
-    chPct = Math.round(100 * Math.min(1, chHours / segHours));
-    htPct = Math.round(100 * Math.min(1, htHours / segHours));
-    emPct = Math.round(100 * Math.min(1, emHours / segHours));
+    const agg = aggregateForecastBucket(list, segStart, segEnd);
+    chPct = Math.round(100 * Math.min(1, agg.chargingHours / segHours));
+    htPct = Math.round(100 * Math.min(1, agg.heatingHours  / segHours));
+    emPct = Math.round(100 * Math.min(1, agg.emergencyHours / segHours));
   } else {
     const cov = coverageInBucket(bStart, bEnd);
     chPct = Math.round(100 * cov.charging / bucketSec);

--- a/tests/forecast-mode-bucket.test.mjs
+++ b/tests/forecast-mode-bucket.test.mjs
@@ -1,0 +1,82 @@
+/**
+ * Unit tests for aggregateForecastBucket — the helper that turns the
+ * hourly modeForecast array into per-mode hour totals for a single
+ * bucket. The previous implementation just counted "+1 if the entry's
+ * timestamp falls inside the bucket", which left every other 30-min
+ * bucket empty (1-hour-spaced events vs. 30-min buckets), producing
+ * the sparse-bar look the user reported on the 24h-with-forecast view.
+ *
+ * The fix treats each entry as the mode active for [t, t+1h) and adds
+ * its overlap with the bucket. Emergency duty scales proportionally.
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { aggregateForecastBucket } from '../playground/js/main/forecast-overlay.js';
+
+const NOW = 0;
+const HOUR = 3600;
+
+function tsAt(hour) { return new Date((NOW + hour * HOUR) * 1000).toISOString(); }
+
+describe('aggregateForecastBucket', () => {
+  it('30-min bucket fully inside a heating hour gets 0.5h heating (renders as full-height bar)', () => {
+    const events = [{ ts: tsAt(1), mode: 'greenhouse_heating' }];
+    const r = aggregateForecastBucket(events, 1.0 * HOUR, 1.5 * HOUR);
+    assert.equal(r.heatingHours, 0.5);
+    assert.equal(r.chargingHours, 0);
+    assert.equal(r.emergencyHours, 0);
+  });
+
+  it('30-min bucket between two adjacent hour-events sums their partial overlaps', () => {
+    // Bucket [0.75 h .. 1.25 h] straddles hour 0 (charging) and hour 1
+    // (heating); each contributes 0.25 h of overlap.
+    const events = [
+      { ts: tsAt(0), mode: 'solar_charging' },
+      { ts: tsAt(1), mode: 'greenhouse_heating' },
+    ];
+    const r = aggregateForecastBucket(events, 0.75 * HOUR, 1.25 * HOUR);
+    assert.ok(Math.abs(r.chargingHours - 0.25) < 1e-9);
+    assert.ok(Math.abs(r.heatingHours  - 0.25) < 1e-9);
+  });
+
+  it('15-min bucket fully inside a charging hour gets 0.25h (full-height)', () => {
+    const events = [{ ts: tsAt(2), mode: 'solar_charging' }];
+    const r = aggregateForecastBucket(events, 2.25 * HOUR, 2.5 * HOUR);
+    assert.equal(r.chargingHours, 0.25);
+  });
+
+  it('emergency duty scales the contribution proportionally', () => {
+    // A 30-min bucket fully inside an emergency hour at duty 0.4
+    // contributes 0.4 × 0.5 = 0.2 h. Bar height = 0.2 / segHours(0.5)
+    // = 40%, matching the duty cycle.
+    const events = [{ ts: tsAt(3), mode: 'emergency_heating', duty: 0.4 }];
+    const r = aggregateForecastBucket(events, 3.0 * HOUR, 3.5 * HOUR);
+    assert.ok(Math.abs(r.emergencyHours - 0.2) < 1e-9);
+  });
+
+  it('1-hour bucket aligned with the event boundary picks up exactly 1 hour', () => {
+    const events = [{ ts: tsAt(5), mode: 'greenhouse_heating' }];
+    const r = aggregateForecastBucket(events, 5 * HOUR, 6 * HOUR);
+    assert.equal(r.heatingHours, 1);
+  });
+
+  it('6-hour bucket gathers six hourly events into 6 hours of mode time', () => {
+    const events = Array.from({ length: 6 }, (_, i) => ({
+      ts: tsAt(i), mode: 'solar_charging',
+    }));
+    const r = aggregateForecastBucket(events, 0, 6 * HOUR);
+    assert.equal(r.chargingHours, 6);
+  });
+
+  it('events with no overlap with the bucket contribute nothing', () => {
+    const events = [{ ts: tsAt(10), mode: 'greenhouse_heating' }];
+    const r = aggregateForecastBucket(events, 0, 5 * HOUR);
+    assert.deepEqual(r, { chargingHours: 0, heatingHours: 0, emergencyHours: 0 });
+  });
+
+  it('events with unknown mode are ignored (forward-compat with future modes)', () => {
+    const events = [{ ts: tsAt(0), mode: 'experimental_future_mode' }];
+    const r = aggregateForecastBucket(events, 0, 1 * HOUR);
+    assert.deepEqual(r, { chargingHours: 0, heatingHours: 0, emergencyHours: 0 });
+  });
+});


### PR DESCRIPTION
## Summary

Two zoom-in regressions surfaced when zooming the 24h-with-forecast view down to 30 min/bar and 15 min/bar:

1. **Forecast bars went sparse.** The renderer counted +1 h whenever an entry's exact timestamp landed in a bucket, so 1 h-spaced events vs. sub-hour buckets left every other slot at 0 %. Now each entry is treated as the mode active for [t, t+1 h) and the overlap with the bucket is summed — a 30-min bucket fully inside an \"emergency duty 0.4\" hour contributes 0.4 × 0.5 h, rendering as a 40 %-tall stripe (matching the underlying duty cycle).

2. **Forecast lines (tank / greenhouse / outside) were cut off** well before the chart's right edge — any sample with t > tMax was dropped, so when a zoomed window fell between two hourly trajectory points the trailing line ended at the last in-window sample. Now the first post-window sample drives a linearly-interpolated synthetic point at tMax, mirroring the leading-edge pattern that history-graph already uses.

The aggregator was extracted as a pure exported helper (`aggregateForecastBucket`) so the inspector's tooltip percentages reuse it — previously each side had a slightly-different copy of the same broken loop and the inspector ignored emergency `duty` entirely.

## Test plan
- [x] New unit test pins the aggregator across the bucket sizes the user zooms through (1 h, 30 min, 15 min, 6 h) plus duty + unknown-mode edge cases
- [x] Existing `forecast-tooltip.spec.js` (mode-band percentages, tank/greenhouse/outdoor temps) still passes against the shared aggregator
- [ ] Eyeball the zoomed 24h-with-forecast view at 30 min/bar and 15 min/bar on the preview deploy: bars are now contiguous and the tank/greenhouse/outside dashed lines extend to the right edge

🤖 Generated with [Claude Code](https://claude.com/claude-code)