### PR TITLE
ci: auto-merge dependabot PRs once checks pass

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,23 @@
+name: Dependabot auto-merge
+
+# Auto-enable GitHub's "merge when ready" on every Dependabot PR. The
+# merge only fires once required status checks (CI, CodeQL, etc.) pass
+# and any required reviews are satisfied — GitHub holds the PR until
+# then. If checks fail, the PR stays open for manual triage.
+
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Enable auto-merge (squash)
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- New `.github/workflows/dependabot-auto-merge.yml` workflow runs on `pull_request_target` and, for any PR authored by `dependabot[bot]`, calls `gh pr merge --auto --squash`. GitHub holds the merge until all required status checks (CI, CodeQL) and reviews succeed; failing CI keeps the PR open for manual triage.
- Workflow has the minimal `contents: write` + `pull-requests: write` permissions and gates the job on the PR author, so it never touches non-Dependabot PRs.

## Test plan
- [ ] Merge this PR and confirm it appears on the next Dependabot PR run.
- [ ] On a passing Dependabot PR, verify the "merge when ready" badge shows and the PR squash-merges once all required checks complete.
- [ ] On a failing Dependabot PR, verify auto-merge stays armed but the PR is not merged.

https://claude.ai/code/session_014gwChLCivx4i8K7jL4psgR

---
_Generated by [Claude Code](https://claude.ai/code/session_014gwChLCivx4i8K7jL4psgR)_