### PR TITLE
Round line joins on history-graph temperature lines

### DIFF
--- a/playground/js/main/history-graph.js
+++ b/playground/js/main/history-graph.js
@@ -196,6 +196,14 @@ export function drawHistoryGraph() {
   canvas.width = canvas.offsetWidth * dpr;
   canvas.height = canvas.offsetHeight * dpr;
   ctx.scale(dpr, dpr);
+  // Round joins/caps for every stroke this pass. Setting the backing-store
+  // size above resets the context to defaults, so this has to come after.
+  // Temperature lines zigzag with sensor noise; when the chart is zoomed
+  // out an up/down spike collapses into an acute V, and a miter join would
+  // extend the stroke a long point past the real peak — round joins clamp
+  // it to the vertex.
+  ctx.lineJoin = 'round';
+  ctx.lineCap = 'round';
   const dw = canvas.offsetWidth;
   const dh = canvas.offsetHeight;
   ctx.clearRect(0, 0, dw, dh);

--- a/tests/frontend/graph-line-join.spec.js
+++ b/tests/frontend/graph-line-join.spec.js
@@ -1,0 +1,127 @@
+// @ts-check
+// History-graph temperature lines must be stroked with round line joins.
+//
+// Bug it guards against: drawHistoryGraph / drawTempLine left the canvas
+// lineJoin at its 'miter' default. When the chart is zoomed out, adjacent
+// noisy samples compress into a narrow x-range, so an up/down spike
+// becomes a very acute V. A miter join extends the stroke a long point
+// past that vertex — the drawn spike overshoots the real peak
+// temperature. Round joins clamp the stroke to the vertex.
+import { test, expect } from './fixtures.js';
+
+const NOW = Date.now();
+const DAY_MS = 86400_000;
+
+// 24 h of 5-minute samples. The collector value zigzags so the polyline
+// has the acute vertices that expose a miter overshoot.
+const HISTORY_POINTS = Array.from({ length: 289 }, (_, i) => ({
+  ts: NOW - DAY_MS + i * 300_000,
+  collector: 5 + (i % 2 === 0 ? 3 : 0),
+  tank_top: 42,
+  tank_bottom: 38,
+  greenhouse: 15,
+  outdoor: 6,
+}));
+
+async function scaffold(page) {
+  await page.addInitScript(() => {
+    // Record the lineJoin in effect at every canvas stroke() so the test
+    // can inspect how the temperature lines were drawn.
+    window.__strokes = [];
+    const proto = CanvasRenderingContext2D.prototype;
+    const origStroke = proto.stroke;
+    proto.stroke = function (...args) {
+      window.__strokes.push({
+        lineJoin: this.lineJoin,
+        lineCap: this.lineCap,
+        strokeStyle: this.strokeStyle,
+      });
+      return origStroke.apply(this, args);
+    };
+
+    const OrigWS = window.WebSocket;
+    // @ts-ignore
+    window.WebSocket = function () {
+      const fake = {
+        readyState: 0, onopen: null, onmessage: null, onclose: null, onerror: null,
+        close() { this.readyState = 3; },
+        send() {},
+      };
+      setTimeout(() => {
+        fake.readyState = 1;
+        if (fake.onopen) fake.onopen(new Event('open'));
+        if (fake.onmessage) {
+          fake.onmessage({ data: JSON.stringify({ type: 'connection', status: 'connected' }) });
+          fake.onmessage({ data: JSON.stringify({
+            type: 'state',
+            data: {
+              mode: 'idle',
+              temps: { collector: 8, tank_top: 42, tank_bottom: 38, greenhouse: 15, outdoor: 6 },
+              valves: { vi_btm: false, vi_top: false, vi_coll: false, vo_coll: false, vo_rad: false, vo_tank: false, v_air: false },
+              actuators: { pump: false, fan: false, space_heater: false },
+              controls_enabled: true,
+              manual_override: null,
+            },
+          }) });
+        }
+      }, 50);
+      return fake;
+    };
+    // @ts-ignore
+    window.WebSocket.prototype = OrigWS.prototype;
+    // @ts-ignore
+    window.WebSocket.OPEN = 1;
+    // @ts-ignore
+    window.WebSocket.CLOSED = 3;
+  });
+
+  await page.route('**/api/history**', r => r.fulfill({
+    status: 200, contentType: 'application/json',
+    body: JSON.stringify({ range: '24h', points: HISTORY_POINTS, events: [] }),
+  }));
+  await page.route('**/api/forecast', r => r.fulfill({
+    status: 200, contentType: 'application/json', body: 'null',
+  }));
+  await page.route('**/api/watchdog/state', r => r.fulfill({
+    status: 200, contentType: 'application/json',
+    body: JSON.stringify({ pending: null, watchdogs: [], snapshot: { we: {}, wz: {}, wb: {} }, recent: [] }),
+  }));
+  await page.route('**/api/device-config', r => r.fulfill({
+    status: 200, contentType: 'application/json',
+    body: JSON.stringify({ ce: true, ea: 31, fm: null, we: {}, wz: {}, wb: {}, v: 1 }),
+  }));
+  await page.route('**/api/events**', r => r.fulfill({
+    status: 200, contentType: 'application/json', body: '[]',
+  }));
+  await page.route('**/api/push/**', r => r.fulfill({
+    status: 200, contentType: 'application/json', body: '{}',
+  }));
+}
+
+test('temperature lines are stroked with round joins so spikes do not overshoot', async ({ page }) => {
+  await scaffold(page);
+  await page.goto('/playground/');
+  await page.waitForFunction(() => window.__initComplete === true);
+
+  // Collector line is '#ef5350', main tank line is '#e9c349'. Wait until
+  // both have been drawn at least once.
+  await page.waitForFunction(() => {
+    const s = window.__strokes || [];
+    return s.some(x => x.strokeStyle === '#ef5350') && s.some(x => x.strokeStyle === '#e9c349');
+  });
+
+  const strokes = await page.evaluate(() => window.__strokes);
+  const collector = strokes.filter(s => s.strokeStyle === '#ef5350');
+  const tank = strokes.filter(s => s.strokeStyle === '#e9c349');
+
+  expect(collector.length).toBeGreaterThan(0);
+  expect(tank.length).toBeGreaterThan(0);
+  for (const s of collector) {
+    expect(s.lineJoin).toBe('round');
+    expect(s.lineCap).toBe('round');
+  }
+  for (const s of tank) {
+    expect(s.lineJoin).toBe('round');
+    expect(s.lineCap).toBe('round');
+  }
+});


### PR DESCRIPTION
## Summary

- The history-graph temperature lines were stroked with the canvas default `lineJoin: 'miter'`. When the chart is zoomed out, noisy adjacent samples collapse into a narrow x-range, turning each up/down spike into a very acute V. A miter join extends the stroke a long point past that vertex — so a spike gets drawn *beyond* the real peak temperature (visible in the reported COLLECTOR screenshots, where the same spike looks taller the further you zoom out).
- Fix: set `lineJoin`/`lineCap` to `'round'` once per draw pass in `drawHistoryGraph`, after the canvas resize that resets context state. Round joins clamp the stroke to the actual vertices, so spikes render at their true height at every zoom level. This covers the main tank line, all `drawTempLine` series, and the forecast overlay (they share the context).

Note: pushed to the existing `claude/fix-inspector-tooltip-alignment-jNSvI` branch per the session's branch instructions (its prior PR #187 is already merged), so this PR's diff is just the line-join change.

## Test plan

- [x] New `tests/frontend/graph-line-join.spec.js` — instruments the canvas `stroke()` calls and asserts the collector and tank temperature lines are drawn with round joins/caps. Confirmed it fails on pre-fix code (`miter`) and passes after the fix.
- [x] `npm run lint`, `npm run knip`, `check:file-size --strict`, `check:assets --strict` — all clean
- [x] Full unit suite (1193 pass) + Playwright frontend + e2e (325 pass)

https://claude.ai/code/session_01B3B8fhRYrhxWGsp19c3sdn

---
_Generated by [Claude Code](https://claude.ai/code/session_01B3B8fhRYrhxWGsp19c3sdn)_