### PR TITLE
graph: fullscreen mode with Y-axis autoscale + labels

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -284,6 +284,9 @@
               <span>Forecast</span>
               <div class="mode-toggle-switch" id="graph-show-forecast" role="switch" tabindex="0" aria-checked="false"></div>
             </div>
+            <button type="button" class="graph-fullscreen-btn" id="graph-fullscreen-btn" aria-label="Toggle fullscreen" aria-pressed="false" title="Toggle fullscreen">
+              <span class="material-symbols-outlined" id="graph-fullscreen-icon">fullscreen</span>
+            </button>
           </div>
           <div class="graph-container">
             <canvas id="chart"></canvas>

--- a/playground/js/main.js
+++ b/playground/js/main.js
@@ -46,6 +46,7 @@ import {
   setModel, setController, setRunning,
   setSimSpeed, setShowAllSensors, setShowForecast,
   hiddenSeries, toggleSeriesHidden,
+  setChartFullscreen,
 } from './main/state.js';
 
 let config = null;
@@ -97,6 +98,7 @@ async function init() {
   setupAllSensorsToggle();
   setupForecastToggle();
   setupLegendToggles();
+  setupFullscreenToggle();
   setupFAB();
   resetSim();
   // Schematic view — async build, handle held in display-update module.
@@ -273,6 +275,52 @@ function applyForecastLegendVisibility() {
   document.querySelectorAll('.forecast-legend').forEach((el) => {
     el.style.display = display;
   });
+}
+
+// Fullscreen toggle for the chart card. Uses the native Fullscreen API
+// on the same .graph-card element so the existing toggles, legend, WS
+// data updates, and chartZoom state all stay live — no duplicate DOM,
+// no parallel state to keep in sync. The icon flips on
+// fullscreenchange (also covers ESC and the browser's own exit gesture)
+// and a redraw fires so the autoscale + Y-axis labels re-evaluate
+// against the new dimensions. A window resize listener keeps the
+// canvas sharp during the enter/exit animation on browsers that fire
+// resize before fullscreenchange.
+function setupFullscreenToggle() {
+  const btn = document.getElementById('graph-fullscreen-btn');
+  const icon = document.getElementById('graph-fullscreen-icon');
+  const card = document.querySelector('.graph-card');
+  if (!btn || !card || !icon) return;
+
+  const reqFs = card.requestFullscreen || card.webkitRequestFullscreen;
+  const exitFs = document.exitFullscreen || document.webkitExitFullscreen;
+  // Hide the affordance entirely on browsers without the API rather
+  // than show a button that does nothing when tapped.
+  if (!reqFs || !exitFs) { btn.style.display = 'none'; return; }
+
+  const fsElement = () => document.fullscreenElement || document.webkitFullscreenElement || null;
+
+  btn.addEventListener('click', () => {
+    if (fsElement() === card) {
+      const r = exitFs.call(document);
+      if (r && typeof r.catch === 'function') r.catch(() => {});
+    } else {
+      const r = reqFs.call(card);
+      if (r && typeof r.catch === 'function') r.catch(() => {});
+    }
+  });
+
+  const sync = () => {
+    const active = fsElement() === card;
+    setChartFullscreen(active);
+    icon.textContent = active ? 'fullscreen_exit' : 'fullscreen';
+    btn.setAttribute('aria-pressed', active ? 'true' : 'false');
+    btn.setAttribute('aria-label', active ? 'Exit fullscreen' : 'Toggle fullscreen');
+    drawHistoryGraph();
+  };
+  document.addEventListener('fullscreenchange', sync);
+  document.addEventListener('webkitfullscreenchange', sync);
+  window.addEventListener('resize', () => drawHistoryGraph());
 }
 
 // Click/keyboard handlers on each `.graph-legend-item[data-series]` toggle

--- a/playground/js/main/history-graph.js
+++ b/playground/js/main/history-graph.js
@@ -10,7 +10,7 @@ import { SIM_START_HOUR } from '../sim-bootstrap.js';
 import {
   timeSeriesStore, graphRange, showAllSensors, chartZoom,
   showForecast, forecastData, FORECAST_OVERLAY_SEC,
-  hiddenSeries,
+  hiddenSeries, chartFullscreen,
 } from './state.js';
 import { coverageInBucket } from './mode-events.js';
 import { drawForecastOverlay } from './forecast-overlay.js';
@@ -135,6 +135,47 @@ export function tankAvgOf(row) {
   return (row.t_tank_top + row.t_tank_bottom) / 2;
 }
 
+// Pure: scan visible non-hidden temperature samples and return a Y
+// range that fits them with 10% headroom, snapped to multiples of 5°
+// for tidy axis labels. Falls back to the embedded-card default
+// [0,100] when no in-window samples exist (boot before /api/history
+// has resolved). The 5° floor on the data span keeps a flat line from
+// rendering as a paper-thin slice when readings barely move.
+export function autoYRange(timeSeriesStore, tMin, tMax, hidden, allSensors) {
+  let lo = Infinity;
+  let hi = -Infinity;
+  const baseKeys = ['t_collector', 't_greenhouse', 't_outdoor'];
+  const detailKeys = allSensors ? ['t_tank_top', 't_tank_bottom'] : [];
+  for (let i = 0; i < timeSeriesStore.times.length; i++) {
+    const t = timeSeriesStore.times[i];
+    if (t < tMin || t > tMax) continue;
+    const row = timeSeriesStore.values[i];
+    if (!hidden.has('tank')) {
+      const a = tankAvgOf(row);
+      if (a !== null) { if (a < lo) lo = a; if (a > hi) hi = a; }
+    }
+    for (let k = 0; k < baseKeys.length; k++) {
+      const key = baseKeys[k];
+      if (hidden.has(key)) continue;
+      const v = row[key];
+      if (isNum(v)) { if (v < lo) lo = v; if (v > hi) hi = v; }
+    }
+    for (let k = 0; k < detailKeys.length; k++) {
+      const key = detailKeys[k];
+      if (hidden.has(key)) continue;
+      const v = row[key];
+      if (isNum(v)) { if (v < lo) lo = v; if (v > hi) hi = v; }
+    }
+  }
+  if (!isFinite(lo) || !isFinite(hi)) return { yMin: 0, yMax: 100 };
+  if (hi - lo < 5) hi = lo + 5;
+  const range = hi - lo;
+  return {
+    yMin: Math.floor((lo - range * 0.1) / 5) * 5,
+    yMax: Math.ceil((hi + range * 0.1) / 5) * 5,
+  };
+}
+
 export function drawHistoryGraph() {
   const canvas = document.getElementById('chart');
   const ctx = canvas.getContext('2d');
@@ -149,7 +190,9 @@ export function drawHistoryGraph() {
   const dh = canvas.offsetHeight;
   ctx.clearRect(0, 0, dw, dh);
 
-  const pad = { top: 16, right: 16, bottom: 24, left: 8 };
+  // Fullscreen mode adds a left-side gutter for the Y-axis labels.
+  // Otherwise the chart hugs the card edge as before.
+  const pad = { top: 16, right: 16, bottom: 24, left: chartFullscreen ? 36 : 8 };
   const pw = dw - pad.left - pad.right;
   const ph = dh - pad.top - pad.bottom;
 
@@ -158,10 +201,15 @@ export function drawHistoryGraph() {
   const { tMin, tMax } = getChartWindow();
   const visibleRange = tMax - tMin;
 
-  // Y range for temperature
-  const yMin = 0, yMax = 100;
+  // Y range — fullscreen mode autoscales to the visible non-hidden
+  // series (with 10% padding, snapped to multiples of 5°). The default
+  // [0,100] keeps the embedded card view stable across data.
+  const { yMin, yMax } = chartFullscreen
+    ? autoYRange(timeSeriesStore, tMin, tMax, hiddenSeries, showAllSensors)
+    : { yMin: 0, yMax: 100 };
 
-  // Grid lines
+  // Grid lines (4 segments → 5 lines counting both edges; the inner
+  // 3 are the "interior" lines drawn here).
   ctx.strokeStyle = 'rgba(255,255,255,0.05)';
   ctx.lineWidth = 1;
   for (let i = 1; i < 4; i++) {
@@ -170,6 +218,23 @@ export function drawHistoryGraph() {
     ctx.moveTo(pad.left, y);
     ctx.lineTo(pad.left + pw, y);
     ctx.stroke();
+  }
+
+  // Y-axis labels — fullscreen only. Five labels at the gridline
+  // positions (0, 1/4, 2/4, 3/4, 4/4) so the user can read off
+  // temperatures without hovering for the inspector.
+  if (chartFullscreen) {
+    ctx.fillStyle = '#a5abb9';
+    ctx.font = '10px Manrope, sans-serif';
+    ctx.textAlign = 'right';
+    ctx.textBaseline = 'middle';
+    for (let i = 0; i <= 4; i++) {
+      const frac = i / 4;
+      const y = pad.top + ph - frac * ph;
+      const v = yMin + frac * (yMax - yMin);
+      ctx.fillText(Math.round(v) + '°', pad.left - 4, y);
+    }
+    ctx.textBaseline = 'alphabetic';
   }
 
   // X-axis time labels — pick a step that keeps the label count readable

--- a/playground/js/main/state.js
+++ b/playground/js/main/state.js
@@ -68,6 +68,15 @@ export function toggleSeriesHidden(id) {
   return hiddenSeries.has(id);
 }
 
+// True while the chart card is in browser fullscreen. Mirrors
+// `document.fullscreenElement === graphCard`, set on the
+// `fullscreenchange` event. drawHistoryGraph reads this to enable
+// y-axis autoscale + axis labels; the same DOM stays mounted, so all
+// settings (toggles, hidden series) and live-WS data updates flow
+// through unchanged.
+export let chartFullscreen = false;
+export function setChartFullscreen(v) { chartFullscreen = v; }
+
 // Full engine horizon, shown when the forecast overlay is on. The
 // physics/cost engine returns 48 h of trajectory + weather, and the
 // overlay surfaces all of it so the user can see the entire projected

--- a/playground/public/style.css
+++ b/playground/public/style.css
@@ -648,6 +648,35 @@ select, input, textarea { max-width: 100%; }
   user-select: none;
 }
 
+/* Fullscreen toggle — sits at the right edge of the graph header
+ * alongside the All Sensors / Forecast switches. Clicking it calls
+ * requestFullscreen on the .graph-card so the same DOM (toggles,
+ * legend, canvas) stretches to fill the viewport — every setting
+ * stays in sync because nothing is duplicated. */
+.graph-fullscreen-btn {
+  background: transparent;
+  border: none;
+  color: var(--on-surface-variant);
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 8px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 120ms ease, color 120ms ease;
+}
+.graph-fullscreen-btn:hover {
+  color: var(--on-surface);
+  background: var(--surface-container-highest);
+}
+.graph-fullscreen-btn:focus-visible {
+  outline: 2px solid var(--on-surface-variant);
+  outline-offset: 2px;
+}
+.graph-fullscreen-btn .material-symbols-outlined {
+  font-size: 20px;
+  line-height: 1;
+}
 
 .graph-container {
   position: relative;
@@ -746,6 +775,39 @@ select, input, textarea { max-width: 100%; }
   color: var(--on-surface-variant);
   font-weight: 500;
   margin-left: 4px;
+}
+
+/* ── Fullscreen chart layout ──
+ * The graph-card is the element passed to requestFullscreen, so the
+ * :fullscreen pseudo-class targets it directly. The header + legend
+ * are kept (the toggles and clickable labels stay reachable); the
+ * canvas container grows into the remaining vertical space. */
+.graph-card:fullscreen,
+.graph-card:-webkit-full-screen {
+  width: 100vw;
+  height: 100vh;
+  padding: 16px 24px;
+  background: var(--surface);
+  border-radius: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.graph-card:fullscreen .graph-header,
+.graph-card:-webkit-full-screen .graph-header {
+  margin-bottom: 0;
+  flex: 0 0 auto;
+}
+.graph-card:fullscreen .graph-container,
+.graph-card:-webkit-full-screen .graph-container {
+  flex: 1 1 auto;
+  height: auto;
+  min-height: 0;
+}
+.graph-card:fullscreen .graph-legend,
+.graph-card:-webkit-full-screen .graph-legend {
+  flex: 0 0 auto;
+  margin-top: 0;
 }
 
 /* ── Graph Inspector ── */

--- a/tests/auto-y-range.test.mjs
+++ b/tests/auto-y-range.test.mjs
@@ -1,0 +1,91 @@
+/**
+ * Unit tests for autoYRange — the pure helper that the chart's
+ * fullscreen mode uses to fit the Y axis to the visible non-hidden
+ * temperature samples. The embedded card view stays on the fixed
+ * [0,100] range, so this helper is only exercised when the user
+ * enters fullscreen.
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { autoYRange } from '../playground/js/main/history-graph.js';
+
+function makeStore(rows) {
+  return {
+    times: rows.map(r => r.t),
+    values: rows.map(r => r.v),
+  };
+}
+
+describe('autoYRange', () => {
+  it('returns [0,100] when no in-window samples exist', () => {
+    const store = makeStore([]);
+    const r = autoYRange(store, 0, 1000, new Set(), false);
+    assert.deepStrictEqual(r, { yMin: 0, yMax: 100 });
+  });
+
+  it('fits the visible range with 10% headroom snapped to multiples of 5', () => {
+    const store = makeStore([
+      { t: 100, v: { t_collector: 30, t_tank_top: 50, t_tank_bottom: 40, t_greenhouse: 18, t_outdoor: 10 } },
+      { t: 200, v: { t_collector: 60, t_tank_top: 55, t_tank_bottom: 42, t_greenhouse: 19, t_outdoor: 11 } },
+    ]);
+    const r = autoYRange(store, 0, 1000, new Set(), false);
+    // min visible = 10 (outdoor), max visible = 60 (collector)
+    // range = 50 → pad ±5 → [5, 65] → snap to multiples of 5 = [5, 65]
+    assert.strictEqual(r.yMin, 5);
+    assert.strictEqual(r.yMax, 65);
+  });
+
+  it('skips samples outside [tMin,tMax]', () => {
+    const store = makeStore([
+      { t: 50,  v: { t_collector: 90, t_tank_top: 80, t_tank_bottom: 70, t_greenhouse: 60, t_outdoor: 50 } },
+      { t: 200, v: { t_collector: 30, t_tank_top: 40, t_tank_bottom: 30, t_greenhouse: 18, t_outdoor: 10 } },
+    ]);
+    const r = autoYRange(store, 100, 300, new Set(), false);
+    // Only the t=200 row counts: min=10, max=35 (tank avg = (40+30)/2)
+    // range = 25 → pad ±2.5 → [7.5, 37.5] → floor/ceil to /5 = [5, 40]
+    assert.strictEqual(r.yMin, 5);
+    assert.strictEqual(r.yMax, 40);
+  });
+
+  it('drops a series whose id is in the hidden set', () => {
+    const store = makeStore([
+      { t: 100, v: { t_collector: 90, t_tank_top: 50, t_tank_bottom: 40, t_greenhouse: 20, t_outdoor: 12 } },
+    ]);
+    const r = autoYRange(store, 0, 1000, new Set(['t_collector']), false);
+    // collector hidden — max visible = 45 (tank avg), min = 12 (outdoor)
+    assert.ok(r.yMax < 90, `expected < 90 with collector hidden, got ${r.yMax}`);
+  });
+
+  it('drops the tank average when "tank" is hidden', () => {
+    const store = makeStore([
+      { t: 100, v: { t_collector: 30, t_tank_top: 90, t_tank_bottom: 80, t_greenhouse: 20, t_outdoor: 12 } },
+    ]);
+    // With tank hidden and allSensors=false, the 80-90° tank readings
+    // shouldn't pull the upper bound up — only collector/greenhouse/outdoor
+    // contribute, so max ≈ 30.
+    const r = autoYRange(store, 0, 1000, new Set(['tank']), false);
+    assert.ok(r.yMax <= 35, `expected yMax around 30 with tank hidden, got ${r.yMax}`);
+  });
+
+  it('includes tank top/bottom only when allSensors=true', () => {
+    const store = makeStore([
+      { t: 100, v: { t_collector: 30, t_tank_top: 80, t_tank_bottom: 60, t_greenhouse: 20, t_outdoor: 12 } },
+    ]);
+    // With tank hidden but allSensors=true the individual top/bottom
+    // are visible and pull the upper bound to ~80.
+    const r = autoYRange(store, 0, 1000, new Set(['tank']), true);
+    assert.ok(r.yMax >= 80, `expected yMax >= 80 with allSensors top visible, got ${r.yMax}`);
+  });
+
+  it('keeps a flat-line band visible (5° floor on the data span)', () => {
+    const store = makeStore([
+      { t: 100, v: { t_collector: 20, t_tank_top: 20, t_tank_bottom: 20, t_greenhouse: 20, t_outdoor: 20 } },
+      { t: 200, v: { t_collector: 20.1, t_tank_top: 20, t_tank_bottom: 20, t_greenhouse: 20, t_outdoor: 20 } },
+    ]);
+    const r = autoYRange(store, 0, 1000, new Set(), false);
+    // All ≈20 → floor enforces ≥5° band; with 10% headroom and snap
+    // to /5, the result must straddle 20 with a non-zero range.
+    assert.ok(r.yMax - r.yMin >= 5, `expected band ≥ 5°, got ${r.yMax - r.yMin}`);
+    assert.ok(r.yMin <= 20 && r.yMax >= 20);
+  });
+});

--- a/tests/frontend/chart-fullscreen.spec.js
+++ b/tests/frontend/chart-fullscreen.spec.js
@@ -1,0 +1,198 @@
+// @ts-check
+/**
+ * Tests for the chart's fullscreen mode (issue #166 follow-up).
+ *
+ * Real fullscreen requires a user-gesture and OS-level cooperation,
+ * so these tests stub `Element.requestFullscreen` /
+ * `document.exitFullscreen` and manually dispatch `fullscreenchange`.
+ * That exercises every code path the real API would take — icon flip,
+ * aria-pressed, autoscale + Y-axis labels, redraw, exit handling — in
+ * a deterministic way under headless Chromium.
+ */
+import { test, expect } from './fixtures.js';
+
+async function installMockWs(page) {
+  await page.addInitScript(() => {
+    const OrigWS = window.WebSocket;
+    // @ts-ignore
+    window.WebSocket = function () {
+      const fake = {
+        readyState: 0, onopen: null, onmessage: null, onclose: null, onerror: null,
+        close: function () { this.readyState = 3; },
+        send: function () {},
+      };
+      // @ts-ignore
+      window.__mockWs = fake;
+      const stateData = {
+        mode: 'solar_charging',
+        temps: { collector: 62.5, tank_top: 48.2, tank_bottom: 33.9, greenhouse: 21.7, outdoor: 11.4 },
+        valves: { vi_btm: true, vi_top: false, vi_coll: false, vo_coll: true, vo_rad: false, vo_tank: false, v_air: false },
+        actuators: { pump: true, fan: false, space_heater: false },
+        controls_enabled: true,
+        manual_override: null,
+      };
+      setTimeout(() => {
+        fake.readyState = 1;
+        if (fake.onopen) fake.onopen(new Event('open'));
+        if (fake.onmessage) {
+          fake.onmessage({ data: JSON.stringify({ type: 'connection', status: 'connected' }) });
+          fake.onmessage({ data: JSON.stringify({ type: 'state', data: stateData }) });
+        }
+      }, 50);
+      return fake;
+    };
+    // @ts-ignore
+    window.WebSocket.prototype = OrigWS.prototype;
+    window.WebSocket.OPEN = 1;
+    window.WebSocket.CLOSED = 3;
+  });
+}
+
+async function mockHistoryApi(page) {
+  const now = Date.now();
+  const body = JSON.stringify({
+    range: '24h',
+    points: [
+      { ts: now - 7200_000, collector: 25.0, tank_top: 52.0, tank_bottom: 34.0, greenhouse: 17.0, outdoor: 9.0 },
+      { ts: now - 3600_000, collector: 45.0, tank_top: 58.0, tank_bottom: 36.0, greenhouse: 18.5, outdoor: 10.0 },
+      { ts: now - 1800_000, collector: 60.0, tank_top: 62.0, tank_bottom: 38.0, greenhouse: 20.0, outdoor: 11.0 },
+    ],
+    events: [
+      { ts: now - 7200_000, type: 'mode', id: 'controller', from: 'idle', to: 'idle' },
+      { ts: now - 3600_000, type: 'mode', id: 'controller', from: 'idle', to: 'solar_charging' },
+    ],
+  });
+  await page.route('**/api/history**', route => route.fulfill({
+    status: 200, contentType: 'application/json', body,
+  }));
+}
+
+/**
+ * Stub the Fullscreen API on the page so click + exit toggles dispatch
+ * a `fullscreenchange` event without actually entering fullscreen.
+ * Returns nothing — assertions read `document.fullscreenElement` after
+ * the event fires.
+ */
+async function installFullscreenStub(page) {
+  await page.addInitScript(() => {
+    let fsElement = null;
+    Object.defineProperty(document, 'fullscreenElement', {
+      configurable: true,
+      get() { return fsElement; },
+    });
+    // @ts-ignore
+    Element.prototype.requestFullscreen = function () {
+      fsElement = this;
+      // Fire on the next tick so a click handler chain can complete.
+      setTimeout(() => document.dispatchEvent(new Event('fullscreenchange')), 0);
+      return Promise.resolve();
+    };
+    // @ts-ignore
+    document.exitFullscreen = function () {
+      fsElement = null;
+      setTimeout(() => document.dispatchEvent(new Event('fullscreenchange')), 0);
+      return Promise.resolve();
+    };
+  });
+}
+
+test.describe('Chart fullscreen mode', () => {
+  test('button is present in the header with an a11y-friendly label', async ({ page }) => {
+    await installMockWs(page);
+    await mockHistoryApi(page);
+    await page.goto('/playground/', { waitUntil: 'domcontentloaded' });
+
+    const btn = page.locator('#graph-fullscreen-btn');
+    await expect(btn).toBeVisible();
+    await expect(btn).toHaveAttribute('aria-pressed', 'false');
+    await expect(btn).toHaveAttribute('aria-label', /toggle fullscreen|fullscreen/i);
+    await expect(page.locator('#graph-fullscreen-icon')).toHaveText('fullscreen');
+  });
+
+  test('clicking the button enters fullscreen and flips the icon + aria', async ({ page }) => {
+    await installFullscreenStub(page);
+    await installMockWs(page);
+    await mockHistoryApi(page);
+    await page.goto('/playground/', { waitUntil: 'domcontentloaded' });
+
+    await expect(page.locator('#connection-dot')).toHaveClass(/connected/, { timeout: 3000 });
+
+    const btn = page.locator('#graph-fullscreen-btn');
+    await btn.click();
+
+    await expect(btn).toHaveAttribute('aria-pressed', 'true');
+    await expect(page.locator('#graph-fullscreen-icon')).toHaveText('fullscreen_exit');
+
+    // The graph-card must now report itself as the fullscreen element.
+    const isFs = await page.evaluate(() => document.fullscreenElement && document.fullscreenElement.classList.contains('graph-card'));
+    expect(isFs).toBe(true);
+  });
+
+  test('exit gesture (ESC / browser) restores the icon and aria state', async ({ page }) => {
+    await installFullscreenStub(page);
+    await installMockWs(page);
+    await mockHistoryApi(page);
+    await page.goto('/playground/', { waitUntil: 'domcontentloaded' });
+
+    await expect(page.locator('#connection-dot')).toHaveClass(/connected/, { timeout: 3000 });
+
+    const btn = page.locator('#graph-fullscreen-btn');
+    await btn.click();
+    await expect(btn).toHaveAttribute('aria-pressed', 'true');
+
+    // Simulate the user pressing ESC: the browser exits fullscreen and
+    // fires fullscreenchange. The wiring must restore the entry icon.
+    await btn.click();
+    await expect(btn).toHaveAttribute('aria-pressed', 'false');
+    await expect(page.locator('#graph-fullscreen-icon')).toHaveText('fullscreen');
+  });
+
+  test('toggles + clickable legend stay reachable + functional in fullscreen', async ({ page }) => {
+    await installFullscreenStub(page);
+    await installMockWs(page);
+    await mockHistoryApi(page);
+    await page.goto('/playground/', { waitUntil: 'domcontentloaded' });
+
+    await expect(page.locator('#connection-dot')).toHaveClass(/connected/, { timeout: 3000 });
+
+    await page.locator('#graph-fullscreen-btn').click();
+    await expect(page.locator('#graph-fullscreen-btn')).toHaveAttribute('aria-pressed', 'true');
+
+    // All Sensors switch toggles inside fullscreen too.
+    await page.locator('#graph-show-all-sensors').click();
+    await expect(page.locator('#graph-show-all-sensors')).toHaveClass(/active/);
+    await expect(page.locator('#legend-tank-top')).toBeVisible();
+
+    // Clickable legend label still works.
+    const collector = page.locator('.graph-legend-item[data-series="t_collector"]');
+    await collector.click();
+    await expect(collector).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  test('canvas redraws after entering fullscreen (autoscale + Y labels kick in)', async ({ page }) => {
+    await installFullscreenStub(page);
+    await installMockWs(page);
+    await mockHistoryApi(page);
+    await page.goto('/playground/', { waitUntil: 'domcontentloaded' });
+
+    // Wait for at least the seeded history to render.
+    await expect.poll(() => page.evaluate(() => {
+      // @ts-ignore
+      return typeof window.__getHistoryPointCount === 'function'
+        ? window.__getHistoryPointCount()
+        : null;
+    }), { timeout: 5000 }).toBeGreaterThanOrEqual(3);
+
+    const before = await page.locator('#chart').screenshot();
+
+    await page.locator('#graph-fullscreen-btn').click();
+    await expect(page.locator('#graph-fullscreen-btn')).toHaveAttribute('aria-pressed', 'true');
+
+    // Force a frame so the redraw triggered by the fullscreenchange
+    // handler has flushed before we sample the canvas.
+    await page.evaluate(() => new Promise(r => requestAnimationFrame(() => r(null))));
+
+    const after = await page.locator('#chart').screenshot();
+    expect(Buffer.compare(before, after)).not.toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- New `fullscreen` icon button in the chart card header calls `requestFullscreen` on the `.graph-card` element. The **same DOM stays mounted** in fullscreen — the time-range slider, "All sensors" / "Forecast" toggles, the clickable legend, and the canvas all stretch to fill the viewport. Every setting, every WebSocket data update, and the existing pinch / mouse zoom keep working with zero duplication.
- In fullscreen `drawHistoryGraph` swaps the fixed `[0,100]` Y range for `autoYRange()` — scans visible non-hidden samples (collector / tank-avg / greenhouse / outdoor, plus tank top/bottom when "All sensors" is on), adds 10 % headroom, and snaps to multiples of 5 °. Y-axis labels render in a 36 px left gutter at each gridline. Embedded card view keeps the fixed `[0,100]` range so the bento layout is unchanged.
- `fullscreenchange` listener mirrors the icon (`fullscreen` ⇄ `fullscreen_exit`) and `aria-pressed`, so ESC / the browser's own exit gesture restore the entry state. A `resize` listener keeps the canvas crisp during the transition animation.
- Webkit-prefixed fallback for Safari; the button hides itself on browsers without the API rather than offering a tap that does nothing.

## Files

- `playground/index.html` — fullscreen `<button>` in `.graph-header`
- `playground/js/main/state.js` — `chartFullscreen` flag + setter
- `playground/js/main/history-graph.js` — autoscale + axis-label rendering, exports `autoYRange`
- `playground/js/main.js` — `setupFullscreenToggle()` wires click / fullscreenchange / resize
- `playground/public/style.css` — button styles, `:fullscreen` layout (and `-webkit-full-screen` fallback)
- `tests/auto-y-range.test.mjs` — 7 unit tests for the autoscale helper
- `tests/frontend/chart-fullscreen.spec.js` — 5 Playwright tests (button a11y, enter / exit / icon flip, toggles + legend stay reachable in fullscreen, canvas redraw on enter)

## Test plan

- [x] `npm run lint` / `npm run knip` / `check:file-size --strict` / `check:assets --strict` — all clean
- [x] `npm run test:unit` — 1151 pass / 0 fail (incl. 7 new in `auto-y-range.test.mjs`)
- [x] `npx playwright test` — 312 pass (incl. 5 new in `chart-fullscreen.spec.js`)
- [x] `npm run coverage:frontend` — gate ✓
- [ ] Manual smoke on the preview deploy: tap the fullscreen icon on the Status view, verify the chart fills the viewport with Y-axis labels visible, the time-range slider / All sensors / Forecast toggles all work, legend labels still toggle their series, ESC restores. Repeat on a phone (iOS Safari + Android Chrome).

https://claude.ai/code/session_01XH3iqLbdUyCBsdqTV4a4ds

---
_Generated by [Claude Code](https://claude.ai/code/session_01XH3iqLbdUyCBsdqTV4a4ds)_