### PR TITLE
Forecast: sanity-gated fits + empirical radiator UA

### DIFF
--- a/scripts/backfill-historical-forecasts.mjs
+++ b/scripts/backfill-historical-forecasts.mjs
@@ -202,7 +202,30 @@ async function backfillPredictions(startDate, endDate) {
   process.stdout.write(`\r[backfill] predictions ${written}\n`);
 }
 
+// Live tu loaded once from device-config.js (S3 / local) and reused
+// across all captureAt calls. Backfilling with the OPERATIONAL
+// thresholds is the whole point — the per-night "Tank lasts" / heater
+// kWh totals depend on geT/gxT/ehE/ehX, and forecast_predictions
+// recorded with default-tuned thresholds isn't comparable to live.
+let _liveTu = null;
+async function loadLiveTu() {
+  if (_liveTu !== null) return _liveTu;
+  const dc = await import(path.join(repoRoot, 'server/lib/device-config.js'));
+  return new Promise((resolve) => {
+    dc.load(() => {
+      const cfg = dc.getConfig();
+      _liveTu = {
+        tu: cfg.tu || {},
+        tuning: dc.effectiveTuning(cfg.tu || {}),
+      };
+      resolve(_liveTu);
+    });
+  });
+}
+
 async function captureAt(genAt, computeSustainForecast, fitEmpiricalCoefficients, ALGORITHM_VERSION) {
+  const { tu, tuning } = await loadLiveTu();
+
   // 1) initial state from sensor_readings_30s within ±5 min
   const tankTop    = await sensorAt('tank_top',    genAt, 5);
   const tankBottom = await sensorAt('tank_bottom', genAt, 5);
@@ -222,18 +245,26 @@ async function captureAt(genAt, computeSustainForecast, fitEmpiricalCoefficients
   const prices48h  = await fetchPricesFor(genAt, 48);
   if (weather48h.length === 0) return null;
 
-  // 4) coefficients fit from history available up to genAt
-  // For backfill simplicity, we re-fit per capture using up to 14 d of
-  // history before genAt. This mirrors the live engine's 14-day window.
+  // 4) coefficients fit from history available up to genAt. Mirrors
+  // forecast-handler.queryHistory14d (radiation join + maintenance
+  // filter) so the fit input matches the live engine exactly.
   const history = await fetchHistoryUpTo(genAt, 14);
   const coefficients = fitEmpiricalCoefficients(history);
 
-  // 5) run engine
+  // 5) run engine with live tu — same plumbing as forecast-handler.compute()
   const fc = computeSustainForecast({
     now: genAt, tankTop, tankBottom, greenhouseTemp: ghTemp,
     currentMode,
     weather48h, prices48h, coefficients,
-    config: { weatherFetchedAt: genAt },
+    config: {
+      weatherFetchedAt: genAt,
+      greenhouseEnterC:         tuning.geT,
+      greenhouseExitC:          tuning.gxT,
+      greenhouseMinTankDeltaC:  tuning.gmD,
+      greenhouseExitTankDeltaC: tuning.gxD,
+      emergencyEnterC:          tuning.ehE,
+      emergencyExitC:           tuning.ehX,
+    },
   });
 
   // 6) build rows in same shape as forecast-predictions.js buildRows
@@ -241,6 +272,7 @@ async function captureAt(genAt, computeSustainForecast, fitEmpiricalCoefficients
     generatedAt: genAt.toISOString(),
     forecast: fc, weather: weather48h, prices: prices48h,
     coefficients, algorithmVersion: ALGORITHM_VERSION,
+    tu,
   });
 }
 
@@ -378,7 +410,7 @@ function buildPredictionRows(opts) {
       precipitationMm: wx?.precipitation ?? null,
       priceCKwh: px?.priceCKwh ?? null,
       algorithmVersion: opts.algorithmVersion,
-      tu: null,
+      tu: opts.tu || null,
       coefficients: opts.coefficients,
     });
   }

--- a/server/lib/forecast/sustain-forecast-fit.js
+++ b/server/lib/forecast/sustain-forecast-fit.js
@@ -22,6 +22,26 @@ const MIN_BUCKETS_FOR_FIT     = 5;
 // lower bar lets them converge from days, not weeks, of clean history.
 const MIN_BUCKETS_FOR_GH_FIT  = 3;
 
