### PR TITLE
Pan the chart while pinch-zooming, tracking the gesture midpoint

### DIFF
--- a/coverage-exclusions.json
+++ b/coverage-exclusions.json
@@ -1,6 +1,4 @@
 {
   "_comment": "Frontend JS files that bypass the 50% coverage gate enforced by scripts/coverage-check.mjs. Paths are relative to the repo root; each key maps to a written reason. Prefer adding a test over adding an entry here. CI also fails if an excluded file has climbed above the threshold — delete stale entries when that happens.",
-  "files": {
-    "playground/js/main/chart-pinch-zoom.js": "Pure helpers (pinchZoomWindow, panZoomWindow) are covered by tests/pinch-zoom.test.mjs in the unit suite. The remaining lines are the multi-finger pointer-event state machine that disambiguates tap / long-press / pan / pinch, which Playwright's frontend project can't simulate without real two-touch gestures. Verified manually on the preview deploy."
-  }
+  "files": {}
 }

--- a/playground/js/main/chart-pinch-zoom.js
+++ b/playground/js/main/chart-pinch-zoom.js
@@ -2,10 +2,13 @@
 // pan / pinch / tap / long-press disambiguate against a single source of
 // pointer-event truth.
 //
-//   2 fingers            — pinch zoom the x-axis (y stays fixed at 0–100°C).
-//                          The 1H/6H/12H/24H timeframe-selector value is
-//                          the upper bound; pinch-out past it snaps back
-//                          to the default sliding window.
+//   2 fingers            — pinch zoom the x-axis (the y-axis reacts on its
+//                          own). The moment under the gesture midpoint
+//                          stays pinned to it, so sliding the fingers pans
+//                          the window while their spread zooms it. The
+//                          1H/6H/12H/24H timeframe-selector value is the
+//                          upper bound; pinch-out past it snaps back to
+//                          the default sliding window.
 //   1 finger drag while  — pan the visible window left/right within the
 //   zoomed                 timeframe-selector's natural span.
 //   1 finger short tap   — reset zoom (no-op if already at default).
@@ -19,7 +22,7 @@ import {
   graphRange, chartZoom, setChartZoom, timeSeriesStore,
   showForecast, FORECAST_OVERLAY_SEC,
 } from './state.js';
-import { drawHistoryGraph, getChartWindow } from './history-graph.js';
+import { drawHistoryGraph, getChartWindow, chartPadding } from './history-graph.js';
 import { showInspector, hideInspector } from './graph-inspector.js';
 import { store } from '../app-state.js';
 
@@ -28,18 +31,17 @@ const TAP_MAX_PX = 8;     // movement that still counts as a tap
 const TAP_MAX_MS = 300;   // touch duration that still counts as a tap
 const LONG_PRESS_MS = 400;
 
