### PR TITLE
Improve sustain-forecast accuracy: destratification, heating thermostat, solar reference

### DIFF
--- a/server/lib/forecast/sustain-forecast-fit-base.js
+++ b/server/lib/forecast/sustain-forecast-fit-base.js
@@ -1,0 +1,124 @@
+'use strict';
+
+// sustain-forecast-fit-base.js — shared constants, sanity bounds and
+// pure helpers for the sustain-forecast fitting + engine code. Split
+// out of sustain-forecast-fit.js purely to keep every file in this
+// directory under the 600-line cap. No I/O, no deps.
+
+// ── Physical constants (shared with engine) ──
+const TANK_THERMAL_MASS_J_PER_K = 300 * 4186;
+// Tank energy capacity in kWh per K (300 L water, 4186 J/(kg·K)):
+// 300 × 4186 / 3.6e6 = 0.349 kWh/K — the operationally meaningful unit.
+const TANK_KWH_PER_K = TANK_THERMAL_MASS_J_PER_K / 3.6e6;
+
+// ── Fit defaults ──
+const DEFAULT_TANK_LEAKAGE_W_PER_K = 3.0;
+
+// Fit thresholds.
+const MIN_IDLE_BUCKET_MINUTES = 20;
+const MIN_BUCKETS_FOR_FIT     = 5;
+// GH-air fits run on far fewer rows than the tank/heater fits because
+// they need radiation present + the right mode + non-maintenance — a
+// lower bar lets them converge from days, not weeks, of clean history.
+const MIN_BUCKETS_FOR_GH_FIT  = 3;
+
+// Sanity bounds. Fits whose output falls outside these ranges are
+// physically implausible for this greenhouse and are rejected (return
+// null) — caller falls through to DEFAULT_CONFIG. Bounds are
+// deliberately wide; the goal is to catch garbage fits (e.g. α near
+// zero from a radiation column with no spread, or a τ that says the
+// greenhouse cools fully in 6 minutes), not to second-guess plausible
+// variations. Values seeded from operational observation: GH peaks at
+// ~33 °C in sunny noon, cools to outdoor in ~2 h after vents close,
+// radiator measured at ~80–100 W/K from logged tank-drop data.
+const GH_TAU_MIN_H        = 0.5;
+// User's logged cooldown 27.8 → 12.1 °C in 4 h (outdoor 10 °C) implies
+// τ ≈ 1.9 h. Long-tail soil/structure thermal mass biases the 14d-
+// average fit upward toward 4 h, which makes the simulation hold gh
+// well above ehE all night (heater never fires). Cap at 3 h: above
+// this is implausible for an air-temperature-driven control loop.
+const GH_TAU_MAX_H        = 3.0;
+const GH_ALPHA_MIN        = 0.005;
+const GH_ALPHA_MAX        = 0.05;
+const RAD_UA_MIN_W_PER_K  = 40;
+// Empirically the car-radiator + fan setup measures 80–100 W/K from
+// logged greenhouse_heating-mode tank-drop pairs. The fit's median
+// drifts higher than this — likely because heating-mode tank loss
+// includes both radiator output AND ambient leakage, and the fit
+// attributes all of it to UA. 130 caps the upward bias while leaving
+// headroom for genuinely high-flow operating points.
+const RAD_UA_MAX_W_PER_K  = 130;
+const GH_LOSS_MIN_W_PER_K = 30;
+const GH_LOSS_MAX_W_PER_K = 300;
+const TANK_LEAK_MIN_W_PER_K = 1;
+const TANK_LEAK_MAX_W_PER_K = 30;
+// Cloud-reference radiation (W/m²) — the gain-weighted mean RadiationGlobal
+// over historical charging hours. Outside this band the fit is rejected
+// (too few samples / a radiation column with no spread) and the engine
+// keeps DEFAULT_CONFIG.cloudReferenceWm2.
+const CLOUD_REF_MIN_WM2 = 200;
+const CLOUD_REF_MAX_WM2 = 900;
+
+// ── Helsinki TZ helpers (deterministic across server timezones) ──
+const HELSINKI_HOUR_FMT = new Intl.DateTimeFormat('en-GB', {
+  timeZone: 'Europe/Helsinki', hour12: false, hour: '2-digit',
+});
+const HELSINKI_HHMM_FMT = new Intl.DateTimeFormat('en-GB', {
+  timeZone: 'Europe/Helsinki', hour12: false, hour: '2-digit', minute: '2-digit',
+});
+function helsinkiHour(date) {
+  const h = parseInt(HELSINKI_HOUR_FMT.format(date), 10);
+  return h === 24 ? 0 : h;
+}
+function helsinkiHHMM(date) {
+  return HELSINKI_HHMM_FMT.format(date);
+}
+
+// Shared mode-labeller: returns one mode string per reading by
+// forward-walking the modes array. Was duplicated in three fit
+// functions (fitSolarGainByHour, fitGreenhouseLossWPerK,
+// fitEmpiricalCoefficients) — consolidated here in 2026-05-08 when the
+// new GH heat-balance fits added a fourth and fifth caller.
+function labelModes(readings, modes) {
+  const labels = new Array(readings.length);
+  let cursor = 0;
+  let currentMode = 'idle';
+  while (cursor < modes.length) {
+    const tsMs = modes[cursor].ts instanceof Date ? modes[cursor].ts.getTime() : Number(modes[cursor].ts);
+    const r0Ms = readings[0].ts instanceof Date ? readings[0].ts.getTime() : Number(readings[0].ts);
+    if (tsMs <= r0Ms) { currentMode = modes[cursor].mode; cursor++; }
+    else break;
+  }
+  labels[0] = currentMode;
+  for (let i = 1; i < readings.length; i++) {
+    const rMs = readings[i].ts instanceof Date ? readings[i].ts.getTime() : Number(readings[i].ts);
+    while (cursor < modes.length) {
+      const mMs = modes[cursor].ts instanceof Date ? modes[cursor].ts.getTime() : Number(modes[cursor].ts);
+      if (mMs <= rMs) { currentMode = modes[cursor].mode; cursor++; }
+      else break;
+    }
+    labels[i] = currentMode;
+  }
+  return labels;
+}
+
+// ── Least-squares slope through origin: slope = Σ(xi·yi) / Σ(xi²) ──
+function slopeThruOrigin(xs, ys) {
+  let sumXY = 0, sumX2 = 0;
+  for (let i = 0; i < xs.length; i++) {
+    sumXY += xs[i] * ys[i];
+    sumX2 += xs[i] * xs[i];
+  }
+  return sumX2 === 0 ? null : sumXY / sumX2;
+}
+
+module.exports = {
+  TANK_THERMAL_MASS_J_PER_K, TANK_KWH_PER_K, DEFAULT_TANK_LEAKAGE_W_PER_K,
+  MIN_IDLE_BUCKET_MINUTES, MIN_BUCKETS_FOR_FIT, MIN_BUCKETS_FOR_GH_FIT,
+  GH_TAU_MIN_H, GH_TAU_MAX_H, GH_ALPHA_MIN, GH_ALPHA_MAX,
+  RAD_UA_MIN_W_PER_K, RAD_UA_MAX_W_PER_K,
+  GH_LOSS_MIN_W_PER_K, GH_LOSS_MAX_W_PER_K,
+  TANK_LEAK_MIN_W_PER_K, TANK_LEAK_MAX_W_PER_K,
+  CLOUD_REF_MIN_WM2, CLOUD_REF_MAX_WM2,
+  helsinkiHour, helsinkiHHMM, labelModes, slopeThruOrigin,
+};

--- a/server/lib/forecast/sustain-forecast-fit.js
+++ b/server/lib/forecast/sustain-forecast-fit.js
@@ -3,122 +3,31 @@
 // sustain-forecast-fit.js — empirical-coefficient fitting for the
 // 48 h sustain forecast engine. Pure functions, no I/O.
 //
-// Split out of sustain-forecast.js purely to keep both files under
-// the 600-line cap. The engine imports the fit functions and the
-// shared Helsinki-time helpers (so all hour-of-day computation goes
-// through the same path).
+// Split out of sustain-forecast.js purely to keep files under the
+// 600-line cap; shared constants + helpers live in -fit-base.js.
 