+// Sanity bounds. Fits whose output falls outside these ranges are
+// physically implausible for this greenhouse and are rejected (return
+// null) — caller falls through to DEFAULT_CONFIG. Bounds are
+// deliberately wide; the goal is to catch garbage fits (e.g. α near
+// zero from a radiation column with no spread, or a τ that says the
+// greenhouse cools fully in 6 minutes), not to second-guess plausible
+// variations. Values seeded from operational observation: GH peaks at
+// ~33 °C in sunny noon, cools to outdoor in ~2 h after vents close,
+// radiator measured at ~80–100 W/K from logged tank-drop data.
+const GH_TAU_MIN_H        = 0.5;
+const GH_TAU_MAX_H        = 8.0;
+const GH_ALPHA_MIN        = 0.005;
+const GH_ALPHA_MAX        = 0.05;
+const RAD_UA_MIN_W_PER_K  = 40;
+const RAD_UA_MAX_W_PER_K  = 200;
+const GH_LOSS_MIN_W_PER_K = 30;
+const GH_LOSS_MAX_W_PER_K = 300;
+const TANK_LEAK_MIN_W_PER_K = 1;
+const TANK_LEAK_MAX_W_PER_K = 30;
+
 // ── Helsinki TZ helpers (deterministic across server timezones) ──
 const HELSINKI_HOUR_FMT = new Intl.DateTimeFormat('en-GB', {
   timeZone: 'Europe/Helsinki', hour12: false, hour: '2-digit',
@@ -73,24 +93,6 @@ function slopeThruOrigin(xs, ys) {
     sumX2 += xs[i] * xs[i];
   }
   return sumX2 === 0 ? null : sumXY / sumX2;
-}
-
-// 2-variable linear regression through origin: y = b1·x1 + b2·x2.
-// Solves the normal equations via Cramer's rule. Returns null when the
-// design matrix is singular (e.g. all x1=0 or x1, x2 perfectly
-// collinear). Used to co-fit τ_gh and α_solar from the GH heat balance.
-function fitTwoVarThruOrigin(x1s, x2s, ys) {
-  let s11 = 0, s12 = 0, s22 = 0, s1y = 0, s2y = 0;
-  for (let i = 0; i < ys.length; i++) {
-    s11 += x1s[i] * x1s[i];
-    s12 += x1s[i] * x2s[i];
-    s22 += x2s[i] * x2s[i];
-    s1y += x1s[i] * ys[i];
-    s2y += x2s[i] * ys[i];
-  }
-  const det = s11 * s22 - s12 * s12;
-  if (det === 0 || !isFinite(det)) return null;
-  return { b1: (s1y * s22 - s2y * s12) / det, b2: (s11 * s2y - s12 * s1y) / det };
 }
 
 /**
@@ -277,34 +279,26 @@ function fitGreenhouseLossWPerK(history, opts) {
 }
 
 /**
- * Co-fit greenhouse passive τ and solar absorption α from the heat
- * balance in idle, vents-closed hours.
+ * Fit greenhouse passive cooling τ from idle, no-radiation hours.
  *
- * The two parameters compete in the per-hour ΔT equation:
- *   d(gh)/dt = (outdoor − gh)/τ + α · radiation
- * Single-variable regressions of either alone are biased — the τ-only
- * fit collapses on sunny hours (gh rises during passive intervals);
- * the α-only fit needs τ from the broken first fit. A 2-variable
- * least-squares against the design columns x1 = (outdoor − gh) and
- * x2 = radiation recovers both at once and uses every clean idle
- * sample, sunny or dark.
+ * Energy balance during idle/no-sun: d(gh)/dt = (outdoor − gh)/τ.
+ * Regress -d(gh)/dt against (gh − outdoor) over clean idle pairs where
+ * radiation < 30 W/m² (joined from weather_forecasts upstream); slope's
+ * reciprocal is τ. Pre-2026-05-08 the joint α/τ fit collapsed α → 0
+ * because daytime idle hours dominated the radiation column with most
+ * samples in steady state (perfectly collinear with the (out-gh)
+ * column). Splitting τ from night and α from day re-establishes
+ * identifiability — each regression sees only data where its
+ * coefficient is the dominant driver.
  *
- * Returns { tauGhH, alphaCPerWm2 }. Either can be null if the fit
- * yields a non-physical sign (caller falls through to defaults).
- *
- * @param {object} history { readings, modes } — readings carry gh,
- *   outdoor, radiationGlobal (joined from weather_forecasts upstream)
- * @param {number} ventOpenC vent threshold; rows above this are
- *   excluded so the linear regime holds
+ * @returns {number|null} τ in hours within sanity bounds, else null
  */
-function fitGhPassiveAndSolar(history, ventOpenC) {
+function fitGhTauNight(history) {
   if (!history || !Array.isArray(history.readings) || history.readings.length < 2 ||
-      !Array.isArray(history.modes)) return { tauGhH: null, alphaCPerWm2: null };
+      !Array.isArray(history.modes)) return null;
   const readings = history.readings;
-  const modes    = history.modes;
-  const modeLabels = labelModes(readings, modes);
-
-  const x1 = []; const x2 = []; const ys = [];
+  const modeLabels = labelModes(readings, history.modes);
+  const xs = []; const ys = [];
   for (let i = 0; i < readings.length - 1; i++) {
     if (modeLabels[i] !== 'idle') continue;
     const r0 = readings[i]; const r1 = readings[i + 1];
@@ -314,33 +308,124 @@ function fitGhPassiveAndSolar(history, ventOpenC) {
     if (dtH <= 0 || dtH > 0.25) continue;
     if (typeof r0.greenhouse !== 'number' || typeof r0.outdoor !== 'number' ||
         typeof r1.greenhouse !== 'number') continue;
-    if (typeof r0.radiationGlobal !== 'number') continue;
-    // Stay well below the vent open point: hours close to or above
-    // ventOpenC have d(gh)/dt ≈ 0 (saturated) regardless of radiation,
-    // which collapses the regression slope toward zero α. The 3 K
-    // buffer keeps the fit in the linear regime.
+    // Hard requirement: radiation present and < 30 W/m². Without joined
+    // radiation we can't tell night from day, and a sunny idle hour
+    // collapses the slope (gh rises → -d(gh)/dt is negative).
+    if (typeof r0.radiationGlobal !== 'number' || r0.radiationGlobal > 30) continue;
+    const dT = r0.greenhouse - r0.outdoor;
+    if (dT <= 1) continue;
+    xs.push(dT);
+    ys.push(-(r1.greenhouse - r0.greenhouse) / dtH);
+  }
+  if (xs.length < MIN_BUCKETS_FOR_GH_FIT) return null;
+  const slope = slopeThruOrigin(xs, ys);
+  if (slope === null || slope <= 0) return null;
+  const tau = 1 / slope;
+  if (tau < GH_TAU_MIN_H || tau > GH_TAU_MAX_H) return null;
+  return tau;
+}
+
+/**
+ * Fit greenhouse solar absorption α from sunny daytime non-heating
+ * hours, using the differential heat balance with τ already known:
+ *
+ *     d(gh)/dt = (out-gh)/τ + α·rad
+ *  ⇒  y_residual = d(gh)/dt − (out-gh)/τ  =  α·rad
+ *
+ * Slope of y_residual vs radiation is α directly. The differential
+ * form handles transient daytime rises (gh climbing as sun heats it)
+ * better than a steady-state slope, and removes the collinearity
+ * between (out-gh) and rad that collapsed the prior joint fit.
+ *
+ * Mode filter excludes greenhouse/emergency heating (extra power into
+ * gh breaks the model), and the vent-saturation buffer keeps the fit
+ * in the linear regime. Sanity-bounded; out-of-range fits return null
+ * and the engine uses DEFAULT_CONFIG.ghSolarAlphaCPerWm2.
+ */
+function fitGhAlphaDay(history, tauGhH, ventOpenC) {
+  if (!history || !Array.isArray(history.readings) || history.readings.length < 2 ||
+      !(tauGhH > 0)) return null;
+  const readings = history.readings;
+  const modeLabels = labelModes(readings, history.modes || []);
+  const xs = []; const ys = [];
+  for (let i = 0; i < readings.length - 1; i++) {
+    if (modeLabels[i] === 'greenhouse_heating' || modeLabels[i] === 'emergency_heating') continue;
+    const r0 = readings[i]; const r1 = readings[i + 1];
+    const t0 = r0.ts instanceof Date ? r0.ts.getTime() : Number(r0.ts);
+    const t1 = r1.ts instanceof Date ? r1.ts.getTime() : Number(r1.ts);
+    const dtH = (t1 - t0) / 3600000;
+    if (dtH <= 0 || dtH > 0.25) continue;
+    if (typeof r0.greenhouse !== 'number' || typeof r0.outdoor !== 'number' ||
+        typeof r1.greenhouse !== 'number' || typeof r0.radiationGlobal !== 'number') continue;
+    if (r0.radiationGlobal < 100) continue;
     if (r0.greenhouse > ventOpenC - 3) continue;
-    x1.push(r0.outdoor - r0.greenhouse);   // (out − gh): drives 1/τ
-    x2.push(r0.radiationGlobal);            // rad: drives α
-    ys.push((r1.greenhouse - r0.greenhouse) / dtH);
+    const dGhPerH   = (r1.greenhouse - r0.greenhouse) / dtH;
+    const passive   = (r0.outdoor - r0.greenhouse) / tauGhH;
+    xs.push(r0.radiationGlobal);
+    ys.push(dGhPerH - passive);
   }
-  if (ys.length < MIN_BUCKETS_FOR_GH_FIT) return { tauGhH: null, alphaCPerWm2: null };
-  const fit = fitTwoVarThruOrigin(x1, x2, ys);
-  if (fit) {
-    // b1 = 1/τ (note y = (out-gh)/τ + α·rad, so b1 fits 1/τ directly).
-    // b2 = α. Reject non-physical results so the engine falls through to
-    // defaults instead of e.g. negative α from a bad fit.
-    return {
-      tauGhH:       fit.b1 > 0  ? 1 / fit.b1 : null,
-      alphaCPerWm2: fit.b2 >= 0 ? fit.b2     : null,
-    };
+  if (xs.length < MIN_BUCKETS_FOR_GH_FIT) return null;
+  const slope = slopeThruOrigin(xs, ys);
+  if (slope === null || slope <= 0) return null;
+  if (slope < GH_ALPHA_MIN || slope > GH_ALPHA_MAX) return null;
+  return slope;
+}
+
+/**
+ * Empirical radiator UA (W/K) — heat-transfer coefficient from tank to
+ * greenhouse air. Computed from greenhouse_heating-mode hours where
+ * the radiator is the only active heat path: UA = (tank-drop power) /
+ * (tank_avg − gh). Median over hourly buckets is more robust than mean
+ * (one rapid mode-transition bucket can drag the mean by 50 %).
+ *
+ * Replaces the hardcoded 80 W/K constant the engine used pre-2026-05-08.
+ * Operational data shows real UA varies 60–120 W/K; the hardcoded mid-
+ * value over-credited radiator output in cool-tank conditions and
+ * under-predicted heater duty in nightly forecasts. Sanity-gated to
+ * [40, 200] W/K so a single bad sample (e.g. radiator just started,
+ * tank still mixing) doesn't propagate.
+ */
+function fitRadiatorUaWPerK(history) {
+  if (!history || !Array.isArray(history.readings) || history.readings.length < 2 ||
+      !Array.isArray(history.modes)) return null;
+  const readings = history.readings;
+  const modeLabels = labelModes(readings, history.modes);
+  // Per-hour bucket of (UA samples). Sub-hourly noise gets averaged
+  // within the bucket; the median across buckets is the headline value.
+  const buckets = {};
+  for (let i = 0; i < readings.length - 1; i++) {
+    if (modeLabels[i] !== 'greenhouse_heating') continue;
+    const r0 = readings[i]; const r1 = readings[i + 1];
+    const t0 = r0.ts instanceof Date ? r0.ts.getTime() : Number(r0.ts);
+    const t1 = r1.ts instanceof Date ? r1.ts.getTime() : Number(r1.ts);
+    const dtSec = (t1 - t0) / 1000;
+    if (dtSec <= 0 || dtSec > 600) continue;
+    if (typeof r0.tankTop !== 'number' || typeof r0.tankBottom !== 'number' ||
+        typeof r1.tankTop !== 'number' || typeof r1.tankBottom !== 'number' ||
+        typeof r0.greenhouse !== 'number') continue;
+    const tankAvg0 = (r0.tankTop + r0.tankBottom) / 2;
+    const tankAvg1 = (r1.tankTop + r1.tankBottom) / 2;
+    const dTankK   = tankAvg0 - tankAvg1;
+    const deltaT   = tankAvg0 - r0.greenhouse;
+    if (dTankK <= 0 || deltaT < 2) continue;
+    const powerW = (dTankK / dtSec) * TANK_THERMAL_MASS_J_PER_K;
+    const ua = powerW / deltaT;
+    if (ua < 30 || ua > 250) continue; // drop obvious outliers
+    const hourKey = Math.floor(t0 / 3600000);
+    if (!buckets[hourKey]) buckets[hourKey] = { sum: 0, n: 0 };
+    buckets[hourKey].sum += ua;
+    buckets[hourKey].n   += 1;
   }
-  // Singular design matrix → fall back to 1-variable fit on x1 only.
-  // Happens when radiation is constant (e.g. always-zero synthetic test
-  // data, or a string of fully overcast hours).
-  const slope = slopeThruOrigin(x1, ys);
-  if (slope === null || slope <= 0) return { tauGhH: null, alphaCPerWm2: null };
-  return { tauGhH: 1 / slope, alphaCPerWm2: null };
+  const bucketUas = [];
+  Object.keys(buckets).forEach(function (k) {
+    const b = buckets[k];
+    if (b.n >= 4) bucketUas.push(b.sum / b.n);
+  });
+  if (bucketUas.length < MIN_BUCKETS_FOR_GH_FIT) return null;
+  bucketUas.sort(function (a, b) { return a - b; });
+  const median = bucketUas[Math.floor(bucketUas.length / 2)];
+  if (median < RAD_UA_MIN_W_PER_K || median > RAD_UA_MAX_W_PER_K) return null;
+  return median;
 }
 
 function fitEmpiricalCoefficients(history, opts) {
@@ -405,27 +490,40 @@ function fitEmpiricalCoefficients(history, opts) {
     }
   }
 
-  const tankSlope = tankXs.length >= MIN_BUCKETS_FOR_FIT ? slopeThruOrigin(tankXs, tankYs) : null;
-  const ghLossSlope = fitGreenhouseLossWPerK(history, opts);
-  // ventOpenC mirrors DEFAULT_CONFIG.ghVentOpenC (33). Vent params are
-  // not fit yet — sparse data; can be added later when more warm-
-  // weather history exists.
-  const ghFit = fitGhPassiveAndSolar(history, 33);
-  const ghTau   = ghFit.tauGhH;
-  const ghAlpha = ghFit.alphaCPerWm2;
+  // Tank leakage: gate to physical bounds. Out-of-range slopes happen
+  // when the bucket loop sees rapid temperature drops from non-leakage
+  // causes (residual radiator effect after mode transition, sensor
+  // anomaly).
+  let tankLeak = null;
+  if (tankXs.length >= MIN_BUCKETS_FOR_FIT) {
+    const slope = slopeThruOrigin(tankXs, tankYs);
+    if (slope !== null && slope >= TANK_LEAK_MIN_W_PER_K && slope <= TANK_LEAK_MAX_W_PER_K) {
+      tankLeak = slope;
+    }
+  }
+  // Greenhouse loss: bound to plausible W/K. fitGreenhouseLossWPerK
+  // already returns null on insufficient data; gate handles the case
+  // where it converges to a non-physical value.
+  let ghLoss = fitGreenhouseLossWPerK(history, opts);
+  if (ghLoss !== null && (ghLoss < GH_LOSS_MIN_W_PER_K || ghLoss > GH_LOSS_MAX_W_PER_K)) ghLoss = null;
+  // Sequential GH-air fits — τ from night-only idle hours (no solar
+  // contamination), α from sunny daytime non-heating hours (vent-
+  // saturation buffer applied). Replaces the joint 2-variable fit that
+  // collapsed α → 0 due to (out-gh)/rad collinearity in steady-state
+  // daytime data.
+  const ghTau   = fitGhTauNight(history);
+  const ghAlpha = ghTau !== null ? fitGhAlphaDay(history, ghTau, 33) : null;
+  const radUa   = fitRadiatorUaWPerK(history);
 
   const out = {
-    tankLeakageWPerK:   tankSlope !== null && tankSlope > 0 ? tankSlope : DEFAULT_TANK_LEAKAGE_W_PER_K,
+    tankLeakageWPerK:   tankLeak !== null ? tankLeak : DEFAULT_TANK_LEAKAGE_W_PER_K,
     solarGainKwhByHour: fitSolarGainByHour(history),
-    usedDefaults:       tankSlope === null,
+    usedDefaults:       tankLeak === null,
   };
-  // Only emit greenhouseLossWPerK when the fit converged. Otherwise the
-  // engine keeps using its DEFAULT_CONFIG.greenhouseLossWPerK fallback —
-  // mirroring how solarGainKwhByHour falls through to the engine's
-  // built-in low-gain mask when the fit gives up.
-  if (ghLossSlope !== null) out.greenhouseLossWPerK = ghLossSlope;
-  if (ghTau   !== null) out.ghTimeConstantH      = ghTau;
-  if (ghAlpha !== null) out.ghSolarAlphaCPerWm2  = ghAlpha;
+  if (ghLoss  !== null) out.greenhouseLossWPerK   = ghLoss;
+  if (ghTau   !== null) out.ghTimeConstantH       = ghTau;
+  if (ghAlpha !== null) out.ghSolarAlphaCPerWm2   = ghAlpha;
+  if (radUa   !== null) out.radiatorUaWPerK       = radUa;
   return out;
 }
 
@@ -439,6 +537,16 @@ module.exports = {
   // Fit functions.
   fitSolarGainByHour,
   fitGreenhouseLossWPerK,
-  fitGhPassiveAndSolar,
+  fitGhTauNight,
+  fitGhAlphaDay,
+  fitRadiatorUaWPerK,
   fitEmpiricalCoefficients,
+  // Sanity bounds (exported so tests can exercise gate behavior).
+  _bounds: {
+    GH_TAU_MIN_H, GH_TAU_MAX_H,
+    GH_ALPHA_MIN, GH_ALPHA_MAX,
+    RAD_UA_MIN_W_PER_K, RAD_UA_MAX_W_PER_K,
+    GH_LOSS_MIN_W_PER_K, GH_LOSS_MAX_W_PER_K,
+    TANK_LEAK_MIN_W_PER_K, TANK_LEAK_MAX_W_PER_K,
+  },
 };

--- a/server/lib/forecast/sustain-forecast.js
+++ b/server/lib/forecast/sustain-forecast.js
@@ -254,11 +254,13 @@ function computeSustainForecast(opts) {
     }
 
     // ── 2. Radiator heat transfer ──
-    // P = UA·(T_tank−T_gh), capped at radPeakW. UA fitted from the live
-    // observation (tankDrop × C / ΔT) at h=0 when greenhouse_heating is
-    // active; falls back to 80 W/K (typical car-radiator + fan setup).
+    // P=UA·(T_tank−T_gh), capped at radPeakW. UA priority: fitted →
+    // live tankDrop at h=0 in heating → hardcoded 80 fallback.
     const radDeltaT = Math.max(0, tankAvg - curGhTemp);
     const radUaWPerK = (function () {
+      if (typeof coeff.radiatorUaWPerK === 'number' && coeff.radiatorUaWPerK > 0) {
+        return coeff.radiatorUaWPerK;
+      }
       if (observedTankDropKPerH !== null && currentMode === 'greenhouse_heating' && h === 0) {
         const observedW = observedTankDropKPerH * TANK_THERMAL_MASS_J_PER_K / SECONDS_PER_HOUR;
         const observedDeltaT = Math.max(1, tankAvg - curGhTemp);

--- a/tests/sustain-forecast.test.js
+++ b/tests/sustain-forecast.test.js
@@ -373,11 +373,9 @@ describe('computeSustainForecast — FMI cloud factor', () => {
   });
 });
 
-// Regression: when the controller has cycled emergency_heating in the
-// past hour, the tank is functionally exhausted right now — not in 4 h
-// per simulation. The card showing "Tank lasts ~4 h" while the user is
-// watching the heater cycle is misleading. emergencyRecentlyActive
-// short-circuits hoursUntilBackupNeeded to 0 and the note reflects it.
+// Regression: emergencyRecentlyActive short-circuits hoursUntilBackup
+// to 0. Pre-fix the card said "Tank lasts ~4 h" while the heater was
+// already cycling — confusing for the operator.
 describe('computeSustainForecast — emergencyRecentlyActive', () => {
   it('reports hoursUntilBackupNeeded=0 when emergency cycled recently', () => {
     const result = computeSustainForecast({
@@ -452,19 +450,12 @@ describe('computeSustainForecast — emergency heater duty cycle', () => {
       'expected ~35 kWh of heater energy at 72% duty, got ' + result.electricKwh);
   });
 
-  // Regression: in real hardware, when the controller is in emergency the
-  // space heater is OVERLAID on whatever pump mode physics would pick
-  // (system.yaml overlays.emergency_heating: "the space heater is overlaid
-  // on the active pump mode"). So when the tank is hot enough, the radiator
-  // keeps delivering heat alongside the heater, and the heater fills only
-  // the gap. Old engine zero'd out the radiator during emergency, so a
-  // 40 °C tank with mild outdoor still projected ~40 kWh of heater, even
-  // though the radiator could carry the whole load alone.
+  // Regression: emergency overlays the space heater on the active pump
+  // mode (system.yaml overlays.emergency_heating). Pre-fix the engine
+  // zero'd the radiator during emergency, so a 40 °C tank still
+  // projected ~40 kWh of heater energy even though the radiator alone
+  // could carry the load.
   it('hot tank materially reduces projected heater energy', () => {
-    // Same outdoor and thresholds — only tank temperature changes. The
-    // radiator's contribution should drag the projected heater kWh well
-    // below the cold-tank case. Pre-fix: both runs returned the same kWh
-    // because the radiator was disabled during emergency.
     const baseOpts = {
       now:            Date.now(),
       greenhouseTemp: 10,
@@ -493,12 +484,9 @@ describe('computeSustainForecast — emergency heater duty cycle', () => {
         cold.electricKwh.toFixed(2) + ' hot=' + hot.electricKwh.toFixed(2));
   });
 
-  // Regression: when the user's tank is near the floor and the system has
-  // been cycling backup all morning, the engine used to project ~30 kWh of
-  // continuous emergency over the next 48 h. The forecast bar visualisation
-  // showed full-height emergency every hour even when later daytime hours
-  // would actually get strong solar gain → tank charges → radiator covers
-  // greenhouse losses and the heater barely runs.
+  // Regression: tank near floor + recent backup cycling used to project
+  // ~30 kWh of continuous emergency over the next 48 h, ignoring sunny
+  // afternoons that would charge the tank back up.
   it('cycles emergency duty down during sunny hours', () => {
     // Strong solar gain at midday (Helsinki hours 10–15). Outdoor 7 °C.
     const solarGainKwhByHour = new Array(24).fill(0);
@@ -537,12 +525,9 @@ describe('computeSustainForecast — emergency heater duty cycle', () => {
     assert.ok(noFix.electricKwh < 22,
       'expected sunny days to lower projected backup energy, got ' + noFix.electricKwh);
 
-    // The mode forecast must still carry a numeric duty for any
-    // emergency entry it does emit, so the chart can render fractional
-    // bars (the user-facing complaint that motivated this fix). Under
-    // the new heat balance, sunny mid-day hours can lift gh above ehE
-    // before any emergency entry fires, so this case may emit zero
-    // emergency entries — that's correct projection, not a regression.
+    // Emergency entries (if any) must carry numeric duty so the chart
+    // can render fractional bars. Sunny midday may lift gh above ehE
+    // before any emergency entry fires — zero entries is OK.
     const emEntries = (noFix.modeForecast || []).filter(function (e) {
       return e.mode === 'emergency_heating';
     });
@@ -550,14 +535,9 @@ describe('computeSustainForecast — emergency heater duty cycle', () => {
       'every emergency entry (if any) must carry a numeric duty fraction');
   });
 
-  // Regression: cold tank shouldn't project greenhouse_heating mode.
-  // Field report 2026-05-05: tank top 14.3 / bottom 11.8 (avg ~13), greenhouse
-  // 12.4, geT/gxT=13/14, ehE/ehX=11/13. Forecast painted 1–2 hours of yellow
-  // "heating (projected)" bars before the emergency took over. The real
-  // device requires tank_top > greenhouse + greenhouseMinTankDelta (default 5K)
-  // to enter, and tank_top >= greenhouse + greenhouseExitTankDelta (default 2K)
-  // to stay — so with that tank state the controller would never run the
-  // pump, and emergency would kick in directly when gh crossed ehE.
+  // Regression (field report 2026-05-05): cold tank (avg 13, gh 12.4)
+  // shouldn't project greenhouse_heating bars — the controller wouldn't
+  // run the pump because tank_top ≯ greenhouse + gmD.
   it('skips greenhouse_heating projection when tank is too cold to drive the radiator', () => {
     const result = computeSustainForecast({
       now:            Date.now(),
@@ -775,13 +755,9 @@ describe('computeSustainForecast — ehX threading', () => {
   });
 });
 
-// Regression test for the undefined-threshold bug. The forecast handler used to
-// pass `tuning.greenhouseEnterTemp` etc. where `effectiveTuning` actually
-// returns `tuning.geT` — so all three thresholds were undefined. With the
-// previous Object.assign, undefined overwrote DEFAULT_CONFIG, and every
-// `curGhTemp < cfg.emergencyEnterC` comparison was false → backup never fired
-// → the card showed "Tank lasts 48+ h, Backup 0 kWh" while greenhouse drifted
-// down to outdoor (~5 °C). Pinning this so a future regression surfaces in CI.
+// Regression: handler used to pass tuning.greenhouseEnterTemp where
+// effectiveTuning returns tuning.geT — undefined leaked through and
+// silently disabled all heating thresholds.
 describe('computeSustainForecast — undefined config thresholds fall back to defaults', () => {
   it('cold night with explicit-undefined thresholds still triggers backup', () => {
     const result = computeSustainForecast({
@@ -1126,10 +1102,98 @@ describe('greenhouse heat balance — solar absorption', () => {
       config: {},
     });
     const peakGh = Math.max.apply(null, fc.greenhouseTrajectory.map(p => p.temp));
-    // Vent open at 33C with τ=0.3h saturates the system a few degrees
-    // above the open point in summer extremes. Real-world ceiling
-    // should be ≤ ~38C (user's observed worst case).
+    // Vent saturates a few K above ventOpenC in summer extremes; real
+    // ceiling ≤ ~38C (user's observed worst case).
     assert.ok(peakGh <= 38, 'vent cap must hold GH below 38C; got ' + peakGh);
     assert.ok(peakGh >= 28, 'expected non-trivial solar warming; got ' + peakGh);
+  });
+});
+
+describe('coefficient sanity gates', () => {
+  const fitMod = require('../server/lib/forecast/sustain-forecast-fit.js');
+  const { _bounds } = fitMod;
+
+  function makeIdleHistory(out, ghStart, dGhPerSample, samples, rad) {
+    const dtSec = 30;
+    const readings = [];
+    let gh = ghStart;
+    for (let i = 0; i < samples; i++) {
+      const ts = new Date(Date.UTC(2026, 4, 1) + i * dtSec * 1000);
+      readings.push({ ts, greenhouse: gh, outdoor: out, tankTop: 30, tankBottom: 30, radiationGlobal: rad });
+      gh = gh + dGhPerSample;
+    }
+    return { readings, modes: [{ ts: readings[0].ts, mode: 'idle' }] };
+  }
+
+  it('rejects τ_gh below the lower bound (would predict full cooling in <30 min)', () => {
+    // Force the regression to find a steep slope: gh drops 1 K every 30 s
+    // sample with (gh-out) ≈ 20 K. -d(gh)/dt = 120 K/h, dT = 20, slope ≈ 6,
+    // τ ≈ 0.17 h — below GH_TAU_MIN_H=0.5.
+    const h = makeIdleHistory(5, 25, -1, 60, 0);
+    assert.equal(fitMod.fitGhTauNight(h), null);
+    assert.ok(_bounds.GH_TAU_MIN_H >= 0.5);
+  });
+
+  it('rejects α below the lower bound (effectively no solar absorption)', () => {
+    // α=0.001 → 700 W/m² gives 0.7 K/h, too small to matter.
+    const dtSec = 30; const tauH = 2.0; const trueAlpha = 0.001;
+    const readings = []; let gh = 12;
+    for (let i = 0; i < 6 * 24 * 60 * 2; i++) {
+      const ts = new Date(Date.UTC(2026, 4, 1) + i * dtSec * 1000);
+      const hourOfDay = Math.floor(i / 120) % 24;
+      const rad = hourOfDay >= 6 && hourOfDay < 18 ? 600 : 0;
+      readings.push({ ts, greenhouse: gh, outdoor: 10, tankTop: 20, tankBottom: 20, radiationGlobal: rad });
+      gh = gh + ((10 - gh) / tauH + trueAlpha * rad) * (dtSec / 3600);
+    }
+    const coeff = fitMod.fitEmpiricalCoefficients({
+      readings, modes: [{ ts: readings[0].ts, mode: 'idle' }],
+    });
+    assert.equal(coeff.ghSolarAlphaCPerWm2, undefined,
+      'α=0.001 should be rejected; got ' + coeff.ghSolarAlphaCPerWm2);
+  });
+
+  it('rejects radiator UA outside [40, 200] W/K and accepts 80 W/K', () => {
+    // dTank/dt = UA·(tank-gh)·3600/MASS — physically integrate so UA
+    // stays constant as ΔT shrinks (Newton's law of cooling).
+    const dtSec = 30; const ghTemp = 12; const tankAvgInit = 25;
+    const TANK_M = 300 * 4186;
+    function makeHistory(uaWPerK) {
+      const readings = []; let tank = tankAvgInit;
+      for (let i = 0; i < 4 * 60 * 2; i++) {
+        const ts = new Date(Date.UTC(2026, 4, 1) + i * dtSec * 1000);
+        readings.push({ ts, greenhouse: ghTemp, outdoor: 5, tankTop: tank, tankBottom: tank, radiationGlobal: 0 });
+        tank = tank - uaWPerK * Math.max(0, tank - ghTemp) * dtSec / TANK_M;
+      }
+      return { readings, modes: [{ ts: readings[0].ts, mode: 'greenhouse_heating' }] };
+    }
+    const ok = fitMod.fitRadiatorUaWPerK(makeHistory(80));
+    assert.ok(ok !== null && Math.abs(ok - 80) / 80 < 0.1, 'expected ≈ 80, got ' + ok);
+    assert.equal(fitMod.fitRadiatorUaWPerK(makeHistory(25)), null, 'UA=25 should be rejected');
+    assert.equal(fitMod.fitRadiatorUaWPerK(makeHistory(250)), null, 'UA=250 should be rejected');
+  });
+
+  it('engine consumes coefficient.radiatorUaWPerK over the hardcoded 80', () => {
+    // Lower UA → more heater kWh because radiator covers less GH loss.
+    const now = Date.UTC(2026, 5, 1, 18, 0, 0);
+    const weather = []; const prices = [];
+    for (let h = 0; h < 48; h++) {
+      const ts = new Date(now + h * 3600 * 1000).toISOString();
+      weather.push({ ts, temperature: 0, radiationGlobal: 0, windSpeed: 1, precipitation: 0 });
+      prices.push({ ts, priceCKwh: 5 });
+    }
+    const baseOpts = {
+      now, tankTop: 25, tankBottom: 23, greenhouseTemp: 12,
+      currentMode: 'idle', weather48h: weather, prices48h: prices,
+      config: { spaceHeaterKw: 1, transferFeeCKwh: 5, greenhouseLossWPerK: 120,
+        emergencyEnterC: 11, emergencyExitC: 12, greenhouseEnterC: 12, greenhouseExitC: 13 },
+    };
+    const high = computeSustainForecast(Object.assign({}, baseOpts, {
+      coefficients: { tankLeakageWPerK: 3, solarGainKwhByHour: new Array(24).fill(0), radiatorUaWPerK: 100 },
+    }));
+    const low = computeSustainForecast(Object.assign({}, baseOpts, {
+      coefficients: { tankLeakageWPerK: 3, solarGainKwhByHour: new Array(24).fill(0), radiatorUaWPerK: 50 },
+    }));
+    assert.ok(low.electricKwh > high.electricKwh,
+      'low UA should project more heater: low=' + low.electricKwh + ' high=' + high.electricKwh);
   });
 });


### PR DESCRIPTION
## Summary

Fixes the under-prediction of nightly heater need observed after PR #170 deployed (live forecast said ~1.9 kWh / 48 h vs reality's 5–10 kWh / night). Root causes were the joint α/τ fit collapsing α toward zero in steady-state daytime data, and the hardcoded radiator UA = 80 W/K over-crediting tank delivery.

- Sequential GH-air fits: τ from no-sun idle hours, α from sunny non-heating hours via the differential heat balance.
- Empirical radiator UA fit; engine consumes `coeff.radiatorUaWPerK` over the hardcoded 80.
- Sanity bounds on every fit output (τ, α, radiator UA, GH loss, tank leakage). Out-of-bounds → null → engine falls through to DEFAULT_CONFIG.
- Backfill script plumbs the live `tu` thresholds into the engine + captured rows.

## Test plan

- [x] 1164 unit tests pass; new tests cover bound rejection (τ, α, radiator UA) and engine UA-consumption invariant.
- [x] lint, knip, file-size --strict, all green.
- [ ] Post-deploy: `/api/forecast` shows materially higher backup-heat projection for next night with current sensor state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)