### PR TITLE
graph: click chart legend labels to toggle series visibility

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -306,21 +306,21 @@
             <div class="graph-crosshair" id="graph-crosshair"></div>
           </div>
           <div class="graph-legend">
-            <div class="graph-legend-item"><div class="graph-legend-dot" style="background:#ee7d77;"></div>Charging</div>
-            <div class="graph-legend-item"><div class="graph-legend-dot" style="background:#e9c349;"></div>Heating</div>
-            <div class="graph-legend-item" id="legend-emergency" style="display:none;"><div class="graph-legend-dot" style="background:#ff7043;"></div>Emergency</div>
-            <div class="graph-legend-item"><div class="graph-legend-line" style="background:#ef5350;"></div>Collector<span class="graph-legend-stats" id="legend-stats-collector"></span></div>
-            <div class="graph-legend-item"><div class="graph-legend-line" style="background:#e9c349;"></div>Tank<span class="graph-legend-stats" id="legend-stats-tank"></span></div>
-            <div class="graph-legend-item sensor-detail" id="legend-tank-top" style="display:none;"><div class="graph-legend-line" style="background:#ff9f43;"></div>Tank Top<span class="graph-legend-stats" id="legend-stats-tank-top"></span></div>
-            <div class="graph-legend-item sensor-detail" id="legend-tank-bottom" style="display:none;"><div class="graph-legend-line" style="background:#b088d6;"></div>Tank Bottom<span class="graph-legend-stats" id="legend-stats-tank-bottom"></span></div>
-            <div class="graph-legend-item"><div class="graph-legend-line" style="background:#69d0c5;"></div>Greenhouse<span class="graph-legend-stats" id="legend-stats-greenhouse"></span></div>
-            <div class="graph-legend-item"><div class="graph-legend-line" style="background:#42a5f5;"></div>Outside<span class="graph-legend-stats" id="legend-stats-outdoor"></span></div>
-            <div class="graph-legend-item forecast-legend" style="display:none;"><div class="graph-legend-line graph-legend-line-dashed" style="background:#e9c349;"></div>Tank (forecast)</div>
-            <div class="graph-legend-item forecast-legend" style="display:none;"><div class="graph-legend-line graph-legend-line-dashed" style="background:#69d0c5;"></div>Greenhouse (forecast)</div>
-            <div class="graph-legend-item forecast-legend" style="display:none;"><div class="graph-legend-line graph-legend-line-dashed" style="background:#42a5f5;"></div>Outside (forecast)</div>
-            <div class="graph-legend-item forecast-legend" style="display:none;"><div class="graph-legend-dot" style="background:#ee7d77;opacity:0.45;"></div>Charging (projected)</div>
-            <div class="graph-legend-item forecast-legend" style="display:none;"><div class="graph-legend-dot" style="background:#e9c349;opacity:0.45;"></div>Heating (projected)</div>
-            <div class="graph-legend-item forecast-legend" style="display:none;"><div class="graph-legend-dot" style="background:#ff7043;opacity:0.55;"></div>Emergency (projected)</div>
+            <div class="graph-legend-item" data-series="charging" role="button" tabindex="0" aria-pressed="false"><div class="graph-legend-dot" style="background:#ee7d77;"></div>Charging</div>
+            <div class="graph-legend-item" data-series="heating" role="button" tabindex="0" aria-pressed="false"><div class="graph-legend-dot" style="background:#e9c349;"></div>Heating</div>
+            <div class="graph-legend-item" id="legend-emergency" data-series="emergency" role="button" tabindex="0" aria-pressed="false" style="display:none;"><div class="graph-legend-dot" style="background:#ff7043;"></div>Emergency</div>
+            <div class="graph-legend-item" data-series="t_collector" role="button" tabindex="0" aria-pressed="false"><div class="graph-legend-line" style="background:#ef5350;"></div>Collector<span class="graph-legend-stats" id="legend-stats-collector"></span></div>
+            <div class="graph-legend-item" data-series="tank" role="button" tabindex="0" aria-pressed="false"><div class="graph-legend-line" style="background:#e9c349;"></div>Tank<span class="graph-legend-stats" id="legend-stats-tank"></span></div>
+            <div class="graph-legend-item sensor-detail" id="legend-tank-top" data-series="t_tank_top" role="button" tabindex="0" aria-pressed="false" style="display:none;"><div class="graph-legend-line" style="background:#ff9f43;"></div>Tank Top<span class="graph-legend-stats" id="legend-stats-tank-top"></span></div>
+            <div class="graph-legend-item sensor-detail" id="legend-tank-bottom" data-series="t_tank_bottom" role="button" tabindex="0" aria-pressed="false" style="display:none;"><div class="graph-legend-line" style="background:#b088d6;"></div>Tank Bottom<span class="graph-legend-stats" id="legend-stats-tank-bottom"></span></div>
+            <div class="graph-legend-item" data-series="t_greenhouse" role="button" tabindex="0" aria-pressed="false"><div class="graph-legend-line" style="background:#69d0c5;"></div>Greenhouse<span class="graph-legend-stats" id="legend-stats-greenhouse"></span></div>
+            <div class="graph-legend-item" data-series="t_outdoor" role="button" tabindex="0" aria-pressed="false"><div class="graph-legend-line" style="background:#42a5f5;"></div>Outside<span class="graph-legend-stats" id="legend-stats-outdoor"></span></div>
+            <div class="graph-legend-item forecast-legend" data-series="forecast_tank" role="button" tabindex="0" aria-pressed="false" style="display:none;"><div class="graph-legend-line graph-legend-line-dashed" style="background:#e9c349;"></div>Tank (forecast)</div>
+            <div class="graph-legend-item forecast-legend" data-series="forecast_greenhouse" role="button" tabindex="0" aria-pressed="false" style="display:none;"><div class="graph-legend-line graph-legend-line-dashed" style="background:#69d0c5;"></div>Greenhouse (forecast)</div>
+            <div class="graph-legend-item forecast-legend" data-series="forecast_outdoor" role="button" tabindex="0" aria-pressed="false" style="display:none;"><div class="graph-legend-line graph-legend-line-dashed" style="background:#42a5f5;"></div>Outside (forecast)</div>
+            <div class="graph-legend-item forecast-legend" data-series="forecast_charging" role="button" tabindex="0" aria-pressed="false" style="display:none;"><div class="graph-legend-dot" style="background:#ee7d77;opacity:0.45;"></div>Charging (projected)</div>
+            <div class="graph-legend-item forecast-legend" data-series="forecast_heating" role="button" tabindex="0" aria-pressed="false" style="display:none;"><div class="graph-legend-dot" style="background:#e9c349;opacity:0.45;"></div>Heating (projected)</div>
+            <div class="graph-legend-item forecast-legend" data-series="forecast_emergency" role="button" tabindex="0" aria-pressed="false" style="display:none;"><div class="graph-legend-dot" style="background:#ff7043;opacity:0.55;"></div>Emergency (projected)</div>
           </div>
         </div>
 

