### PR TITLE
forecast: filter outdoor-sensor sun spike before fits

### DIFF
--- a/scripts/backfill-historical-forecasts.mjs
+++ b/scripts/backfill-historical-forecasts.mjs
@@ -345,7 +345,7 @@ async function fetchHistoryUpTo(genAt, days) {
   // Pull historical hourly radiation + config_events to drive the same
   // maintenance filter + radiation join the live forecast-handler does.
   const radR = await pool.query(
-    'SELECT DISTINCT ON (valid_at) valid_at, radiation_global ' +
+    'SELECT DISTINCT ON (valid_at) valid_at, radiation_global, temperature ' +
     'FROM weather_forecasts ' +
     'WHERE valid_at BETWEEN ($1::timestamptz - INTERVAL \'' + days + ' days\') AND $1::timestamptz ' +
     '  AND radiation_global IS NOT NULL ' +

--- a/server/lib/forecast/forecast-handler.js
+++ b/server/lib/forecast/forecast-handler.js
@@ -18,6 +18,13 @@ const { jsonResponse } = require('../http-handlers');
 const CACHE_TTL_MS         = 60 * 1000;     // 60 s response cache
 const COEFF_CACHE_TTL_MS   = 60 * 60 * 1000; // 1 h coefficient cache
 
+// Threshold above the hour's forecast outdoor temperature beyond which a
+// sensor reading is treated as a direct-sun spike on the sensor housing
+// and replaced with the forecast value. Calibrated against the observed
+// ~5 °C 16:00 spike vs. the forecast/sensor agreement in surrounding
+// hours, which sits within ±1.5 °C. 2.5 °C cleanly separates the two.
+const OUTDOOR_SPIKE_THRESHOLD_C = 2.5;
+
 function createForecastHandler(opts) {
   const pool       = opts.pool;
   const log        = opts.log;
@@ -203,8 +210,12 @@ function createForecastHandler(opts) {
       'FROM state_events ' +
       "WHERE entity_type = 'mode' AND ts > NOW() - INTERVAL '14 days' " +
       'ORDER BY ts';
+    // Pull radiation AND temperature: radiation feeds the GH-air fits,
+    // temperature is used in pivotHistory to reject outdoor-sensor spikes
+    // (the sensor gets direct sun ~16:00 and reads ~5 °C above truth for
+    // ~1 h; substituting the forecast for that window keeps the fits clean).
     const radSql =
-      'SELECT DISTINCT ON (valid_at) valid_at, radiation_global ' +
+      'SELECT DISTINCT ON (valid_at) valid_at, radiation_global, temperature ' +
       'FROM weather_forecasts ' +
       "WHERE valid_at > NOW() - INTERVAL '14 days' AND radiation_global IS NOT NULL " +
       'ORDER BY valid_at, fetched_at DESC';
@@ -450,26 +461,13 @@ function createForecastHandler(opts) {
 }
 
 // ── History pivoting / fit-input shaping ────────────────────────────────
-//
-// Hoisted out of the handler closure so it can be unit-tested and reused.
 // Pivots sensor rows into one record per timestamp, attaches the closest
-// hour-aligned forecast radiation (used by the GH-air fits to mask off
-// sunny hours), and drops readings that fall inside any maintenance
-// interval (manual-override or mode-ban active). Maintenance reasoning:
-//
-//   * `mo` (manual override) events with a non-empty new_value JSON open
-//     an interval; the next `mo` event closes it. Override leaves the
-//     controller un-free to actuate, so any greenhouse cooling/warming
-//     during the window doesn't reflect the automated dynamics we want
-//     to fit.
-//   * `wb` (mode ban) events open / close a per-mode ban. While GH or
-//     EH is banned the controller can't fire heating, so an idle hour
-//     during a ban doesn't represent the engine's "natural cooling"
-//     dynamic — drop those hours from the fit.
-//
-// In both cases the affected greenhouse data is what we DON'T want
-// driving the τ_gh / α_solar / loss fits; tank-side fits could in
-// principle keep them, but consistency wins over a marginal data gain.
+// hour-aligned forecast radiation + outdoor-temp reference, replaces
+// outdoor-sensor spikes with the forecast value, and drops readings
+// inside any maintenance interval (manual override `mo` or mode ban
+// `wb` — during either the controller can't actuate freely, so the
+// dynamics in that window aren't what we want driving τ_gh / α_solar /
+// loss fits). Hoisted out of the handler closure for unit-testability.
 function pivotHistory(sensorRows, modeRows, radRows, maintRows) {
   const buckets = {};
   (sensorRows || []).forEach(function (row) {
@@ -480,11 +478,16 @@ function pivotHistory(sensorRows, modeRows, radRows, maintRows) {
     if (f) buckets[tsMs][f] = row.value;
   });
 
-  // Pre-sort + index radiation by hour for O(1) lookup per reading.
+  // Index radiation + forecast outdoor-temp by hour for O(1) lookup.
+  // Radiation feeds the GH-air fits; the temperature is the ground-truth
+  // reference for outdoor-spike rejection (sensor gets ~5 °C of direct
+  // sun around 16:00 for ~1 h, biasing the daytime fits otherwise).
   const radByHour = {};
+  const tempByHour = {};
   (radRows || []).forEach(function (r) {
     const k = new Date(r.valid_at).getTime();
     radByHour[k] = r.radiation_global;
+    if (typeof r.temperature === 'number') tempByHour[k] = r.temperature;
   });
 
   // Build maintenance intervals from config_events. Each interval is an
@@ -499,11 +502,24 @@ function pivotHistory(sensorRows, modeRows, radRows, maintRows) {
     .map(function (k) {
       const b = buckets[k];
       const tsMs = b.ts.getTime();
-      // Closest hour-aligned radiation (within ±1 h).
+      // Closest hour-aligned forecast (within ±1 h) for both radiation
+      // and outdoor-temperature reference.
       const hourMs = Math.floor(tsMs / 3600000) * 3600000;
       let rad = radByHour[hourMs];
       if (rad === undefined) rad = radByHour[hourMs + 3600000];
       if (typeof rad === 'number') b.radiationGlobal = rad;
+      let fcT = tempByHour[hourMs];
+      if (fcT === undefined) fcT = tempByHour[hourMs + 3600000];
+      // Spike rejection: if the outdoor sensor reading sits well above
+      // the forecast for this hour, attribute it to direct-sun heating
+      // of the sensor housing and replace with the forecast value. The
+      // forecast carries its own ~1–2 °C error but that is far smaller
+      // than the ~5 °C afternoon spike, so substitution is a net win.
+      if (typeof b.outdoor === 'number' && typeof fcT === 'number'
+          && (b.outdoor - fcT) > OUTDOOR_SPIKE_THRESHOLD_C) {
+        b._outdoorRaw = b.outdoor;
+        b.outdoor = fcT;
+      }
       b._maintenance = intervalsCover(intervals, tsMs);
       return b;
     })
@@ -578,4 +594,5 @@ module.exports = {
   // exported for tests
   _pivotHistory: pivotHistory,
   _buildMaintenanceIntervals: buildMaintenanceIntervals,
+  _OUTDOOR_SPIKE_THRESHOLD_C: OUTDOOR_SPIKE_THRESHOLD_C,
 };

--- a/tests/forecast-history-pivot.test.js
+++ b/tests/forecast-history-pivot.test.js
@@ -1,0 +1,133 @@
+'use strict';
+
+/**
+ * Tests for pivotHistory's outdoor-spike rejection.
+ *
+ * The outdoor sensor sits in a spot that catches direct sun for ~1 h
+ * around 16:00 local time, reading several °C above the actual air
+ * temperature for that window. Untreated, the spike contaminates the
+ * τ_gh / α_solar / loss fits because the daytime portion of those
+ * fits sees an anomalously warm "outdoor" that absorbs the radiation
+ * signal — the fit then attributes daytime GH warming to outdoor
+ * heating instead of solar gain, driving α_solar to its sanity-gate
+ * floor. pivotHistory replaces sensor outdoor with the hour's
+ * forecast value when the sensor exceeds it by more than the
+ * threshold, so the fits run on clean data.
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  _pivotHistory: pivotHistory,
+  _OUTDOOR_SPIKE_THRESHOLD_C: SPIKE,
+} = require('../server/lib/forecast/forecast-handler.js');
+
+function ts(hour) { return new Date(Date.UTC(2026, 4, 8, hour, 0, 0)); }
+function ts30(hour, min) { return new Date(Date.UTC(2026, 4, 8, hour, min, 0)); }
+
+function row(sensorId, t, value) {
+  return { ts: t.toISOString(), sensor_id: sensorId, value };
+}
+
+function wxRow(t, opts) {
+  return {
+    valid_at: t.toISOString(),
+    radiation_global: opts.rad,
+    temperature: opts.temp,
+  };
+}
+
+describe('pivotHistory — outdoor spike rejection', () => {
+  it('replaces a sensor reading that exceeds the forecast by more than the threshold', () => {
+    // Forecast at 16:00 says outdoor is 18 °C; sensor reads 24 °C
+    // (a 6 °C spike, far above the 2.5 °C threshold).
+    const sensors = [
+      row('greenhouse', ts(16), 30),
+      row('outdoor',    ts(16), 24),
+      row('tank_top',   ts(16), 35),
+    ];
+    const wx = [wxRow(ts(16), { rad: 500, temp: 18 })];
+    const result = pivotHistory(sensors, [], wx, []);
+    assert.equal(result.readings.length, 1);
+    const r = result.readings[0];
+    assert.equal(r.outdoor, 18, 'outdoor should be replaced with forecast');
+    assert.equal(r._outdoorRaw, 24, 'raw spike preserved on _outdoorRaw');
+  });
+
+  it('keeps the sensor reading when the gap is within the threshold', () => {
+    // Forecast 18 °C, sensor 19 °C — 1 °C gap, under threshold.
+    const sensors = [
+      row('greenhouse', ts(16), 30),
+      row('outdoor',    ts(16), 19),
+    ];
+    const wx = [wxRow(ts(16), { rad: 500, temp: 18 })];
+    const result = pivotHistory(sensors, [], wx, []);
+    assert.equal(result.readings[0].outdoor, 19);
+    assert.equal(result.readings[0]._outdoorRaw, undefined);
+  });
+
+  it('keeps the sensor reading when no forecast is available for the hour', () => {
+    const sensors = [
+      row('greenhouse', ts(16), 30),
+      row('outdoor',    ts(16), 24),
+    ];
+    const result = pivotHistory(sensors, [], [], []);
+    assert.equal(result.readings[0].outdoor, 24);
+    assert.equal(result.readings[0]._outdoorRaw, undefined);
+  });
+
+  it('does not touch readings where sensor is colder than forecast', () => {
+    // Sensor 12 °C, forecast 18 °C — sensor is 6 °C below; not a spike.
+    const sensors = [
+      row('greenhouse', ts(4), 8),
+      row('outdoor',    ts(4), 12),
+    ];
+    const wx = [wxRow(ts(4), { rad: 0, temp: 18 })];
+    const result = pivotHistory(sensors, [], wx, []);
+    assert.equal(result.readings[0].outdoor, 12);
+  });
+
+  it('matches a 30-min reading to the closest hour-aligned forecast', () => {
+    // Reading at 16:30, forecast at 16:00. Threshold is exceeded
+    // → forecast value wins.
+    const sensors = [
+      row('greenhouse', ts30(16, 30), 30),
+      row('outdoor',    ts30(16, 30), 24),
+    ];
+    const wx = [wxRow(ts(16), { rad: 500, temp: 18 })];
+    const result = pivotHistory(sensors, [], wx, []);
+    assert.equal(result.readings[0].outdoor, 18);
+  });
+
+  it('falls forward to the next hour when the floor hour has no forecast', () => {
+    // Sensor at 15:45, no forecast at 15:00 but one at 16:00.
+    const sensors = [
+      row('greenhouse', ts30(15, 45), 30),
+      row('outdoor',    ts30(15, 45), 24),
+    ];
+    const wx = [wxRow(ts(16), { rad: 500, temp: 18 })];
+    const result = pivotHistory(sensors, [], wx, []);
+    assert.equal(result.readings[0].outdoor, 18);
+  });
+
+  it('substitution kicks in exactly above the threshold, not at it', () => {
+    // sensor = forecast + threshold → keep raw; sensor = forecast +
+    // threshold + epsilon → substitute. Pin behaviour so future
+    // threshold tweaks don't silently flip semantics.
+    const baseT = 18;
+    const atThreshold = baseT + SPIKE;
+    const justAbove   = baseT + SPIKE + 0.1;
+
+    const sensorsAt = [row('outdoor', ts(16), atThreshold)];
+    const sensorsAbove = [row('outdoor', ts(16), justAbove)];
+    const wx = [wxRow(ts(16), { rad: 500, temp: baseT })];
+
+    const at = pivotHistory(sensorsAt, [], wx, []);
+    const above = pivotHistory(sensorsAbove, [], wx, []);
+
+    assert.equal(at.readings[0].outdoor, atThreshold,
+      'at exactly threshold: raw value kept');
+    assert.equal(above.readings[0].outdoor, baseT,
+      'just above threshold: substituted with forecast');
+  });
+});


### PR DESCRIPTION
## Summary

- Outdoor sensor catches direct sun for ~1 h around 16:00 and reads ~5 °C above truth, polluting the daytime portion of the α_solar / τ_gh / loss fits
- Production fit was producing α_solar = 0.0051 — pinned at the sanity-gate floor — which made afternoon GH temp predictions undershoot actuals by 10–15 °C (e.g. 08/05 13:30: predicted 18.4 °C, actual 33.6 °C)
- Fix: `pivotHistory` now joins the hour's forecast outdoor temperature alongside radiation and substitutes the forecast value when the sensor exceeds it by more than 2.5 °C, keeping the fits clean

## Why this works

The differential α fit is `y = d(gh)/dt − (out−gh)/τ`. When the sensor reads anomalously high during peak-radiation hours, `(out−gh)` absorbs the heating signal, leaving little residual to attribute to radiation → α collapses. The forecast outdoor (FMI/Open-Meteo) carries ~1–2 °C error, far smaller than the 5 °C spike, so substitution is a clear net win.

Diagnostics evidence (14 d of history, hour-of-day median for outdoor sensor on prod):
- 15:00 → 18.7 °C
- **16:00 → 23.0 °C ← spike**
- 17:00 → 19.1 °C

## Test plan

- [x] New `tests/forecast-history-pivot.test.js`: 7 cases — substitution above threshold, kept below, no-forecast fallback, cold-side ignored, ±1 h match, hour-fall-forward, threshold boundary
- [x] Full unit suite green (1175 tests)
- [x] Full Playwright suite green (318 tests)
- [x] Lint / knip / file-size / unused-assets all clean
- [ ] After deploy: reload diagnostics, verify fitted α rises away from 0.005 floor and afternoon GH predictions match actuals

🤖 Generated with [Claude Code](https://claude.com/claude-code)