### PR TITLE
test: deflake sync-registry periodic timer assertion

### DIFF
--- a/tests/frontend/sync-registry.spec.js
+++ b/tests/frontend/sync-registry.spec.js
@@ -224,11 +224,26 @@ test.describe('sync registry + coordinator contract', () => {
       // 30 ms cadence: tight for the test, well above setInterval's
       // ~4 ms minimum so we get distinct ticks.
       window.__sync._startPeriodicResync(30);
-      // Wait long enough for ≥3 ticks plus the in-flight resync to settle.
-      await new Promise(r => setTimeout(r, 150));
+      // Poll until we observe ≥3 ticks (proves the timer is periodic,
+      // not a one-shot). Generous deadline to absorb CPU contention from
+      // parallel Playwright workers — at 30 ms cadence three ticks
+      // arrive in <100 ms on an idle box, but a loaded CI runner can
+      // throttle setInterval. If five seconds isn't enough, the timer
+      // is genuinely broken, not slow.
+      await new Promise((resolve, reject) => {
+        const deadline = Date.now() + 5000;
+        (function check() {
+          if (fetchCalls >= 3) return resolve();
+          if (Date.now() >= deadline) {
+            return reject(new Error('periodic timer fired ' + fetchCalls + ' times in 5s, expected ≥3'));
+          }
+          setTimeout(check, 15);
+        })();
+      });
       const duringTick = fetchCalls;
       window.__sync._stopPeriodicResync();
-      // Wait again — should NOT keep firing after stop.
+      // Wait an interval-grace window — should NOT keep firing after stop.
+      // 150 ms = 5× cadence, plenty for any pending tick to settle.
       await new Promise(r => setTimeout(r, 150));
       const afterStop = fetchCalls;
       return { duringTick, afterStop };


### PR DESCRIPTION
## Summary

While running the CI test suite five times in a row to surface flakes, the only test that failed was `tests/frontend/sync-registry.spec.js > startPeriodicResync re-runs sources at the configured interval` (1/5 runs).

The test scheduled a 30 ms `setInterval` and asserted that ≥3 ticks fired within a fixed 150 ms wall-clock window. With four parallel Playwright workers saturating the CPU, the browser throttled the timer and only delivered 2 ticks → assertion failed:

```
Expected: >= 3
Received:    2
> 236 |     expect(result.duringTick).toBeGreaterThanOrEqual(3);
```

The fix replaces the fixed 150 ms wait with a poll loop that waits up to 5 s for `fetchCalls` to reach 3. Same scenario verified — the periodic timer must fire ≥3 times (proves it's periodic, not one-shot) and `_stopPeriodicResync()` must halt it. Only the real-time tolerance changes; if the timer never reaches 3 ticks in 5 s, the test still fails (with a clearer message), so a genuinely broken timer would still be caught.

## Verification

- **Unit tests** (`npm run test:unit:ci`): 5/5 runs pass.
- **Frontend tests** (`npx playwright test --project=frontend`, 4 workers, 293 tests): 4/5 baseline runs (1 flake on the periodic-timer assertion), then **5/5 after fix**.
- **E2E tests** (`npx playwright test --project=e2e`, 19 tests): 5/5 isolated runs pass.
- **Static checks** (`npm run lint`, `knip`, `check:file-size --strict`, `check:assets --strict`): all clean.
- The pre-push gate ran the full local CI suite before this push.

## Test plan

- [x] Re-run sync-registry spec 8× in isolation → 6/6 pass each time
- [x] Re-run full frontend suite 5× under 4-worker contention → 5/5 pass
- [x] Re-run e2e suite 5× → 5/5 pass
- [x] Static checks pass

https://claude.ai/code/session_01Dj2y3md2rk2smY6aMrS7My

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dj2y3md2rk2smY6aMrS7My)_