-// ── Physical constants (shared with engine) ──
-const TANK_THERMAL_MASS_J_PER_K = 300 * 4186;
-
-// ── Fit defaults ──
-const DEFAULT_TANK_LEAKAGE_W_PER_K = 3.0;
-
-// Fit thresholds.
-const MIN_IDLE_BUCKET_MINUTES = 20;
-const MIN_BUCKETS_FOR_FIT     = 5;
-// GH-air fits run on far fewer rows than the tank/heater fits because
-// they need radiation present + the right mode + non-maintenance — a
-// lower bar lets them converge from days, not weeks, of clean history.
-const MIN_BUCKETS_FOR_GH_FIT  = 3;
-
-// Sanity bounds. Fits whose output falls outside these ranges are
-// physically implausible for this greenhouse and are rejected (return
-// null) — caller falls through to DEFAULT_CONFIG. Bounds are
-// deliberately wide; the goal is to catch garbage fits (e.g. α near
-// zero from a radiation column with no spread, or a τ that says the
-// greenhouse cools fully in 6 minutes), not to second-guess plausible
-// variations. Values seeded from operational observation: GH peaks at
-// ~33 °C in sunny noon, cools to outdoor in ~2 h after vents close,
-// radiator measured at ~80–100 W/K from logged tank-drop data.
-const GH_TAU_MIN_H        = 0.5;
-// User's logged cooldown 27.8 → 12.1 °C in 4 h (outdoor 10 °C) implies
-// τ ≈ 1.9 h. Long-tail soil/structure thermal mass biases the 14d-
-// average fit upward toward 4 h, which makes the simulation hold gh
-// well above ehE all night (heater never fires). Cap at 3 h: above
-// this is implausible for an air-temperature-driven control loop.
-const GH_TAU_MAX_H        = 3.0;
-const GH_ALPHA_MIN        = 0.005;
-const GH_ALPHA_MAX        = 0.05;
-const RAD_UA_MIN_W_PER_K  = 40;
-// Empirically the car-radiator + fan setup measures 80–100 W/K from
-// logged greenhouse_heating-mode tank-drop pairs. The fit's median
-// drifts higher than this — likely because heating-mode tank loss
-// includes both radiator output AND ambient leakage, and the fit
-// attributes all of it to UA. 130 caps the upward bias while leaving
-// headroom for genuinely high-flow operating points.
-const RAD_UA_MAX_W_PER_K  = 130;
-const GH_LOSS_MIN_W_PER_K = 30;
-const GH_LOSS_MAX_W_PER_K = 300;
-const TANK_LEAK_MIN_W_PER_K = 1;
-const TANK_LEAK_MAX_W_PER_K = 30;
-// Cloud-reference radiation (W/m²) — the gain-weighted mean RadiationGlobal
-// over historical charging hours. Outside this band the fit is rejected
-// (too few samples / a radiation column with no spread) and the engine
-// keeps DEFAULT_CONFIG.cloudReferenceWm2.
-const CLOUD_REF_MIN_WM2 = 200;
-const CLOUD_REF_MAX_WM2 = 900;
-
-// ── Helsinki TZ helpers (deterministic across server timezones) ──
-const HELSINKI_HOUR_FMT = new Intl.DateTimeFormat('en-GB', {
-  timeZone: 'Europe/Helsinki', hour12: false, hour: '2-digit',
-});
-const HELSINKI_HHMM_FMT = new Intl.DateTimeFormat('en-GB', {
-  timeZone: 'Europe/Helsinki', hour12: false, hour: '2-digit', minute: '2-digit',
-});
-function helsinkiHour(date) {
-  const h = parseInt(HELSINKI_HOUR_FMT.format(date), 10);
-  return h === 24 ? 0 : h;
-}
-function helsinkiHHMM(date) {
-  return HELSINKI_HHMM_FMT.format(date);
-}
-
-// Shared mode-labeller: returns one mode string per reading by
-// forward-walking the modes array. Was duplicated in three fit
-// functions (fitSolarGainByHour, fitGreenhouseLossWPerK,
-// fitEmpiricalCoefficients) — consolidated here in 2026-05-08 when the
-// new GH heat-balance fits added a fourth and fifth caller.
-function labelModes(readings, modes) {
-  const labels = new Array(readings.length);
-  let cursor = 0;
-  let currentMode = 'idle';
-  while (cursor < modes.length) {
-    const tsMs = modes[cursor].ts instanceof Date ? modes[cursor].ts.getTime() : Number(modes[cursor].ts);
-    const r0Ms = readings[0].ts instanceof Date ? readings[0].ts.getTime() : Number(readings[0].ts);
-    if (tsMs <= r0Ms) { currentMode = modes[cursor].mode; cursor++; }
-    else break;
-  }
-  labels[0] = currentMode;
-  for (let i = 1; i < readings.length; i++) {
-    const rMs = readings[i].ts instanceof Date ? readings[i].ts.getTime() : Number(readings[i].ts);
-    while (cursor < modes.length) {
-      const mMs = modes[cursor].ts instanceof Date ? modes[cursor].ts.getTime() : Number(modes[cursor].ts);
-      if (mMs <= rMs) { currentMode = modes[cursor].mode; cursor++; }
-      else break;
-    }
-    labels[i] = currentMode;
-  }
-  return labels;
-}
-
-// ── Least-squares slope through origin: slope = Σ(xi·yi) / Σ(xi²) ──
-function slopeThruOrigin(xs, ys) {
-  let sumXY = 0, sumX2 = 0;
-  for (let i = 0; i < xs.length; i++) {
-    sumXY += xs[i] * ys[i];
-    sumX2 += xs[i] * xs[i];
-  }
-  return sumX2 === 0 ? null : sumXY / sumX2;
-}
-
-/**
- * Fit empirical thermal coefficients from historical sensor + mode data.
- */
-// Tank energy capacity in kWh per K (300 L water, 4186 J/(kg·K)):
-// 300 × 4186 / 3.6e6 = 0.349 kWh/K. Useful for converting between tank ΔK
-// and kWh — the operationally meaningful unit.
-const TANK_KWH_PER_K = TANK_THERMAL_MASS_J_PER_K / 3.6e6;
+const base = require('./sustain-forecast-fit-base');
+const TANK_THERMAL_MASS_J_PER_K  = base.TANK_THERMAL_MASS_J_PER_K;
+const TANK_KWH_PER_K             = base.TANK_KWH_PER_K;
+const DEFAULT_TANK_LEAKAGE_W_PER_K = base.DEFAULT_TANK_LEAKAGE_W_PER_K;
+const MIN_IDLE_BUCKET_MINUTES    = base.MIN_IDLE_BUCKET_MINUTES;
+const MIN_BUCKETS_FOR_FIT        = base.MIN_BUCKETS_FOR_FIT;
+const MIN_BUCKETS_FOR_GH_FIT     = base.MIN_BUCKETS_FOR_GH_FIT;
+const GH_TAU_MIN_H        = base.GH_TAU_MIN_H;
+const GH_TAU_MAX_H        = base.GH_TAU_MAX_H;
+const GH_ALPHA_MIN        = base.GH_ALPHA_MIN;
+const GH_ALPHA_MAX        = base.GH_ALPHA_MAX;
+const RAD_UA_MIN_W_PER_K  = base.RAD_UA_MIN_W_PER_K;
+const RAD_UA_MAX_W_PER_K  = base.RAD_UA_MAX_W_PER_K;
+const GH_LOSS_MIN_W_PER_K = base.GH_LOSS_MIN_W_PER_K;
+const GH_LOSS_MAX_W_PER_K = base.GH_LOSS_MAX_W_PER_K;
+const TANK_LEAK_MIN_W_PER_K = base.TANK_LEAK_MIN_W_PER_K;
+const TANK_LEAK_MAX_W_PER_K = base.TANK_LEAK_MAX_W_PER_K;
+const CLOUD_REF_MIN_WM2   = base.CLOUD_REF_MIN_WM2;
+const CLOUD_REF_MAX_WM2   = base.CLOUD_REF_MAX_WM2;
+const helsinkiHour    = base.helsinkiHour;
+const labelModes      = base.labelModes;
+const slopeThruOrigin = base.slopeThruOrigin;
 
 /**
  * Empirical solar gain by hour-of-day, in kWh of tank energy per clock hour
@@ -620,9 +529,8 @@ module.exports = {
   // Constants the engine also needs.
   TANK_THERMAL_MASS_J_PER_K,
   TANK_KWH_PER_K,
-  // TZ helpers.
+  // TZ helper (engine consumes this).
   helsinkiHour,
-  helsinkiHHMM,
   // Fit functions.
   fitSolarGainByHour,
   fitCloudReferenceWm2,

--- a/server/lib/forecast/sustain-forecast-fit.js
+++ b/server/lib/forecast/sustain-forecast-fit.js
@@ -52,6 +52,12 @@ const GH_LOSS_MIN_W_PER_K = 30;
 const GH_LOSS_MAX_W_PER_K = 300;
 const TANK_LEAK_MIN_W_PER_K = 1;
 const TANK_LEAK_MAX_W_PER_K = 30;
+// Cloud-reference radiation (W/m²) — the gain-weighted mean RadiationGlobal
+// over historical charging hours. Outside this band the fit is rejected
+// (too few samples / a radiation column with no spread) and the engine
+// keeps DEFAULT_CONFIG.cloudReferenceWm2.
+const CLOUD_REF_MIN_WM2 = 200;
+const CLOUD_REF_MAX_WM2 = 900;
 
 // ── Helsinki TZ helpers (deterministic across server timezones) ──
 const HELSINKI_HOUR_FMT = new Intl.DateTimeFormat('en-GB', {
@@ -199,6 +205,56 @@ function fitSolarGainByHour(history) {
   for (let h = 0; h < 24; h++) total += out[h];
   if (total < 0.5) return fallback;
   return out;
+}
+
+/**
+ * Cloud-reference radiation (W/m²) for the solar-gain model.
+ *
+ * The forecast credits solar gain as solarGainKwhByHour[h] × (radiation /
+ * cloudReferenceWm2). For that credit to be unbiased on an average-weather
+ * day, cloudReferenceWm2 must equal the radiation level the baseline was
+ * built from — i.e. the gain-weighted mean RadiationGlobal over exactly
+ * the solar_charging samples fitSolarGainByHour sums. A hand-picked
+ * constant (the old 500 W/m²) that sits below the true mean systematically
+ * over-credits gain.
+ *
+ * Uses the same sample gate as fitSolarGainByHour (solar_charging mode,
+ * ≤ 10-min pair, positive tank ΔK) and weights each sample's radiation by
+ * its ΔK, so ref = Σ(ΔK·rad) / Σ(ΔK). Falls back to null on insufficient
+ * data or an out-of-band result; the engine then keeps the seed default.
+ *
+ * @param {object} history  { readings, modes } — readings carry radiationGlobal
+ * @returns {number|null}   Reference W/m² within sanity bounds, else null
+ */
+function fitCloudReferenceWm2(history) {
+  if (!history || !Array.isArray(history.readings) || history.readings.length < 2 ||
+      !Array.isArray(history.modes)) {
+    return null;
+  }
+  const readings = history.readings;
+  const modeLabels = labelModes(readings, history.modes);
+  let sumDk = 0, sumDkRad = 0, n = 0;
+  for (let i = 0; i < readings.length - 1; i++) {
+    if (modeLabels[i] !== 'solar_charging') continue;
+    const r0 = readings[i];
+    const r1 = readings[i + 1];
+    const t0 = r0.ts instanceof Date ? r0.ts.getTime() : Number(r0.ts);
+    const t1 = r1.ts instanceof Date ? r1.ts.getTime() : Number(r1.ts);
+    const dtSec = (t1 - t0) / 1000;
+    if (dtSec <= 0 || dtSec > 600) continue;
+    if (typeof r0.tankTop !== 'number' || typeof r0.tankBottom !== 'number' ||
+        typeof r1.tankTop !== 'number' || typeof r1.tankBottom !== 'number') continue;
+    if (typeof r0.radiationGlobal !== 'number') continue;
+    const dK = (r1.tankTop + r1.tankBottom) / 2 - (r0.tankTop + r0.tankBottom) / 2;
+    if (dK <= 0 || !isFinite(dK)) continue;
+    sumDk    += dK;
+    sumDkRad += dK * r0.radiationGlobal;
+    n        += 1;
+  }
+  if (n < MIN_BUCKETS_FOR_FIT || sumDk <= 0) return null;
+  const ref = sumDkRad / sumDk;
+  if (ref < CLOUD_REF_MIN_WM2 || ref > CLOUD_REF_MAX_WM2) return null;
+  return ref;
 }
 
 /**
@@ -543,16 +599,20 @@ function fitEmpiricalCoefficients(history, opts) {
   const ghTau   = fitGhTauNight(history);
   const ghAlpha = ghTau !== null ? fitGhAlphaDay(history, ghTau, 33) : null;
   const radUa   = fitRadiatorUaWPerK(history);
+  // Self-calibrating cloud reference: keeps the solar-gain credit
+  // unbiased as the solarGainKwhByHour baseline shifts with the season.
+  const cloudRef = fitCloudReferenceWm2(history);
 
   const out = {
     tankLeakageWPerK:   tankLeak !== null ? tankLeak : DEFAULT_TANK_LEAKAGE_W_PER_K,
     solarGainKwhByHour: fitSolarGainByHour(history),
     usedDefaults:       tankLeak === null,
   };
-  if (ghLoss  !== null) out.greenhouseLossWPerK   = ghLoss;
-  if (ghTau   !== null) out.ghTimeConstantH       = ghTau;
-  if (ghAlpha !== null) out.ghSolarAlphaCPerWm2   = ghAlpha;
-  if (radUa   !== null) out.radiatorUaWPerK       = radUa;
+  if (ghLoss   !== null) out.greenhouseLossWPerK = ghLoss;
+  if (ghTau    !== null) out.ghTimeConstantH     = ghTau;
+  if (ghAlpha  !== null) out.ghSolarAlphaCPerWm2 = ghAlpha;
+  if (radUa    !== null) out.radiatorUaWPerK     = radUa;
+  if (cloudRef !== null) out.cloudReferenceWm2   = cloudRef;
   return out;
 }
 
@@ -565,6 +625,7 @@ module.exports = {
   helsinkiHHMM,
   // Fit functions.
   fitSolarGainByHour,
+  fitCloudReferenceWm2,
   fitGreenhouseLossWPerK,
   fitGhTauNight,
   fitGhAlphaDay,
@@ -577,5 +638,6 @@ module.exports = {
     RAD_UA_MIN_W_PER_K, RAD_UA_MAX_W_PER_K,
     GH_LOSS_MIN_W_PER_K, GH_LOSS_MAX_W_PER_K,
     TANK_LEAK_MIN_W_PER_K, TANK_LEAK_MAX_W_PER_K,
+    CLOUD_REF_MIN_WM2, CLOUD_REF_MAX_WM2,
   },
 };

--- a/server/lib/forecast/sustain-forecast-notes.js
+++ b/server/lib/forecast/sustain-forecast-notes.js
@@ -1,0 +1,89 @@
+'use strict';
+
+// sustain-forecast-notes.js — operator-facing prose for the 48 h sustain
+// forecast. Split out of sustain-forecast.js to keep files under the
+// 600-line cap. Pure: takes a summary ctx, returns up to 3 note strings.
+
+const { helsinkiHHMM } = require('./sustain-forecast-fit-base');
+
+// Notes are ordered by operational relevance: GH min temp, tank stored
+// kWh + sustain hours, backup electric usage, solar gain. Capped at 3.
+function buildNotes(ctx) {
+  const notes = [];
+
+  if (ctx.usedDefaults) {
+    notes.push('Forecast based on default coefficients — model still warming up with limited history.');
+  }
+
+  // 1. Greenhouse minimum temperature.
+  if (ctx.ghMin !== undefined && notes.length < 3) {
+    const minDate = new Date(ctx.now + ctx.ghMinIdx * 3600 * 1000);
+    const hhmm    = helsinkiHHMM(minDate);
+    if (ctx.electricKwh > 0) {
+      notes.push(
+        'Greenhouse cools to ' + ctx.ghMin.toFixed(1) + ' °C around ' + hhmm +
+        ', when the space heater takes over to hold it there.'
+      );
+    } else {
+      notes.push(
+        'Greenhouse holds above ' + ctx.ghMin.toFixed(1) + ' °C the whole window — tank covers it without backup.'
+      );
+    }
+  }
+
+  // 2. Tank storage + sustain hours. Same tankStoredEnergyKwh formula
+  //    as the gauge tile / balance card / push notifications.
+  if (ctx.tankStoredKwhNow !== undefined && notes.length < 3) {
+    const stored = ctx.tankStoredKwhNow.toFixed(1);
+    if (ctx.hoursUntilBackupNeeded === 0) {
+      // Tank too cold for radiator OR backup already cycling — naming
+      // this "~0 h until backup" reads as broken; surface it explicitly.
+      notes.push(
+        'Tank stores ~' + stored + ' kWh above the floor, but it’s too cold ' +
+        'to drive the radiator — the space heater is providing the heating.'
+      );
+    } else if (ctx.hoursUntilBackupNeeded !== null) {
+      notes.push(
+        'Tank stores ~' + stored + ' kWh above the floor — covers greenhouse heating for about ~' +
+        Math.round(ctx.hoursUntilBackupNeeded) + ' h before the space heater kicks in.'
+      );
+    } else if (ctx.electricKwh > 0) {
+      notes.push(
+        'Tank stores ~' + stored + ' kWh above the floor; heating bridges most of the night, with ~' +
+        Math.round(ctx.electricKwh) + ' h of space-heater backup mixed in.'
+      );
+    } else {
+      notes.push(
+        'Tank stores ~' + stored + ' kWh above the floor — enough for the whole window with no backup needed.'
+      );
+    }
+  }
+
+  // 3. Backup electricity summary (cost and hours), if any.
+  if (ctx.electricKwh > 0 && notes.length < 3) {
+    const eur = ctx.electricCostEur;
+    notes.push(
+      'Space heater projected: ~' + Math.round(ctx.electricKwh) +
+      ' kWh over the next 48 h, costing about €' + eur.toFixed(2) + '.'
+    );
+  }
+
+  // 4. Solar gain context (today / tomorrow), if there's slot room.
+  if (Array.isArray(ctx.solarGainByDay) && ctx.solarGainByDay.length > 0 && notes.length < 3) {
+    const today = new Intl.DateTimeFormat('en-CA', {
+      timeZone: 'Europe/Helsinki', year: 'numeric', month: '2-digit', day: '2-digit',
+    }).format(new Date(ctx.now));
+    const parts = ctx.solarGainByDay.slice(0, 2).map(function (d) {
+      const label = d.date === today ? 'Today' : 'Tomorrow';
+      const kwh = d.kWh < 0.5 ? d.kWh.toFixed(1) : Math.round(d.kWh);
+      return label + ' ~' + kwh + ' kWh';
+    });
+    if (parts.length > 0) {
+      notes.push('Solar gain projected: ' + parts.join(', ') + '.');
+    }
+  }
+
+  return notes;
+}
+
+module.exports = { buildNotes };

--- a/server/lib/forecast/sustain-forecast.js
+++ b/server/lib/forecast/sustain-forecast.js
@@ -284,19 +284,24 @@ function computeSustainForecast(opts) {
     // sets these; the unified heat balance converts to ΔT. Idle = 0.
     let radHeatToGhW = 0;
     let heaterHeatToGhW = 0;
+    // Radiator output while the thermostat has it ON during
+    // greenhouse_heating; the substep loop cycles it bang-bang and the
+    // resulting duty scales the tank draw. 0 for every other mode.
+    let radWhenOnW = 0;
     // Components captured per-hour for forecast_predictions storage.
     let hourHeaterKwh = 0;
     let hourTankLossW = 0;
 
     if (simMode === 'greenhouse_heating') {
       modeForecast.push({ ts: hourDate, mode: simMode });
-      const radDeliveredW = Math.min(radPeakW, radUaWPerK * radDeltaT);
-      tankDeltaJ -= radDeliveredW * SECONDS_PER_HOUR;
-      radHeatToGhW = radDeliveredW;
+      // The real controller cycles the radiator to hold the greenhouse
+      // inside [geT, gxT]. The substep loop below runs that bang-bang;
+      // the tank draw is applied afterwards, scaled by the duty cycle.
+      // Projecting a full hour of constant radiator output overshot the
+      // ~1 K exit band by many K (radiator ≈ 7 K/h into GH air) and made
+      // the trajectory sawtooth instead of holding the band flat.
+      radWhenOnW = Math.min(radPeakW, radUaWPerK * radDeltaT);
       greenhouseHeatingHours += 1;
-      // hourTankLossW stays at the loop-top default 0 here — the
-      // radiator dominates the tank side and we report leakage as 0
-      // to keep components additive.
     } else if (simMode === 'emergency_heating') {
       // The real device overlays the heater on the active pump mode
       // (system.yaml overlays.emergency_heating: "the space heater is
@@ -355,14 +360,34 @@ function computeSustainForecast(opts) {
     const SUBSTEPS = 60;
     const dtH = 1 / SUBSTEPS;
     let newGhTemp = curGhTemp;
+    // Thermostatic radiator: during greenhouse_heating the controller
+    // cycles the radiator bang-bang to hold gh within [geT, gxT]. radOn
+    // tracks that switch substep-by-substep; radOnSubsteps accumulates
+    // the duty so the tank draw and component capture can be scaled.
+    let radOn = simMode === 'greenhouse_heating' && curGhTemp < cfg.greenhouseExitC;
+    let radOnSubsteps = 0;
     for (let s = 0; s < SUBSTEPS; s++) {
+      if (simMode === 'greenhouse_heating') {
+        if (newGhTemp >= cfg.greenhouseExitC) radOn = false;
+        else if (newGhTemp <= cfg.greenhouseEnterC) radOn = true;
+        if (radOn) radOnSubsteps += 1;
+      }
+      const radNowW = simMode === 'greenhouse_heating'
+        ? (radOn ? radWhenOnW : 0) : radHeatToGhW;
       const ghPassive = (outdoorC - newGhTemp) / cfg.ghTimeConstantH;
       const ghSolar   = cfg.ghSolarAlphaCPerWm2 * radiation;
       const ghVent    = newGhTemp > cfg.ghVentOpenC
         ? -(newGhTemp - cfg.ghVentOpenC) / cfg.ghVentTauH : 0;
       const ghActive  = (cfg.ghTimeConstantH > 0 && cfg.greenhouseLossWPerK > 0)
-        ? (radHeatToGhW + heaterHeatToGhW) / (cfg.ghTimeConstantH * cfg.greenhouseLossWPerK) : 0;
+        ? (radNowW + heaterHeatToGhW) / (cfg.ghTimeConstantH * cfg.greenhouseLossWPerK) : 0;
       newGhTemp += (ghPassive + ghSolar + ghVent + ghActive) * dtH;
+    }
+    // Apply the thermostatic radiator's tank draw once the duty is
+    // known. radHeatToGhW (0 until here for greenhouse_heating) carries
+    // the duty-averaged output into the per-hour component capture.
+    if (simMode === 'greenhouse_heating') {
+      radHeatToGhW = radWhenOnW * (radOnSubsteps / SUBSTEPS);
+      tankDeltaJ -= radHeatToGhW * SECONDS_PER_HOUR;
     }
 
     // ── 3. Solar charging credit ──

--- a/server/lib/forecast/sustain-forecast.js
+++ b/server/lib/forecast/sustain-forecast.js
@@ -82,6 +82,15 @@ const DEFAULT_CONFIG = {
   weatherFetchedAt:         null,
   // Number of buckets used for the empirical fit (for confidence)
   fitBucketCount:           0,
+  // Tank destratification. The step-4 solar skew (60/40 top/bottom) and
+  // any other per-layer asymmetry would let the top/bottom split grow
+  // without bound across a 48 h sim. Real tanks mix (conduction +
+  // convection + pump circulation): observed tank_top − tank_bottom
+  // stays ~1.5 K (14 d median 1.3, p90 3.4) and relaxes within hours.
+  // Each sim hour the spread decays exponentially toward tankStratEqC
+  // with time constant tankMixTauH. Set tankMixTauH ≤ 0 to disable.
+  tankMixTauH:              2.0,
+  tankStratEqC:             1.5,
 };
 
 /**
@@ -391,6 +400,20 @@ function computeSustainForecast(opts) {
     } else {
       tankTopC += tankAvgDeltaC;
       tankBotC += tankAvgDeltaC;
+    }
+
+    // ── 4b. Destratification ──
+    // Conduction + convective mixing pull the top/bottom split back
+    // toward a small equilibrium. Without this the step-4 solar skew
+    // accumulates unboundedly — the 48 h projection drifts the top
+    // several K too hot and the bottom several K too cold even though
+    // the average stays accurate. Conserves the tank average.
+    if (cfg.tankMixTauH > 0) {
+      const stratAvg    = (tankTopC + tankBotC) / 2;
+      const stratDecay  = Math.exp(-1 / cfg.tankMixTauH);
+      const stratSpread = cfg.tankStratEqC + ((tankTopC - tankBotC) - cfg.tankStratEqC) * stratDecay;
+      tankTopC = stratAvg + stratSpread / 2;
+      tankBotC = stratAvg - stratSpread / 2;
     }
 
     // ── 5. Greenhouse temperature update ──

--- a/server/lib/forecast/sustain-forecast.js
+++ b/server/lib/forecast/sustain-forecast.js
@@ -48,10 +48,13 @@ const DEFAULT_CONFIG = {
   emergencyExitC:           12,
   spaceHeaterKw:            1,    // from system.yaml space_heater.assumed_continuous_power_kw
   transferFeeCKwh:          5,    // from system.yaml electricity.transfer_fee_c_kwh
-  // Reference FMI RadiationGlobal that maps to "cloudFactor = 1" in the data-
-  // driven solar gain model. ~500 W/m² is a typical partly-cloudy noon at lat
-  // 60° in May (clear sky peaks ~700-900). The historical solarGainKwhByHour
-  // baseline is normalised against this reference.
+  // Reference FMI RadiationGlobal that maps to "cloudFactor = 1" in the
+  // data-driven solar gain model. For an unbiased credit this must equal
+  // the average radiation over the same charging hours that produced the
+  // solarGainKwhByHour baseline — sustain-forecast-fit emits a fitted
+  // cloudReferenceWm2 (gain-weighted mean) that overrides this. The 500
+  // here is only a cold-start seed before the fit converges; it ran ~23 %
+  // low against real data and over-credited solar gain accordingly.
   cloudReferenceWm2:        500,
   // Tank stops charging around this temperature in the real controller.
   tankMaxC:                 55,
@@ -146,6 +149,7 @@ function computeSustainForecast(opts) {
   applyCoeffOverride(cfg, coeff, 'ghSolarAlphaCPerWm2', v => v >= 0);
   applyCoeffOverride(cfg, coeff, 'ghVentOpenC',         v => v > 0);
   applyCoeffOverride(cfg, coeff, 'ghVentTauH',          v => v > 0);
+  applyCoeffOverride(cfg, coeff, 'cloudReferenceWm2',   v => v > 0);
 
   const tankLeakageWPerK    = typeof coeff.tankLeakageWPerK    === 'number' ? coeff.tankLeakageWPerK    : DEFAULT_TANK_LEAKAGE_W_PER_K;
   // Observed tank-drop rate during the most recent ~hour, in K/h (positive

--- a/server/lib/forecast/sustain-forecast.js
+++ b/server/lib/forecast/sustain-forecast.js
@@ -15,10 +15,10 @@
 //                            weather48h, prices48h, coefficients, config }) → forecast
 
 const fit = require('./sustain-forecast-fit');
+const { buildNotes } = require('./sustain-forecast-notes');
 const { tankStoredEnergyKwh } = require('../energy-balance');
 const TANK_THERMAL_MASS_J_PER_K = fit.TANK_THERMAL_MASS_J_PER_K;
 const helsinkiHour  = fit.helsinkiHour;
-const helsinkiHHMM  = fit.helsinkiHHMM;
 const fitEmpiricalCoefficients = fit.fitEmpiricalCoefficients;
 
 // Engine fallback: used only when a caller passes a coefficients object
@@ -551,86 +551,6 @@ function computeSustainForecast(opts) {
     modelConfidence:        confidence,
     notes,
   };
-}
-
-// Notes are ordered by operational relevance: GH min temp, tank stored
-// kWh + sustain hours, backup electric usage, solar gain. Capped at 3.
-function buildNotes(ctx) {
-  const notes = [];
-
-  if (ctx.usedDefaults) {
-    notes.push('Forecast based on default coefficients — model still warming up with limited history.');
-  }
-
-  // 1. Greenhouse minimum temperature.
-  if (ctx.ghMin !== undefined && notes.length < 3) {
-    const minDate = new Date(ctx.now + ctx.ghMinIdx * 3600 * 1000);
-    const hhmm    = helsinkiHHMM(minDate);
-    if (ctx.electricKwh > 0) {
-      notes.push(
-        'Greenhouse cools to ' + ctx.ghMin.toFixed(1) + ' °C around ' + hhmm +
-        ', when the space heater takes over to hold it there.'
-      );
-    } else {
-      notes.push(
-        'Greenhouse holds above ' + ctx.ghMin.toFixed(1) + ' °C the whole window — tank covers it without backup.'
-      );
-    }
-  }
-
-  // 2. Tank storage + sustain hours. Same tankStoredEnergyKwh formula
-  //    as the gauge tile / balance card / push notifications.
-  if (ctx.tankStoredKwhNow !== undefined && notes.length < 3) {
-    const stored = ctx.tankStoredKwhNow.toFixed(1);
-    if (ctx.hoursUntilBackupNeeded === 0) {
-      // Tank too cold for radiator OR backup already cycling — naming
-      // this "~0 h until backup" reads as broken; surface it explicitly.
-      notes.push(
-        'Tank stores ~' + stored + ' kWh above the floor, but it’s too cold ' +
-        'to drive the radiator — the space heater is providing the heating.'
-      );
-    } else if (ctx.hoursUntilBackupNeeded !== null) {
-      notes.push(
-        'Tank stores ~' + stored + ' kWh above the floor — covers greenhouse heating for about ~' +
-        Math.round(ctx.hoursUntilBackupNeeded) + ' h before the space heater kicks in.'
-      );
-    } else if (ctx.electricKwh > 0) {
-      notes.push(
-        'Tank stores ~' + stored + ' kWh above the floor; heating bridges most of the night, with ~' +
-        Math.round(ctx.electricKwh) + ' h of space-heater backup mixed in.'
-      );
-    } else {
-      notes.push(
-        'Tank stores ~' + stored + ' kWh above the floor — enough for the whole window with no backup needed.'
-      );
-    }
-  }
-
-  // 3. Backup electricity summary (cost and hours), if any.
-  if (ctx.electricKwh > 0 && notes.length < 3) {
-    const eur = ctx.electricCostEur;
-    notes.push(
-      'Space heater projected: ~' + Math.round(ctx.electricKwh) +
-      ' kWh over the next 48 h, costing about €' + eur.toFixed(2) + '.'
-    );
-  }
-
-  // 4. Solar gain context (today / tomorrow), if there's slot room.
-  if (Array.isArray(ctx.solarGainByDay) && ctx.solarGainByDay.length > 0 && notes.length < 3) {
-    const today = new Intl.DateTimeFormat('en-CA', {
-      timeZone: 'Europe/Helsinki', year: 'numeric', month: '2-digit', day: '2-digit',
-    }).format(new Date(ctx.now));
-    const parts = ctx.solarGainByDay.slice(0, 2).map(function (d) {
-      const label = d.date === today ? 'Today' : 'Tomorrow';
-      const kwh = d.kWh < 0.5 ? d.kWh.toFixed(1) : Math.round(d.kWh);
-      return label + ' ~' + kwh + ' kWh';
-    });
-    if (parts.length > 0) {
-      notes.push('Solar gain projected: ' + parts.join(', ') + '.');
-    }
-  }
-
-  return notes;
 }
 
 function round2(v) { return Math.round(v * 100) / 100; }

--- a/tests/sustain-forecast-tuning.test.js
+++ b/tests/sustain-forecast-tuning.test.js
@@ -1,0 +1,134 @@
+'use strict';
+
+// Accuracy-tuning regression tests for the sustain-forecast engine:
+// tank destratification, the greenhouse-heating thermostat, and the
+// self-calibrating solar cloud reference. Split from
+// sustain-forecast.test.js to keep both files under the file-size cap.
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  fitEmpiricalCoefficients,
+  computeSustainForecast,
+} = require('../server/lib/forecast/sustain-forecast.js');
+const { fitCloudReferenceWm2 } = require('../server/lib/forecast/sustain-forecast-fit.js');
+
+function makeWeather48h(overrides) {
+  return Array.from({ length: 48 }, (_, i) => ({
+    ts: new Date(Date.now() + i * 3600 * 1000).toISOString(),
+    temperature:     overrides && overrides.temperature     !== undefined ? overrides.temperature     : 0,
+    radiationGlobal: overrides && overrides.radiationGlobal !== undefined ? overrides.radiationGlobal : 0,
+    windSpeed:       overrides && overrides.windSpeed       !== undefined ? overrides.windSpeed       : 0,
+  }));
+}
+
+function makePrices48h(priceCKwh) {
+  const price = typeof priceCKwh === 'number' ? priceCKwh : 10;
+  return Array.from({ length: 48 }, (_, i) => ({
+    ts:        new Date(Date.now() + i * 3600 * 1000).toISOString(),
+    priceCKwh: price,
+  }));
+}
+
+// ── Tank destratification ──
+// The step-4 solar skew (60/40 top/bottom) and any other per-layer
+// asymmetry would otherwise let the tank top/bottom split grow without
+// bound over a 48 h sim. Real tanks mix: observed tank_top − tank_bottom
+// stays ~1.5 K (14 d median 1.3, p90 3.4) and relaxes within hours.
+describe('computeSustainForecast — tank destratification', () => {
+  const baseOpts = {
+    now: Date.UTC(2026, 4, 18, 18, 0, 0),
+    tankTop: 60, tankBottom: 20, greenhouseTemp: 12, currentMode: 'idle',
+    weather48h: makeWeather48h({ temperature: 5 }),
+    prices48h: makePrices48h(),
+    coefficients: { tankLeakageWPerK: 3, usedDefaults: false },
+  };
+
+  it('relaxes an extreme top/bottom spread toward equilibrium within hours', () => {
+    const result = computeSustainForecast(baseOpts);
+    const traj = result.tankTrajectory;
+    assert.ok((traj[0].top - traj[0].bottom) > 30, 'starts strongly stratified');
+    assert.ok((traj[6].top - traj[6].bottom) < 6,
+      'spread relaxes within 6 h; got ' + (traj[6].top - traj[6].bottom));
+  });
+
+  it('conserves the tank average — mixing only moves heat between layers', () => {
+    const withMix = computeSustainForecast(baseOpts);
+    const noMix   = computeSustainForecast(Object.assign({}, baseOpts, {
+      config: { tankMixTauH: 0 },
+    }));
+    for (let i = 0; i < withMix.tankTrajectory.length; i++) {
+      assert.ok(Math.abs(withMix.tankTrajectory[i].avg - noMix.tankTrajectory[i].avg) < 1e-6,
+        'avg identical with/without mixing at h=' + i);
+    }
+    // tankMixTauH:0 disables destratification — spread stays wide.
+    assert.ok((noMix.tankTrajectory[6].top - noMix.tankTrajectory[6].bottom) > 30,
+      'disabled mixing keeps the spread');
+  });
+});
+
+// ── Greenhouse heating thermostat ──
+// The real controller cycles the radiator bang-bang to hold the
+// greenhouse inside [geT, gxT]. Projecting a full hour of constant
+// radiator output overshoots the ~1 K exit band by many K and makes
+// the trajectory sawtooth instead of holding the band flat.
+describe('computeSustainForecast — greenhouse heating holds the band', () => {
+  it('does not overshoot the exit threshold during sustained radiator heating', () => {
+    const result = computeSustainForecast({
+      now: Date.UTC(2026, 4, 18, 18, 0, 0),
+      tankTop: 55, tankBottom: 50, greenhouseTemp: 12.5,
+      currentMode: 'greenhouse_heating',
+      weather48h: makeWeather48h({ temperature: 2 }),
+      prices48h: makePrices48h(),
+      coefficients: { tankLeakageWPerK: 3, radiatorUaWPerK: 120, usedDefaults: false },
+      config: { greenhouseEnterC: 13, greenhouseExitC: 14,
+        emergencyEnterC: 9, emergencyExitC: 12 },
+    });
+    const peak = Math.max.apply(null, result.greenhouseTrajectory.map(p => p.temp));
+    // A full hour of unthrottled radiator output blows past 18 °C; the
+    // thermostat must cap the greenhouse close to the 14 °C exit point.
+    assert.ok(peak < 15.5, 'greenhouse held near the band; peak=' + peak);
+  });
+});
+
+// ── Self-calibrating cloud reference ──
+// The solar credit is solarGainKwhByHour × radiation / cloudReferenceWm2.
+// The reference must match the radiation the baseline was built from, or
+// the credit is biased. The fit emits a gain-weighted mean and the engine
+// honours it over the seed default.
+describe('computeSustainForecast — fitted cloud reference', () => {
+  it('fitCloudReferenceWm2 emits the gain-weighted charging radiation', () => {
+    const base = Date.UTC(2026, 4, 1, 9, 0, 0);
+    const readings = [];
+    for (let i = 0; i < 8; i++) {
+      readings.push({ ts: new Date(base + i * 10 * 60000),
+        tankTop: 30 + i, tankBottom: 28 + i, greenhouse: 14, outdoor: 8,
+        radiationGlobal: 600 });
+    }
+    const history = { readings, modes: [{ ts: new Date(base - 60000), mode: 'solar_charging' }] };
+    assert.equal(Math.round(fitCloudReferenceWm2(history)), 600);
+    assert.equal(Math.round(fitEmpiricalCoefficients(history).cloudReferenceWm2), 600);
+  });
+
+  it('returns null when there are no charging hours to measure', () => {
+    assert.equal(fitCloudReferenceWm2({ readings: [], modes: [] }), null);
+  });
+
+  it('a higher coefficient cloudReferenceWm2 credits less solar gain', () => {
+    const base = {
+      now: Date.UTC(2026, 4, 18, 9, 0, 0),
+      tankTop: 30, tankBottom: 28, greenhouseTemp: 15, currentMode: 'idle',
+      weather48h: makeWeather48h({ temperature: 10, radiationGlobal: 600 }),
+      prices48h: makePrices48h(),
+    };
+    const sg = new Array(24).fill(0.4);
+    const lowRef  = computeSustainForecast(Object.assign({}, base, {
+      coefficients: { tankLeakageWPerK: 3, solarGainKwhByHour: sg, cloudReferenceWm2: 400 } }));
+    const highRef = computeSustainForecast(Object.assign({}, base, {
+      coefficients: { tankLeakageWPerK: 3, solarGainKwhByHour: sg, cloudReferenceWm2: 800 } }));
+    const lowEnd  = lowRef.tankTrajectory[12].avg;
+    const highEnd = highRef.tankTrajectory[12].avg;
+    assert.ok(lowEnd > highEnd + 2,
+      'lower cloud reference credits more solar: low=' + lowEnd + ' high=' + highEnd);
+  });
+});

--- a/tests/sustain-forecast.test.js
+++ b/tests/sustain-forecast.test.js
@@ -7,7 +7,7 @@ const {
   computeSustainForecast,
   _TANK_THERMAL_MASS_J_PER_K,
 } = require('../server/lib/forecast/sustain-forecast.js');
-const { fitSolarGainByHour, fitGreenhouseLossWPerK, fitCloudReferenceWm2 } = require('../server/lib/forecast/sustain-forecast-fit.js');
+const { fitSolarGainByHour, fitGreenhouseLossWPerK } = require('../server/lib/forecast/sustain-forecast-fit.js');
 
 // ── Helpers ──
 
@@ -1195,108 +1195,5 @@ describe('coefficient sanity gates', () => {
     }));
     assert.ok(low.electricKwh > high.electricKwh,
       'low UA should project more heater: low=' + low.electricKwh + ' high=' + high.electricKwh);
-  });
-});
-
-// ── Tank destratification ──
-// The step-4 solar skew (60/40 top/bottom) and any other per-layer
-// asymmetry would otherwise let the tank top/bottom split grow without
-// bound over a 48 h sim. Real tanks mix: observed tank_top − tank_bottom
-// stays ~1.5 K (14 d median 1.3, p90 3.4) and relaxes within hours.
-describe('computeSustainForecast — tank destratification', () => {
-  const baseOpts = {
-    now: Date.UTC(2026, 4, 18, 18, 0, 0),
-    tankTop: 60, tankBottom: 20, greenhouseTemp: 12, currentMode: 'idle',
-    weather48h: makeWeather48h({ temperature: 5 }),
-    prices48h: makePrices48h(),
-    coefficients: { tankLeakageWPerK: 3, usedDefaults: false },
-  };
-
-  it('relaxes an extreme top/bottom spread toward equilibrium within hours', () => {
-    const result = computeSustainForecast(baseOpts);
-    const traj = result.tankTrajectory;
-    assert.ok((traj[0].top - traj[0].bottom) > 30, 'starts strongly stratified');
-    assert.ok((traj[6].top - traj[6].bottom) < 6,
-      'spread relaxes within 6 h; got ' + (traj[6].top - traj[6].bottom));
-  });
-
-  it('conserves the tank average — mixing only moves heat between layers', () => {
-    const withMix = computeSustainForecast(baseOpts);
-    const noMix   = computeSustainForecast(Object.assign({}, baseOpts, {
-      config: { tankMixTauH: 0 },
-    }));
-    for (let i = 0; i < withMix.tankTrajectory.length; i++) {
-      assert.ok(Math.abs(withMix.tankTrajectory[i].avg - noMix.tankTrajectory[i].avg) < 1e-6,
-        'avg identical with/without mixing at h=' + i);
-    }
-    // tankMixTauH:0 disables destratification — spread stays wide.
-    assert.ok((noMix.tankTrajectory[6].top - noMix.tankTrajectory[6].bottom) > 30,
-      'disabled mixing keeps the spread');
-  });
-});
-
-// ── Greenhouse heating thermostat ──
-// The real controller cycles the radiator bang-bang to hold the
-// greenhouse inside [geT, gxT]. Projecting a full hour of constant
-// radiator output overshoots the ~1 K exit band by many K and makes
-// the trajectory sawtooth instead of holding the band flat.
-describe('computeSustainForecast — greenhouse heating holds the band', () => {
-  it('does not overshoot the exit threshold during sustained radiator heating', () => {
-    const result = computeSustainForecast({
-      now: Date.UTC(2026, 4, 18, 18, 0, 0),
-      tankTop: 55, tankBottom: 50, greenhouseTemp: 12.5,
-      currentMode: 'greenhouse_heating',
-      weather48h: makeWeather48h({ temperature: 2 }),
-      prices48h: makePrices48h(),
-      coefficients: { tankLeakageWPerK: 3, radiatorUaWPerK: 120, usedDefaults: false },
-      config: { greenhouseEnterC: 13, greenhouseExitC: 14,
-        emergencyEnterC: 9, emergencyExitC: 12 },
-    });
-    const peak = Math.max.apply(null, result.greenhouseTrajectory.map(p => p.temp));
-    // A full hour of unthrottled radiator output blows past 18 °C; the
-    // thermostat must cap the greenhouse close to the 14 °C exit point.
-    assert.ok(peak < 15.5, 'greenhouse held near the band; peak=' + peak);
-  });
-});
-
-// ── Self-calibrating cloud reference ──
-// The solar credit is solarGainKwhByHour × radiation / cloudReferenceWm2.
-// The reference must match the radiation the baseline was built from, or
-// the credit is biased. The fit emits a gain-weighted mean and the engine
-// honours it over the seed default.
-describe('computeSustainForecast — fitted cloud reference', () => {
-  it('fitCloudReferenceWm2 emits the gain-weighted charging radiation', () => {
-    const base = Date.UTC(2026, 4, 1, 9, 0, 0);
-    const readings = [];
-    for (let i = 0; i < 8; i++) {
-      readings.push({ ts: new Date(base + i * 10 * 60000),
-        tankTop: 30 + i, tankBottom: 28 + i, greenhouse: 14, outdoor: 8,
-        radiationGlobal: 600 });
-    }
-    const history = { readings, modes: [{ ts: new Date(base - 60000), mode: 'solar_charging' }] };
-    assert.equal(Math.round(fitCloudReferenceWm2(history)), 600);
-    assert.equal(Math.round(fitEmpiricalCoefficients(history).cloudReferenceWm2), 600);
-  });
-
-  it('returns null when there are no charging hours to measure', () => {
-    assert.equal(fitCloudReferenceWm2({ readings: [], modes: [] }), null);
-  });
-
-  it('a higher coefficient cloudReferenceWm2 credits less solar gain', () => {
-    const base = {
-      now: Date.UTC(2026, 4, 18, 9, 0, 0),
-      tankTop: 30, tankBottom: 28, greenhouseTemp: 15, currentMode: 'idle',
-      weather48h: makeWeather48h({ temperature: 10, radiationGlobal: 600 }),
-      prices48h: makePrices48h(),
-    };
-    const sg = new Array(24).fill(0.4);
-    const lowRef  = computeSustainForecast(Object.assign({}, base, {
-      coefficients: { tankLeakageWPerK: 3, solarGainKwhByHour: sg, cloudReferenceWm2: 400 } }));
-    const highRef = computeSustainForecast(Object.assign({}, base, {
-      coefficients: { tankLeakageWPerK: 3, solarGainKwhByHour: sg, cloudReferenceWm2: 800 } }));
-    const lowEnd  = lowRef.tankTrajectory[12].avg;
-    const highEnd = highRef.tankTrajectory[12].avg;
-    assert.ok(lowEnd > highEnd + 2,
-      'lower cloud reference credits more solar: low=' + lowEnd + ' high=' + highEnd);
   });
 });

--- a/tests/sustain-forecast.test.js
+++ b/tests/sustain-forecast.test.js
@@ -1234,3 +1234,27 @@ describe('computeSustainForecast — tank destratification', () => {
       'disabled mixing keeps the spread');
   });
 });
+
+// ── Greenhouse heating thermostat ──
+// The real controller cycles the radiator bang-bang to hold the
+// greenhouse inside [geT, gxT]. Projecting a full hour of constant
+// radiator output overshoots the ~1 K exit band by many K and makes
+// the trajectory sawtooth instead of holding the band flat.
+describe('computeSustainForecast — greenhouse heating holds the band', () => {
+  it('does not overshoot the exit threshold during sustained radiator heating', () => {
+    const result = computeSustainForecast({
+      now: Date.UTC(2026, 4, 18, 18, 0, 0),
+      tankTop: 55, tankBottom: 50, greenhouseTemp: 12.5,
+      currentMode: 'greenhouse_heating',
+      weather48h: makeWeather48h({ temperature: 2 }),
+      prices48h: makePrices48h(),
+      coefficients: { tankLeakageWPerK: 3, radiatorUaWPerK: 120, usedDefaults: false },
+      config: { greenhouseEnterC: 13, greenhouseExitC: 14,
+        emergencyEnterC: 9, emergencyExitC: 12 },
+    });
+    const peak = Math.max.apply(null, result.greenhouseTrajectory.map(p => p.temp));
+    // A full hour of unthrottled radiator output blows past 18 °C; the
+    // thermostat must cap the greenhouse close to the 14 °C exit point.
+    assert.ok(peak < 15.5, 'greenhouse held near the band; peak=' + peak);
+  });
+});

--- a/tests/sustain-forecast.test.js
+++ b/tests/sustain-forecast.test.js
@@ -7,7 +7,7 @@ const {
   computeSustainForecast,
   _TANK_THERMAL_MASS_J_PER_K,
 } = require('../server/lib/forecast/sustain-forecast.js');
-const { fitSolarGainByHour, fitGreenhouseLossWPerK } = require('../server/lib/forecast/sustain-forecast-fit.js');
+const { fitSolarGainByHour, fitGreenhouseLossWPerK, fitCloudReferenceWm2 } = require('../server/lib/forecast/sustain-forecast-fit.js');
 
 // ── Helpers ──
 
@@ -1256,5 +1256,47 @@ describe('computeSustainForecast — greenhouse heating holds the band', () => {
     // A full hour of unthrottled radiator output blows past 18 °C; the
     // thermostat must cap the greenhouse close to the 14 °C exit point.
     assert.ok(peak < 15.5, 'greenhouse held near the band; peak=' + peak);
+  });
+});
+
+// ── Self-calibrating cloud reference ──
+// The solar credit is solarGainKwhByHour × radiation / cloudReferenceWm2.
+// The reference must match the radiation the baseline was built from, or
+// the credit is biased. The fit emits a gain-weighted mean and the engine
+// honours it over the seed default.
+describe('computeSustainForecast — fitted cloud reference', () => {
+  it('fitCloudReferenceWm2 emits the gain-weighted charging radiation', () => {
+    const base = Date.UTC(2026, 4, 1, 9, 0, 0);
+    const readings = [];
+    for (let i = 0; i < 8; i++) {
+      readings.push({ ts: new Date(base + i * 10 * 60000),
+        tankTop: 30 + i, tankBottom: 28 + i, greenhouse: 14, outdoor: 8,
+        radiationGlobal: 600 });
+    }
+    const history = { readings, modes: [{ ts: new Date(base - 60000), mode: 'solar_charging' }] };
+    assert.equal(Math.round(fitCloudReferenceWm2(history)), 600);
+    assert.equal(Math.round(fitEmpiricalCoefficients(history).cloudReferenceWm2), 600);
+  });
+
+  it('returns null when there are no charging hours to measure', () => {
+    assert.equal(fitCloudReferenceWm2({ readings: [], modes: [] }), null);
+  });
+
+  it('a higher coefficient cloudReferenceWm2 credits less solar gain', () => {
+    const base = {
+      now: Date.UTC(2026, 4, 18, 9, 0, 0),
+      tankTop: 30, tankBottom: 28, greenhouseTemp: 15, currentMode: 'idle',
+      weather48h: makeWeather48h({ temperature: 10, radiationGlobal: 600 }),
+      prices48h: makePrices48h(),
+    };
+    const sg = new Array(24).fill(0.4);
+    const lowRef  = computeSustainForecast(Object.assign({}, base, {
+      coefficients: { tankLeakageWPerK: 3, solarGainKwhByHour: sg, cloudReferenceWm2: 400 } }));
+    const highRef = computeSustainForecast(Object.assign({}, base, {
+      coefficients: { tankLeakageWPerK: 3, solarGainKwhByHour: sg, cloudReferenceWm2: 800 } }));
+    const lowEnd  = lowRef.tankTrajectory[12].avg;
+    const highEnd = highRef.tankTrajectory[12].avg;
+    assert.ok(lowEnd > highEnd + 2,
+      'lower cloud reference credits more solar: low=' + lowEnd + ' high=' + highEnd);
   });
 });

--- a/tests/sustain-forecast.test.js
+++ b/tests/sustain-forecast.test.js
@@ -1197,3 +1197,40 @@ describe('coefficient sanity gates', () => {
       'low UA should project more heater: low=' + low.electricKwh + ' high=' + high.electricKwh);
   });
 });
+
+// ── Tank destratification ──
+// The step-4 solar skew (60/40 top/bottom) and any other per-layer
+// asymmetry would otherwise let the tank top/bottom split grow without
+// bound over a 48 h sim. Real tanks mix: observed tank_top − tank_bottom
+// stays ~1.5 K (14 d median 1.3, p90 3.4) and relaxes within hours.
+describe('computeSustainForecast — tank destratification', () => {
+  const baseOpts = {
+    now: Date.UTC(2026, 4, 18, 18, 0, 0),
+    tankTop: 60, tankBottom: 20, greenhouseTemp: 12, currentMode: 'idle',
+    weather48h: makeWeather48h({ temperature: 5 }),
+    prices48h: makePrices48h(),
+    coefficients: { tankLeakageWPerK: 3, usedDefaults: false },
+  };
+
+  it('relaxes an extreme top/bottom spread toward equilibrium within hours', () => {
+    const result = computeSustainForecast(baseOpts);
+    const traj = result.tankTrajectory;
+    assert.ok((traj[0].top - traj[0].bottom) > 30, 'starts strongly stratified');
+    assert.ok((traj[6].top - traj[6].bottom) < 6,
+      'spread relaxes within 6 h; got ' + (traj[6].top - traj[6].bottom));
+  });
+
+  it('conserves the tank average — mixing only moves heat between layers', () => {
+    const withMix = computeSustainForecast(baseOpts);
+    const noMix   = computeSustainForecast(Object.assign({}, baseOpts, {
+      config: { tankMixTauH: 0 },
+    }));
+    for (let i = 0; i < withMix.tankTrajectory.length; i++) {
+      assert.ok(Math.abs(withMix.tankTrajectory[i].avg - noMix.tankTrajectory[i].avg) < 1e-6,
+        'avg identical with/without mixing at h=' + i);
+    }
+    // tankMixTauH:0 disables destratification — spread stays wide.
+    assert.ok((noMix.tankTrajectory[6].top - noMix.tankTrajectory[6].bottom) > 30,
+      'disabled mixing keeps the spread');
+  });
+});


### PR DESCRIPTION
## Summary

Three validated accuracy fixes to the 48 h sustain-forecast engine, each
diagnosed and verified with a walk-forward backtest over 14 days of real
sensor readings (112 forecast origins, ~5000 scored hourly predictions,
actual FMI weather so model error is isolated from weather-forecast error).

1. **Tank destratification** — the engine split solar gains 60/40
   top/bottom with no mechanism to ever narrow the spread, so the
   top/bottom split grew unbounded over a 48 h projection. Added an
   exponential relaxation toward a small equilibrium (matching observed
   behaviour: 14 d median spread 1.3 K, p90 3.4 K, relaxes within hours).

2. **Greenhouse-heating thermostat** — the heating mode was decided once
   per simulated hour and ran the radiator at constant full power for the
   whole hour (~7 K into the greenhouse air vs a ~1 K hysteresis band),
   overshooting to ~18 °C and sawtoothing. The radiator now cycles
   bang-bang inside the substep loop and the tank draw is duty-scaled.

3. **Self-calibrating cloud reference** — the solar credit divides by a
   hand-picked 500 W/m², but the fitted gain baseline comes from charging
   hours whose gain-weighted mean radiation is ~615 W/m², over-crediting
   solar by ~23 %. The fit now emits `cloudReferenceWm2` so the credit
   stays unbiased as the baseline shifts with the season.

A fourth commit splits the touched files (`sustain-forecast.js`,
`sustain-forecast-fit.js`, the test file) to stay under the file-size
caps — behaviour-preserving, backtest output bit-identical.

### Backtest result (MAE vs real readings, all horizons)

| Metric | Before | After |
|---|---|---|
| Tank top | 5.25 °C | **2.30 °C** |
| Tank bottom | 3.90 °C | **2.26 °C** |
| Tank average | 2.10 °C | 2.25 °C |
| Greenhouse | 3.10 °C | 2.90 °C |
| Mode-projection accuracy | ~56 % | **~65 %** |

Tank-top/bottom errors more than halve. Tank-average MAE rises slightly
because the heating fix removes an over-drain that was masking a residual
emergency-mode cooling bias — an honest number now, and the next thing to
chase (see "Follow-ups").

### Follow-ups (not in this PR)

- Emergency-heating drains the tank too fast (residual −0.6 °C avg bias).
- Daytime greenhouse solar warming is under-predicted (day MAE ~4 °C); a
  single linear `α·radiation` term can't capture the vent-capped peak.

## Test plan

- [x] `npm run test:unit` — 1216 pass
- [x] forecast suite — 128 tests, new regression tests for all three fixes
- [x] `npx playwright test` — 328 pass
- [x] lint / knip / file-size (strict) / assets — all clean
- [x] walk-forward backtest against 14 d of real readings

https://claude.ai/code/session_01VxsuAEQTPuwi7sTXkjtiQE

---
_Generated by [Claude Code](https://claude.ai/code/session_01VxsuAEQTPuwi7sTXkjtiQE)_