### PR TITLE
Forecast: cap GH τ at 3 h to match observed air-cooling

### DIFF
--- a/server/lib/forecast/sustain-forecast-fit.js
+++ b/server/lib/forecast/sustain-forecast-fit.js
@@ -36,7 +36,13 @@ const GH_TAU_MAX_H        = 8.0;
 const GH_ALPHA_MIN        = 0.005;
 const GH_ALPHA_MAX        = 0.05;
 const RAD_UA_MIN_W_PER_K  = 40;
-const RAD_UA_MAX_W_PER_K  = 200;
+// Empirically the car-radiator + fan setup measures 80–100 W/K from
+// logged greenhouse_heating-mode tank-drop pairs. The fit's median
+// drifts higher than this — likely because heating-mode tank loss
+// includes both radiator output AND ambient leakage, and the fit
+// attributes all of it to UA. 130 caps the upward bias while leaving
+// headroom for genuinely high-flow operating points.
+const RAD_UA_MAX_W_PER_K  = 130;
 const GH_LOSS_MIN_W_PER_K = 30;
 const GH_LOSS_MAX_W_PER_K = 300;
 const TANK_LEAK_MIN_W_PER_K = 1;
@@ -298,12 +304,13 @@ function fitGhTauNight(history) {
       !Array.isArray(history.modes)) return null;
   const readings = history.readings;
   const modeLabels = labelModes(readings, history.modes);
-  // Require idle to have been stable for >= IDLE_SETTLE_MS before
-  // counting a pair — the engine's post-heating transient (radiator
-  // valves close, residual hot pipe water cools rapidly toward gh)
-  // briefly inflates the apparent cooling slope, biasing τ low. 30 min
-  // settle gives the structural thermal mass time to stabilize.
-  const IDLE_SETTLE_MS = 30 * 60 * 1000;
+  // Require idle stable for IDLE_SETTLE_MS before counting a pair —
+  // the engine's post-heating transient (radiator valves close,
+  // residual hot pipe water cools rapidly toward gh) briefly inflates
+  // the apparent cooling slope, biasing τ low. 15 min is enough to
+  // skip the transient without losing too many samples in real data
+  // where idle stretches between mode-cycles are short.
+  const IDLE_SETTLE_MS = 15 * 60 * 1000;
   let idleSinceMs = -Infinity;
   let prevMode = null;
   const xs = []; const ys = [];

--- a/server/lib/forecast/sustain-forecast-fit.js
+++ b/server/lib/forecast/sustain-forecast-fit.js
@@ -32,7 +32,12 @@ const MIN_BUCKETS_FOR_GH_FIT  = 3;
 // ~33 °C in sunny noon, cools to outdoor in ~2 h after vents close,
 // radiator measured at ~80–100 W/K from logged tank-drop data.
 const GH_TAU_MIN_H        = 0.5;
-const GH_TAU_MAX_H        = 8.0;
+// User's logged cooldown 27.8 → 12.1 °C in 4 h (outdoor 10 °C) implies
+// τ ≈ 1.9 h. Long-tail soil/structure thermal mass biases the 14d-
+// average fit upward toward 4 h, which makes the simulation hold gh
+// well above ehE all night (heater never fires). Cap at 3 h: above
+// this is implausible for an air-temperature-driven control loop.
+const GH_TAU_MAX_H        = 3.0;
 const GH_ALPHA_MIN        = 0.005;
 const GH_ALPHA_MAX        = 0.05;
 const RAD_UA_MIN_W_PER_K  = 40;


### PR DESCRIPTION
Iteration on #173. Live engine after deploy:
- τ fit converges at 4.19 h (fit-bias from soil/structure thermal mass).
- α undefined → engine default 0.025.
- radUa undefined (159 was rejected).

At τ=4.19 h the simulation holds gh well above ehE all night with outdoor dropping to 3 °C — heater predicted to fire 0 kWh tonight, which is wrong for a 5 °C overnight low.

User's own logged cooldown gives τ ≈ 1.9 h. Cap at 3 h to keep the model in line with the air-temperature-driven control loop it's projecting against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)