-// Mirror the pad object in drawHistoryGraph; needed to translate pinch
-// midpoint pixels into a fraction of the plot area.
-const PAD_LEFT = 8;
-const PAD_RIGHT = 16;
-
-// Pure: derive the new visible window from a 2-finger gesture. Returns
-// null when the result would equal or exceed maxRange — caller then
-// clears chartZoom so the default sliding view returns.
+// Pure: derive the new visible window from a 2-finger gesture.
+// timeAtPinchCenter is the moment anchored to the gesture (captured at
+// gesture start); fracOfPinchCenter is where the midpoint currently sits
+// across the plot — sampled every move, so a sliding gesture pans the
+// window while the finger spread zooms it. Returns null when the result
+// would equal or exceed maxRange — caller then clears chartZoom so the
+// default sliding view returns.
 export function pinchZoomWindow({
   initialRange,
-  initialFracOfPinchCenter,
-  initialTimeAtPinchCenter,
+  fracOfPinchCenter,
+  timeAtPinchCenter,
   distanceRatio,
   maxRange,
   minRange,
@@ -47,8 +49,8 @@ export function pinchZoomWindow({
   let newRange = initialRange / distanceRatio;
   if (newRange >= maxRange) return null;
   if (newRange < minRange) newRange = minRange;
-  const f = initialFracOfPinchCenter;
-  const tc = initialTimeAtPinchCenter;
+  const f = fracOfPinchCenter;
+  const tc = timeAtPinchCenter;
   return { tMin: tc - f * newRange, tMax: tc + (1 - f) * newRange };
 }
 
@@ -117,14 +119,18 @@ export function setupChartPinchZoom() {
   let pinch = null;
   let one = null;
 
+  // chartPadding() is the single source the renderer draws against
+  // (fullscreen widens the left gutter), so the pinch midpoint→fraction
+  // math stays aligned with the plotted data in every mode.
   function plotWidth() {
     const r = canvas.getBoundingClientRect();
-    return Math.max(1, r.width - PAD_LEFT - PAD_RIGHT);
+    const pad = chartPadding();
+    return Math.max(1, r.width - pad.left - pad.right);
   }
 
   function midpointFracX(rect, p1, p2) {
     const m = (p1.x + p2.x) / 2 - rect.left;
-    const f = (m - PAD_LEFT) / plotWidth();
+    const f = (m - chartPadding().left) / plotWidth();
     if (f < 0) return 0;
     if (f > 1) return 1;
     return f;
@@ -139,8 +145,10 @@ export function setupChartPinchZoom() {
     const f0 = midpointFracX(rect, pts[0], pts[1]);
     const win = getChartWindow();
     const range0 = win.tMax - win.tMin;
+    // The moment under the gesture midpoint — stays anchored for the
+    // whole gesture so a sliding pinch pans the window to keep it there.
     const tMid = win.tMin + f0 * range0;
-    pinch = { d0, f0, tMid, range0 };
+    pinch = { d0, tMid, range0 };
   }
 
   function updatePinch(e) {
@@ -150,11 +158,15 @@ export function setupChartPinchZoom() {
     const d = Math.abs(pts[0].x - pts[1].x);
     if (d < 1) return;
     e.preventDefault();
+    const rect = canvas.getBoundingClientRect();
     const bound = defaultBound();
+    // Resample the midpoint fraction every move: the anchored moment
+    // (pinch.tMid) is re-placed under wherever the gesture sits now, so
+    // sliding the fingers pans the window while their spread zooms it.
     const next = pinchZoomWindow({
       initialRange: pinch.range0,
-      initialFracOfPinchCenter: pinch.f0,
-      initialTimeAtPinchCenter: pinch.tMid,
+      fracOfPinchCenter: midpointFracX(rect, pts[0], pts[1]),
+      timeAtPinchCenter: pinch.tMid,
       distanceRatio: d / pinch.d0,
       // maxRange = the full default window (history + forecast horizon when
       // the overlay is on). Without this, pinch-out would snap back the
@@ -163,7 +175,9 @@ export function setupChartPinchZoom() {
       maxRange: bound.tMax - bound.tMin,
       minRange: MIN_RANGE_SEC,
     });
-    setChartZoom(next);
+    // Clamp into the pannable bound — the same guard the 1-finger pan
+    // uses — so sliding the gesture can't push the window past the data.
+    setChartZoom(next ? panZoomWindow(next, 0, bound) : null);
     drawHistoryGraph();
   }
 

--- a/tests/frontend/chart-pinch-zoom.spec.js
+++ b/tests/frontend/chart-pinch-zoom.spec.js
@@ -1,0 +1,174 @@
+// @ts-check
+// Two-finger pinch zoom on the history-graph canvas. The gesture funnels
+// through chart-pinch-zoom.js as raw PointerEvents, so the test drives it
+// by dispatching pointerType:'touch' events directly — the same technique
+// chart-mouse-zoom.spec.js uses for mouse.
+//
+// Behaviour under test: the pinch keeps the moment under the gesture
+// midpoint anchored to that midpoint *as the midpoint moves* — so the
+// chart pans while it zooms, instead of staying locked to the x-position
+// the gesture started at.
+import { test, expect } from './fixtures.js';
+
+test.use({ viewport: { width: 412, height: 915 } });
+
+const NOW = Date.now();
+
+const LIVE_POINTS = [
+  { ts: NOW - 7200_000, collector: 25.0, tank_top: 38.0, tank_bottom: 30.0, greenhouse: 17.0, outdoor: 9.0 },
+  { ts: NOW - 3600_000, collector: 45.0, tank_top: 42.0, tank_bottom: 34.0, greenhouse: 18.5, outdoor: 10.0 },
+  { ts: NOW - 60_000,   collector: 60.0, tank_top: 44.0, tank_bottom: 36.0, greenhouse: 19.0, outdoor: 11.0 },
+];
+
+async function scaffold(page) {
+  await page.addInitScript(() => {
+    const OrigWS = window.WebSocket;
+    // @ts-ignore
+    window.WebSocket = function () {
+      const fake = {
+        readyState: 0, onopen: null, onmessage: null, onclose: null, onerror: null,
+        close() { this.readyState = 3; },
+        send() {},
+      };
+      setTimeout(() => {
+        fake.readyState = 1;
+        if (fake.onopen) fake.onopen(new Event('open'));
+        if (fake.onmessage) {
+          fake.onmessage({ data: JSON.stringify({ type: 'connection', status: 'connected' }) });
+          fake.onmessage({ data: JSON.stringify({
+            type: 'state',
+            data: {
+              mode: 'idle',
+              temps: { collector: 60, tank_top: 44, tank_bottom: 36, greenhouse: 19, outdoor: 11 },
+              valves: { vi_btm: false, vi_top: false, vi_coll: false, vo_coll: false, vo_rad: false, vo_tank: false, v_air: false },
+              actuators: { pump: false, fan: false, space_heater: false },
+              controls_enabled: true,
+              manual_override: null,
+            },
+          }) });
+        }
+      }, 50);
+      return fake;
+    };
+    // @ts-ignore
+    window.WebSocket.prototype = OrigWS.prototype;
+    // @ts-ignore
+    window.WebSocket.OPEN = 1;
+    // @ts-ignore
+    window.WebSocket.CLOSED = 3;
+  });
+
+  await page.route('**/api/history**', r => r.fulfill({
+    status: 200, contentType: 'application/json',
+    body: JSON.stringify({ range: '24h', points: LIVE_POINTS, events: [] }),
+  }));
+  await page.route('**/api/forecast', r => r.fulfill({
+    status: 200, contentType: 'application/json', body: 'null',
+  }));
+  await page.route('**/api/watchdog/state', r => r.fulfill({
+    status: 200, contentType: 'application/json',
+    body: JSON.stringify({ pending: null, watchdogs: [], snapshot: { we: {}, wz: {}, wb: {} }, recent: [] }),
+  }));
+  await page.route('**/api/device-config', r => r.fulfill({
+    status: 200, contentType: 'application/json',
+    body: JSON.stringify({ ce: true, ea: 31, fm: null, we: {}, wz: {}, wb: {}, v: 1 }),
+  }));
+  await page.route('**/api/events**', r => r.fulfill({
+    status: 200, contentType: 'application/json', body: '[]',
+  }));
+  await page.route('**/api/push/**', r => r.fulfill({
+    status: 200, contentType: 'application/json', body: '{}',
+  }));
+}
+
+// Dispatch a two-finger pinch. fingers0 / fingers1 are [leftX, rightX]
+// plot-fractions at gesture start and end. Returns nothing — read
+// chartZoom afterwards.
+async function pinch(page, fingers0, fingers1) {
+  await page.evaluate(({ f0, f1 }) => {
+    const canvas = document.getElementById('chart');
+    const rect = canvas.getBoundingClientRect();
+    const y = rect.top + rect.height / 2;
+    const padLeft = 8, padRight = 16;
+    const pw = rect.width - padLeft - padRight;
+    const plotX = (frac) => rect.left + padLeft + frac * pw;
+    const fire = (type, id, x) => canvas.dispatchEvent(new PointerEvent(type, {
+      pointerId: id, pointerType: 'touch', clientX: x, clientY: y,
+      bubbles: true, cancelable: true,
+    }));
+    fire('pointerdown', 10, plotX(f0[0]));
+    fire('pointerdown', 11, plotX(f0[1]));
+    fire('pointermove', 10, plotX(f1[0]));
+    fire('pointermove', 11, plotX(f1[1]));
+    fire('pointerup', 10, plotX(f1[0]));
+    fire('pointerup', 11, plotX(f1[1]));
+  }, { f0: fingers0, f1: fingers1 });
+}
+
+async function chartWindow(page) {
+  return page.evaluate(async () => {
+    const g = await import('/playground/js/main/history-graph.js');
+    return g.getChartWindow();
+  });
+}
+
+async function readZoom(page) {
+  return page.evaluate(async () => {
+    const s = await import('/playground/js/main/state.js');
+    return s.chartZoom ? { tMin: s.chartZoom.tMin, tMax: s.chartZoom.tMax } : null;
+  });
+}
+
+test.describe('History-graph pinch zoom', () => {
+  test('spreading two fingers zooms the x-axis in around the gesture midpoint', async ({ page }) => {
+    await scaffold(page);
+    await page.goto('/playground/');
+    await page.waitForFunction(() => window.__initComplete === true);
+
+    const win0 = await chartWindow(page);
+    const range0 = win0.tMax - win0.tMin;
+
+    // Midpoint stays at plot-fraction 0.5; finger gap triples (0.1→0.3 of
+    // the plot width) → ~3× zoom-in.
+    await pinch(page, [0.45, 0.55], [0.35, 0.65]);
+
+    const zoom = await readZoom(page);
+    expect(zoom).not.toBeNull();
+    const newRange = zoom.tMax - zoom.tMin;
+    expect(newRange).toBeGreaterThan(range0 * 0.25);
+    expect(newRange).toBeLessThan(range0 * 0.45);
+
+    // Midpoint did not move, so the time under it stays at fraction 0.5.
+    const tMid = win0.tMin + 0.5 * range0;
+    const tAtMidpoint = zoom.tMin + 0.5 * newRange;
+    expect(Math.abs(tAtMidpoint - tMid)).toBeLessThan(newRange * 0.03);
+  });
+
+  test('sliding the gesture while pinching pans the window with the midpoint', async ({ page }) => {
+    await scaffold(page);
+    await page.goto('/playground/');
+    await page.waitForFunction(() => window.__initComplete === true);
+
+    const win0 = await chartWindow(page);
+    const range0 = win0.tMax - win0.tMin;
+    // The moment under the gesture midpoint at start (plot-fraction 0.5).
+    const tAnchor = win0.tMin + 0.5 * range0;
+
+    // Fingers start ±0.05 around fraction 0.5 and end ±0.10 around
+    // fraction 0.7: the gap doubles (2× zoom) AND the midpoint slides
+    // from 0.5 to 0.7. The anchored moment must follow to fraction 0.7.
+    await pinch(page, [0.45, 0.55], [0.60, 0.80]);
+
+    const zoom = await readZoom(page);
+    expect(zoom).not.toBeNull();
+    const newRange = zoom.tMax - zoom.tMin;
+    // ~2× zoom from the doubled finger gap.
+    expect(newRange).toBeGreaterThan(range0 * 0.4);
+    expect(newRange).toBeLessThan(range0 * 0.6);
+
+    // The anchored moment tracks the moved midpoint — it now sits at
+    // fraction 0.7, not the 0.5 it started at.
+    const tAt70 = zoom.tMin + 0.7 * newRange;
+    expect(Math.abs(tAt70 - tAnchor)).toBeLessThan(newRange * 0.04);
+  });
+});

--- a/tests/pinch-zoom.test.mjs
+++ b/tests/pinch-zoom.test.mjs
@@ -17,8 +17,8 @@ describe('pinchZoomWindow', () => {
   it('halves the visible range when fingers spread to twice the distance', () => {
     const r = pinchZoomWindow({
       initialRange: 24 * HOUR,
-      initialFracOfPinchCenter: 0.5,
-      initialTimeAtPinchCenter: 12 * HOUR,
+      fracOfPinchCenter: 0.5,
+      timeAtPinchCenter: 12 * HOUR,
       distanceRatio: 2,
       maxRange: 24 * HOUR,
       minRange: 60,
@@ -31,8 +31,8 @@ describe('pinchZoomWindow', () => {
     // time. After zooming 2×, that mark must still sit at 25% across.
     const r = pinchZoomWindow({
       initialRange: 24 * HOUR,
-      initialFracOfPinchCenter: 0.25,
-      initialTimeAtPinchCenter: 6 * HOUR,
+      fracOfPinchCenter: 0.25,
+      timeAtPinchCenter: 6 * HOUR,
       distanceRatio: 2,
       maxRange: 24 * HOUR,
       minRange: 60,
@@ -48,8 +48,8 @@ describe('pinchZoomWindow', () => {
     // immediately busts the cap.
     const r = pinchZoomWindow({
       initialRange: 12 * HOUR,
-      initialFracOfPinchCenter: 0.5,
-      initialTimeAtPinchCenter: 12 * HOUR,
+      fracOfPinchCenter: 0.5,
+      timeAtPinchCenter: 12 * HOUR,
       distanceRatio: 0.4,
       maxRange: 24 * HOUR,
       minRange: 60,
@@ -60,8 +60,8 @@ describe('pinchZoomWindow', () => {
   it('clamps very tight pinches to minRange instead of going to zero', () => {
     const r = pinchZoomWindow({
       initialRange: 1 * HOUR,
-      initialFracOfPinchCenter: 0.5,
-      initialTimeAtPinchCenter: 0,
+      fracOfPinchCenter: 0.5,
+      timeAtPinchCenter: 0,
       distanceRatio: 1000,
       maxRange: 24 * HOUR,
       minRange: 60,
@@ -75,8 +75,8 @@ describe('pinchZoomWindow', () => {
     // maxRange.
     const r = pinchZoomWindow({
       initialRange: 6 * HOUR,
-      initialFracOfPinchCenter: 0.5,
-      initialTimeAtPinchCenter: 3 * HOUR,
+      fracOfPinchCenter: 0.5,
+      timeAtPinchCenter: 3 * HOUR,
       distanceRatio: 1.5,
       maxRange: 24 * HOUR,
       minRange: 60,


### PR DESCRIPTION
## Summary

- Two-finger pinch zoom previously captured the gesture midpoint fraction **once at gesture start** and reused it for every move. The moment under the midpoint stayed locked to the x-position the gesture began at — so the chart could only zoom, never pan, during the gesture.
- Now the midpoint fraction is resampled on every move and the anchored moment is re-placed under it: **sliding the fingers pans the window while their spread zooms it**, both at once. The result is clamped into the pannable bound, matching the 1-finger pan so the gesture can't slide past the data edges.
- The y-axis is untouched — the gesture still only zooms the x-axis and the y-axis reacts on its own.
- Also dropped the stale local `PAD_LEFT`/`PAD_RIGHT` copy in favour of the shared `chartPadding()` (added in #187), so the pinch midpoint→fraction mapping is correct in fullscreen too.

The frontend Playwright suite *can* drive two-finger gestures via synthetic pointer events (same technique the mouse-zoom spec uses), so `chart-pinch-zoom.js` no longer needs its coverage exclusion — the new spec brings it to ~78% and the entry is removed.

## Test plan

- [x] New `tests/frontend/chart-pinch-zoom.spec.js` — drives synthetic two-finger pinches: one stationary-midpoint zoom, and one where the midpoint slides mid-gesture. Asserts the anchored moment tracks the moved midpoint. Confirmed it fails pre-fix (anchor stuck at the start fraction) and passes after.
- [x] `tests/pinch-zoom.test.mjs` updated for the renamed pure-helper params.
- [x] `npm run lint`, `npm run knip`, `check:file-size --strict`, `check:assets --strict`, frontend coverage gate — all clean
- [x] Full unit suite (1193 pass) + Playwright frontend + e2e (327 pass)

https://claude.ai/code/session_01B3B8fhRYrhxWGsp19c3sdn

---
_Generated by [Claude Code](https://claude.ai/code/session_01B3B8fhRYrhxWGsp19c3sdn)_