### PR TITLE
Fix flaky e2e suite from stale webServer reuse

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -59,8 +59,14 @@ export default defineConfig({
     {
       command: 'node tests/e2e/_setup/start.cjs',
       port: 3220,
-      reuseExistingServer: true,
-      timeout: 20000,
+      // Never reuse an existing harness: with reuse on, Playwright's
+      // port probe could latch onto a previous run's harness that is
+      // mid-shutdown, hand the tests a dying server, and skip spawning
+      // a fresh one — every request then fails with ECONNREFUSED. With
+      // reuse off Playwright always spawns its own; start.cjs's
+      // waitForPortFree handles a slow-to-die predecessor on 1883/3220.
+      reuseExistingServer: false,
+      timeout: 30000,
     },
   ],
 });

--- a/tests/e2e/_setup/start.cjs
+++ b/tests/e2e/_setup/start.cjs
@@ -85,28 +85,49 @@ require.cache[pgPath] = {
 
 // ── 2. aedes MQTT broker ──────────────────────────────────────
 
+const { waitForPortFree } = require('./wait-for-port.cjs');
 const { Aedes } = require('aedes');
 const MQTT_PORT = 1883;
+const HTTP_PORT = 3220;
+const PORT_FREE_TIMEOUT_MS = 10000;
 
+// Playwright runs this harness with `reuseExistingServer: false` (see the
+// webServer block in playwright.config.js), so a new boot can race a
+// previous run's harness that is still releasing 1883/3220. Bind only
+// once each port is free — otherwise the bind throws EADDRINUSE and the
+// whole e2e run fails. See ./wait-for-port.cjs.
+//
 // aedes@1 moved to an async factory; the old `new Aedes()` constructor
-// throws a migration error. `createBroker()` returns a promise — we
-// boot the rest of the harness inside its `.then` so the broker is
-// accepting connections before server/server.js tries to dial out.
-Aedes.createBroker().then((broker) => {
-  const mqttServer = net.createServer(broker.handle);
-  mqttServer.listen(MQTT_PORT, '127.0.0.1', () => {
-    process.stdout.write(`[e2e-harness] aedes listening on 127.0.0.1:${MQTT_PORT}\n`);
-    bootServer();
-  });
+// throws a migration error. `createBroker()` returns a promise — we boot
+// the rest of the harness through the chain so the broker is accepting
+// connections before server/server.js tries to dial out.
+waitForPortFree(MQTT_PORT, '127.0.0.1', PORT_FREE_TIMEOUT_MS)
+  .then(() => Aedes.createBroker())
+  .then((broker) => {
+    const mqttServer = net.createServer(broker.handle);
 
-  // Register teardown hooks once the broker is live.
-  const shutdown = () => {
-    try { mqttServer.close(); } catch (_) { /* noop */ }
-    broker.close().then(() => process.exit(0), () => process.exit(1));
-  };
-  process.on('SIGTERM', shutdown);
-  process.on('SIGINT', shutdown);
-});
+    // Register teardown hooks once the broker is live.
+    const shutdown = () => {
+      try { mqttServer.close(); } catch (_) { /* noop */ }
+      broker.close().then(() => process.exit(0), () => process.exit(1));
+    };
+    process.on('SIGTERM', shutdown);
+    process.on('SIGINT', shutdown);
+
+    return new Promise((resolve, reject) => {
+      mqttServer.once('error', reject);
+      mqttServer.listen(MQTT_PORT, '127.0.0.1', () => {
+        process.stdout.write(`[e2e-harness] aedes listening on 127.0.0.1:${MQTT_PORT}\n`);
+        resolve();
+      });
+    });
+  })
+  .then(() => waitForPortFree(HTTP_PORT, '127.0.0.1', PORT_FREE_TIMEOUT_MS))
+  .then(() => bootServer())
+  .catch((err) => {
+    process.stderr.write(`[e2e-harness] fatal: ${err && err.message}\n`);
+    process.exit(1);
+  });
 
 // ── 3. Env + server boot ──────────────────────────────────────
 

--- a/tests/e2e/_setup/wait-for-port.cjs
+++ b/tests/e2e/_setup/wait-for-port.cjs
@@ -1,0 +1,39 @@
+'use strict';
+
+// Resolve once nothing is listening on host:port, or reject after
+// timeoutMs. start.cjs uses this to defer binding 1883/3220 until a
+// slow-to-die predecessor harness has released the ports — otherwise
+// the fresh boot races the old process and crashes with EADDRINUSE.
+//
+// "Free" is detected by a probe connection being refused (ECONNREFUSED).
+// A successful connect — or a probe that hangs — means something is
+// still bound, so we retry until the deadline.
+
+const net = require('net');
+
+function waitForPortFree(port, host, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  return new Promise((resolve, reject) => {
+    function probe() {
+      const sock = net.connect({ port, host });
+      let settled = false;
+      function finish(isFree) {
+        if (settled) return;
+        settled = true;
+        sock.destroy();
+        if (isFree) { resolve(); return; }
+        if (Date.now() >= deadline) {
+          reject(new Error('port ' + port + ' on ' + host + ' still in use after ' + timeoutMs + 'ms'));
+          return;
+        }
+        setTimeout(probe, 200);
+      }
+      sock.once('connect', function () { finish(false); });
+      sock.once('error', function () { finish(true); });
+      sock.setTimeout(1000, function () { finish(false); });
+    }
+    probe();
+  });
+}
+
+module.exports = { waitForPortFree };

--- a/tests/wait-for-port.test.js
+++ b/tests/wait-for-port.test.js
@@ -1,0 +1,38 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const net = require('node:net');
+
+const { waitForPortFree } = require('./e2e/_setup/wait-for-port.cjs');
+
+// A port unlikely to collide with the dev servers (3210/3220) or the
+// e2e MQTT broker (1883).
+const TEST_PORT = 39517;
+const HOST = '127.0.0.1';
+
+describe('waitForPortFree', () => {
+  it('resolves immediately when the port is already free', async () => {
+    await waitForPortFree(TEST_PORT, HOST, 2000);
+  });
+
+  it('rejects when the port stays occupied past the timeout', async () => {
+    const server = net.createServer();
+    await new Promise((resolve) => server.listen(TEST_PORT, HOST, resolve));
+    try {
+      await assert.rejects(
+        waitForPortFree(TEST_PORT, HOST, 600),
+        /still in use/,
+      );
+    } finally {
+      await new Promise((resolve) => server.close(resolve));
+    }
+  });
+
+  it('resolves once an occupied port is released mid-wait', async () => {
+    const server = net.createServer();
+    await new Promise((resolve) => server.listen(TEST_PORT, HOST, resolve));
+    // Release the port shortly after the wait begins — mirrors a
+    // predecessor harness finishing its shutdown.
+    setTimeout(() => server.close(), 300);
+    await waitForPortFree(TEST_PORT, HOST, 5000);
+  });
+});


### PR DESCRIPTION
## Summary

Ran the full CI test suite with each test executed **5×** to hunt for flakiness:

| Suite | Result |
|---|---|
| `npm run test:unit` | stable — 5/5 runs green |
| `npm run test:frontend` | stable — 5/5 runs green (306 tests each) |
| `npm run test:e2e` | **flaky** — 1 run had 17/19 tests fail with `ECONNREFUSED` |

### Root cause

The `e2e` Playwright project's webServer was configured `reuseExistingServer: true` with a bare TCP port probe. When a fresh e2e run started while a previous harness (`tests/e2e/_setup/start.cjs`) was still shutting down, Playwright's probe latched onto the dying server, decided to *reuse* it, skipped spawning a fresh one, and handed the tests a server that died mid-run — every request then failed with `ECONNREFUSED` on `3220` (HTTP) and `1883` (MQTT).

This bites anyone running `test:frontend` then `test:e2e` back-to-back (both Playwright projects share the `:3220` webServer entry).

### Fix

- `playwright.config.js`: set `reuseExistingServer: false` for the e2e harness so Playwright always spawns its own — never a stale/dying one.
- `tests/e2e/_setup/start.cjs`: bind `1883`/`3220` only once each port is free, via a new `waitForPortFree` helper — otherwise a fresh boot racing a slow-to-die predecessor would crash with `EADDRINUSE`.
- `tests/e2e/_setup/wait-for-port.cjs`: the new helper (probe-until-refused with a deadline).
- `tests/wait-for-port.test.js`: unit coverage for the helper.

No e2e test logic changed — the same 19 scenarios run against the same harness.

### Verification

- `waitForPortFree` unit test: 3/3 pass.
- Harness boots cleanly when `1883`+`3220` are held by a predecessor (waits instead of crashing) — verified directly.
- e2e suite re-run **5×** after the fix: all green.
- unit + frontend suites unaffected.

## Test plan

- [x] `npm run test:unit` (incl. new `wait-for-port.test.js`)
- [x] `npm run test:e2e` × 5 — green
- [x] `npm run test:frontend` × 5 — green
- [x] `npm run lint` / `knip` / `check:file-size` / `check:assets`

https://claude.ai/code/session_01TgKk1astc7RvVonhhq5JuD

---
_Generated by [Claude Code](https://claude.ai/code/session_01TgKk1astc7RvVonhhq5JuD)_