--- a/playground/js/main.js
+++ b/playground/js/main.js
@@ -45,6 +45,7 @@ import {
   params, timeSeriesStore, trendStore,
   setModel, setController, setRunning,
   setSimSpeed, setShowAllSensors, setShowForecast,
+  hiddenSeries, toggleSeriesHidden,
 } from './main/state.js';
 
 let config = null;
@@ -95,6 +96,7 @@ async function init() {
   setupTimeRangeSlider();
   setupAllSensorsToggle();
   setupForecastToggle();
+  setupLegendToggles();
   setupFAB();
   resetSim();
   // Schematic view — async build, handle held in display-update module.
@@ -270,6 +272,33 @@ function applyForecastLegendVisibility() {
   const display = showForecast ? '' : 'none';
   document.querySelectorAll('.forecast-legend').forEach((el) => {
     el.style.display = display;
+  });
+}
+
+// Click/keyboard handlers on each `.graph-legend-item[data-series]` toggle
+// the matching series in `hiddenSeries`. The drawing code reads the set
+// directly, so a redraw reflects the change. aria-pressed mirrors the
+// hidden state — the inactive CSS hangs off that attribute selector so
+// state, a11y, and visuals all stay aligned.
+function setupLegendToggles() {
+  const items = document.querySelectorAll('.graph-legend-item[data-series]');
+  items.forEach((el) => {
+    const id = el.getAttribute('data-series');
+    if (!id) return;
+    const sync = () => el.setAttribute('aria-pressed', hiddenSeries.has(id) ? 'true' : 'false');
+    sync();
+    const toggle = () => {
+      toggleSeriesHidden(id);
+      sync();
+      drawHistoryGraph();
+    };
+    el.addEventListener('click', toggle);
+    el.addEventListener('keydown', (e) => {
+      if (e.key === ' ' || e.key === 'Enter') {
+        e.preventDefault();
+        toggle();
+      }
+    });
   });
 }
 

--- a/playground/js/main/forecast-overlay.js
+++ b/playground/js/main/forecast-overlay.js
@@ -8,6 +8,7 @@
 
 import { pickBucketSize } from '../ui.js';
 import { drawEmergencyStripes } from './emergency-stripes.js';
+import { hiddenSeries } from './state.js';
 
 // Forecast overlay rendering: tank avg + greenhouse + outdoor trajectories
 // (dashed) past "now", predicted mode bands (charging/heating/emergency)
@@ -76,9 +77,9 @@ export function drawForecastOverlay(ctx, data, nowSec, cutoffSec, tMin, tMax, vi
   // Outdoor lives in the raw weather array (top-level of the response,
   // alongside `forecast`), not in the engine's projection — the engine
   // consumes it as an input to compute tank/greenhouse cooling.
-  drawDashed(toPts(fc.tankTrajectory, p => (typeof p.avg === 'number' ? p.avg : (p.top + p.bottom) / 2)), '#e9c349', 1.5);
-  drawDashed(toPts(fc.greenhouseTrajectory, p => p.temp), '#69d0c5', 1.5);
-  drawDashed(toPts(data.weather, p => p.temperature, 'validAt'), '#42a5f5', 1);
+  if (!hiddenSeries.has('forecast_tank'))       drawDashed(toPts(fc.tankTrajectory, p => (typeof p.avg === 'number' ? p.avg : (p.top + p.bottom) / 2)), '#e9c349', 1.5);
+  if (!hiddenSeries.has('forecast_greenhouse')) drawDashed(toPts(fc.greenhouseTrajectory, p => p.temp), '#69d0c5', 1.5);
+  if (!hiddenSeries.has('forecast_outdoor'))    drawDashed(toPts(data.weather, p => p.temperature, 'validAt'), '#42a5f5', 1);
 
   // Predicted mode bands (charging / heating / emergency) past "now",
   // bucketed at the same bucketSec as the historical duty bars on the
@@ -183,18 +184,18 @@ function drawForecastModeBars(ctx, modeForecast, nowSec, cutoffSec, tMin, tMax, 
     const barW = Math.max(1, ((segEnd - segStart) / visibleRange) * pw - 2);
     let stackH = 0;
 
-    if (chargingFrac > 0) {
+    if (chargingFrac > 0 && !hiddenSeries.has('forecast_charging')) {
       const bh = chargingFrac * barAreaH;
       ctx.fillStyle = 'rgba(238, 125, 119, 0.45)';
       ctx.fillRect(barX, barY0 - bh, barW, bh);
       stackH += bh;
     }
-    if (heatingFrac > 0) {
+    if (heatingFrac > 0 && !hiddenSeries.has('forecast_heating')) {
       const bh = heatingFrac * barAreaH;
       ctx.fillStyle = 'rgba(233, 195, 73, 0.45)';
       ctx.fillRect(barX, barY0 - stackH - bh, barW, bh);
     }
-    if (emergencyFrac > 0) {
+    if (emergencyFrac > 0 && !hiddenSeries.has('forecast_emergency')) {
       const bh = emergencyFrac * barAreaH;
       // Mirror the historical band: anchor at baseline so the stripes
       // overlay the underlying charging/heating bar at the same X.

--- a/playground/js/main/history-graph.js
+++ b/playground/js/main/history-graph.js
@@ -10,6 +10,7 @@ import { SIM_START_HOUR } from '../sim-bootstrap.js';
 import {
   timeSeriesStore, graphRange, showAllSensors, chartZoom,
   showForecast, forecastData, FORECAST_OVERLAY_SEC,
+  hiddenSeries,
 } from './state.js';
 import { coverageInBucket } from './mode-events.js';
 import { drawForecastOverlay } from './forecast-overlay.js';
@@ -229,14 +230,14 @@ export function drawHistoryGraph() {
 
     let stackH = 0;
 
-    if (chargingFrac > 0) {
+    if (chargingFrac > 0 && !hiddenSeries.has('charging')) {
       const bh = chargingFrac * barAreaH;
       ctx.fillStyle = 'rgba(238, 125, 119, 0.6)';
       ctx.fillRect(barX, barY0 - bh, barW, bh);
       stackH += bh;
     }
 
-    if (heatingFrac > 0) {
+    if (heatingFrac > 0 && !hiddenSeries.has('heating')) {
       const htBh = heatingFrac * barAreaH;
       ctx.fillStyle = 'rgba(233, 195, 73, 0.6)';
       ctx.fillRect(barX, barY0 - stackH - htBh, barW, htBh);
@@ -244,14 +245,18 @@ export function drawHistoryGraph() {
 
     if (emergencyFrac > 0) {
       hasEmergency = true;
-      const emBh = emergencyFrac * barAreaH;
-      // Anchor the EMERGENCY band at the baseline (Y-zero), not stacked
-      // on top of charging+heating. The stripes are transparent between
-      // lines so the underlying mode bar's true height stays readable
-      // through the gaps — matches the overlay semantics.
-      drawEmergencyStripes(ctx, barX, barY0 - emBh, barW, emBh, 'rgba(255, 112, 67, 0.85)');
+      if (!hiddenSeries.has('emergency')) {
+        const emBh = emergencyFrac * barAreaH;
+        // Anchor the EMERGENCY band at the baseline (Y-zero), not stacked
+        // on top of charging+heating. The stripes are transparent between
+        // lines so the underlying mode bar's true height stays readable
+        // through the gaps — matches the overlay semantics.
+        drawEmergencyStripes(ctx, barX, barY0 - emBh, barW, emBh, 'rgba(255, 112, 67, 0.85)');
+      }
     }
   }
+  // The legend slot stays visible whenever emergency activity exists in
+  // the window so the user can click it back on after hiding it.
   document.getElementById('legend-emergency').style.display = hasEmergency ? 'flex' : 'none';
 
   // ── Temperature line (gold, matching Stitch design) ──
@@ -260,7 +265,7 @@ export function drawHistoryGraph() {
   // interpolated point at tMin so the line meets the chart's left edge
   // even when a real sensor-reading gap straddles the boundary.
   const smoothW = lineSmoothingWindow(visibleRange);
-  const pts = smoothPoints(
+  const pts = hiddenSeries.has('tank') ? [] : smoothPoints(
     collectSeriesPts(timeSeriesStore, tMin, tMax, visibleRange, pad, pw, ph, yMin, yMax, tankAvgOf),
     smoothW,
   );
@@ -308,18 +313,18 @@ export function drawHistoryGraph() {
 
   // ── Tank sub-sensor lines (only with the "All sensors" toggle) ──
   if (showAllSensors) {
-    drawTempLine(ctx, timeSeriesStore, tMin, tMax, visibleRange, pad, pw, ph, yMin, yMax, 't_tank_top', '#ff9f43', 1);
-    drawTempLine(ctx, timeSeriesStore, tMin, tMax, visibleRange, pad, pw, ph, yMin, yMax, 't_tank_bottom', '#b088d6', 1);
+    if (!hiddenSeries.has('t_tank_top'))    drawTempLine(ctx, timeSeriesStore, tMin, tMax, visibleRange, pad, pw, ph, yMin, yMax, 't_tank_top', '#ff9f43', 1);
+    if (!hiddenSeries.has('t_tank_bottom')) drawTempLine(ctx, timeSeriesStore, tMin, tMax, visibleRange, pad, pw, ph, yMin, yMax, 't_tank_bottom', '#b088d6', 1);
   }
 
   // ── Collector line (red) ──
-  drawTempLine(ctx, timeSeriesStore, tMin, tMax, visibleRange, pad, pw, ph, yMin, yMax, 't_collector', '#ef5350', 1.5);
+  if (!hiddenSeries.has('t_collector')) drawTempLine(ctx, timeSeriesStore, tMin, tMax, visibleRange, pad, pw, ph, yMin, yMax, 't_collector', '#ef5350', 1.5);
 
   // ── Greenhouse line (green) ──
-  drawTempLine(ctx, timeSeriesStore, tMin, tMax, visibleRange, pad, pw, ph, yMin, yMax, 't_greenhouse', '#69d0c5', 1);
+  if (!hiddenSeries.has('t_greenhouse')) drawTempLine(ctx, timeSeriesStore, tMin, tMax, visibleRange, pad, pw, ph, yMin, yMax, 't_greenhouse', '#69d0c5', 1);
 
   // ── Outside line (blue) ──
-  drawTempLine(ctx, timeSeriesStore, tMin, tMax, visibleRange, pad, pw, ph, yMin, yMax, 't_outdoor', '#42a5f5', 1);
+  if (!hiddenSeries.has('t_outdoor')) drawTempLine(ctx, timeSeriesStore, tMin, tMax, visibleRange, pad, pw, ph, yMin, yMax, 't_outdoor', '#42a5f5', 1);
 
   // ── Forecast overlay (next 48 h, dashed, only with the "Forecast" toggle) ──
   // Live-only (chartNowSec returns null in sim mode → overlay no-ops).

--- a/playground/js/main/state.js
+++ b/playground/js/main/state.js
@@ -57,6 +57,17 @@ export function setShowForecast(v) { showForecast = v; }
 export let forecastData = null;
 export function setForecastData(v) { forecastData = v; }
 
+// Per-series hide flags driven by clicks on the chart legend. Each
+// id matches a `data-series` attribute on a legend item and the
+// corresponding skip-check in history-graph.js / forecast-overlay.js.
+// In-memory only (matches showAllSensors / showForecast).
+export const hiddenSeries = new Set();
+export function toggleSeriesHidden(id) {
+  if (hiddenSeries.has(id)) hiddenSeries.delete(id);
+  else hiddenSeries.add(id);
+  return hiddenSeries.has(id);
+}
+
 // Full engine horizon, shown when the forecast overlay is on. The
 // physics/cost engine returns 48 h of trajectory + weather, and the
 // overlay surfaces all of it so the user can see the entire projected

--- a/playground/public/style.css
+++ b/playground/public/style.css
@@ -679,6 +679,28 @@ select, input, textarea { max-width: 100%; }
   letter-spacing: 0.1em;
   color: var(--on-surface-variant);
   font-weight: 600;
+  cursor: pointer;
+  user-select: none;
+  -webkit-tap-highlight-color: transparent;
+  transition: opacity 0.15s ease;
+}
+
+.graph-legend-item:focus-visible {
+  outline: 2px solid var(--on-surface-variant);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+/* Inactive style — applied when the user clicks a legend label to hide
+ * its series in the graph. Dim the whole row and strike through the text
+ * so the marker stays color-identifiable but reads as "off". */
+.graph-legend-item[aria-pressed="true"] {
+  opacity: 0.4;
+  text-decoration: line-through;
+}
+
+.graph-legend-item[aria-pressed="true"] .graph-legend-stats {
+  text-decoration: line-through;
 }
 
 .graph-legend-dot {

--- a/tests/frontend/chart-legend-toggle.spec.js
+++ b/tests/frontend/chart-legend-toggle.spec.js
@@ -1,0 +1,149 @@
+// @ts-check
+/**
+ * Tests for clickable legend labels on the Status history graph.
+ *
+ * Each .graph-legend-item carries a data-series id; clicking it toggles
+ * the matching series in the hiddenSeries set (state.js), updates
+ * aria-pressed on the row, and triggers a redraw that skips that
+ * series' bars/lines.
+ */
+import { test, expect } from './fixtures.js';
+
+async function installMockWs(page) {
+  await page.addInitScript(() => {
+    const OrigWS = window.WebSocket;
+    // @ts-ignore
+    window.WebSocket = function () {
+      const fake = {
+        readyState: 0, onopen: null, onmessage: null, onclose: null, onerror: null,
+        close: function () { this.readyState = 3; },
+        send: function () {},
+      };
+      // @ts-ignore
+      window.__mockWs = fake;
+      const stateData = {
+        mode: 'solar_charging',
+        temps: { collector: 62.5, tank_top: 48.2, tank_bottom: 33.9, greenhouse: 21.7, outdoor: 11.4 },
+        valves: { vi_btm: true, vi_top: false, vi_coll: false, vo_coll: true, vo_rad: false, vo_tank: false, v_air: false },
+        actuators: { pump: true, fan: false, space_heater: false },
+        controls_enabled: true,
+        manual_override: null,
+      };
+      setTimeout(() => {
+        fake.readyState = 1;
+        if (fake.onopen) fake.onopen(new Event('open'));
+        if (fake.onmessage) {
+          fake.onmessage({ data: JSON.stringify({ type: 'connection', status: 'connected' }) });
+          fake.onmessage({ data: JSON.stringify({ type: 'state', data: stateData }) });
+        }
+      }, 50);
+      return fake;
+    };
+    // @ts-ignore
+    window.WebSocket.prototype = OrigWS.prototype;
+    window.WebSocket.OPEN = 1;
+    window.WebSocket.CLOSED = 3;
+  });
+}
+
+async function mockHistoryApi(page) {
+  const now = Date.now();
+  const body = JSON.stringify({
+    range: '24h',
+    points: [
+      { ts: now - 7200_000, collector: 25.0, tank_top: 52.0, tank_bottom: 34.0, greenhouse: 17.0, outdoor: 9.0 },
+      { ts: now - 3600_000, collector: 45.0, tank_top: 58.0, tank_bottom: 36.0, greenhouse: 18.5, outdoor: 10.0 },
+      { ts: now - 1800_000, collector: 60.0, tank_top: 62.0, tank_bottom: 38.0, greenhouse: 20.0, outdoor: 11.0 },
+    ],
+    events: [
+      { ts: now - 7200_000, type: 'mode', id: 'controller', from: 'idle', to: 'idle' },
+      { ts: now - 3600_000, type: 'mode', id: 'controller', from: 'idle', to: 'solar_charging' },
+    ],
+  });
+  await page.route('**/api/history**', route => route.fulfill({
+    status: 200, contentType: 'application/json', body,
+  }));
+}
+
+test.describe('Chart legend toggles', () => {
+  test('clicking a legend label toggles aria-pressed and applies inactive style', async ({ page }) => {
+    await installMockWs(page);
+    await mockHistoryApi(page);
+    await page.goto('/playground/', { waitUntil: 'domcontentloaded' });
+
+    await expect(page.locator('#connection-dot')).toHaveClass(/connected/, { timeout: 3000 });
+
+    const collector = page.locator('.graph-legend-item[data-series="t_collector"]');
+    await expect(collector).toHaveAttribute('aria-pressed', 'false');
+
+    // Visible by default — line-through only applies when pressed.
+    await expect(collector).toHaveCSS('text-decoration-line', 'none');
+
+    await collector.click();
+    await expect(collector).toHaveAttribute('aria-pressed', 'true');
+    await expect(collector).toHaveCSS('text-decoration-line', 'line-through');
+
+    // Click again restores it.
+    await collector.click();
+    await expect(collector).toHaveAttribute('aria-pressed', 'false');
+    await expect(collector).toHaveCSS('text-decoration-line', 'none');
+  });
+
+  test('Enter and Space toggle a legend label from the keyboard', async ({ page }) => {
+    await installMockWs(page);
+    await mockHistoryApi(page);
+    await page.goto('/playground/', { waitUntil: 'domcontentloaded' });
+
+    await expect(page.locator('#connection-dot')).toHaveClass(/connected/, { timeout: 3000 });
+
+    const tank = page.locator('.graph-legend-item[data-series="tank"]');
+    await tank.focus();
+
+    await page.keyboard.press('Enter');
+    await expect(tank).toHaveAttribute('aria-pressed', 'true');
+
+    await page.keyboard.press('Space');
+    await expect(tank).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  test('every clickable legend row has role=button + tabindex for a11y', async ({ page }) => {
+    await installMockWs(page);
+    await mockHistoryApi(page);
+    await page.goto('/playground/', { waitUntil: 'domcontentloaded' });
+
+    const items = page.locator('.graph-legend-item[data-series]');
+    const count = await items.count();
+    expect(count).toBeGreaterThanOrEqual(7);
+    for (let i = 0; i < count; i++) {
+      const item = items.nth(i);
+      await expect(item).toHaveAttribute('role', 'button');
+      await expect(item).toHaveAttribute('tabindex', '0');
+      await expect(item).toHaveAttribute('aria-pressed', /^(true|false)$/);
+    }
+  });
+
+  test('hiding the Charging bar visibly changes the rendered chart', async ({ page }) => {
+    await installMockWs(page);
+    await mockHistoryApi(page);
+    await page.goto('/playground/', { waitUntil: 'domcontentloaded' });
+
+    await expect(page.locator('#connection-dot')).toHaveClass(/connected/, { timeout: 3000 });
+
+    // Wait for at least the seeded history to be drawn.
+    await expect.poll(() => page.evaluate(() => {
+      // @ts-ignore
+      return typeof window.__getHistoryPointCount === 'function'
+        ? window.__getHistoryPointCount()
+        : null;
+    }), { timeout: 5000 }).toBeGreaterThanOrEqual(3);
+
+    const before = await page.locator('#chart').screenshot();
+
+    await page.locator('.graph-legend-item[data-series="charging"]').click();
+    await expect(page.locator('.graph-legend-item[data-series="charging"]'))
+      .toHaveAttribute('aria-pressed', 'true');
+
+    const after = await page.locator('#chart').screenshot();
+    expect(Buffer.compare(before, after)).not.toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Each `.graph-legend-item` is now a `role=button` keyed by `data-series`. Clicking (or pressing Enter/Space) toggles the matching id in a shared `hiddenSeries: Set` in `playground/js/main/state.js`.
- `history-graph.js` skips charging / heating / emergency bars and the per-sensor temperature lines when their id is hidden; `forecast-overlay.js` does the same for the dashed forecast trajectories and projected mode bars.
- Hidden labels read as inactive: `[aria-pressed="true"]` dims the whole row to 0.4 opacity and strikes through the text, while the colour swatch stays so the series is still identifiable. `cursor: pointer` and a `:focus-visible` outline signal the new affordance.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run knip` — clean
- [x] `npm run check:file-size -- --strict` — 0 over hard cap
- [x] `npm run check:assets -- --strict` — clean
- [x] `npm run test:unit` — 1144 pass / 0 fail
- [x] `npx playwright test` — 307 pass (incl. 4 new in `tests/frontend/chart-legend-toggle.spec.js`: click + keyboard toggle, role/tabindex/aria-pressed contract, canvas screenshot diff after hiding Charging)
- [x] `npm run coverage:frontend` — gate ✓
- [ ] Manual smoke on the preview deploy: tap each legend label on the Status view (live mode) and confirm the matching bars / lines disappear, the row dims with strikethrough, and tapping again restores it. Repeat with Forecast on for the dashed-trajectory rows.

https://claude.ai/code/session_01XH3iqLbdUyCBsdqTV4a4ds

---
_Generated by [Claude Code](https://claude.ai/code/session_01XH3iqLbdUyCBsdqTV4a4ds)_