### PR TITLE
Forecast preview in the device Tuning thresholds view

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -668,11 +668,10 @@
           <div style="margin-top:8px;"><button type="button" id="dc-tuning-reset" class="link-btn" style="background:none;border:0;color:var(--secondary);cursor:pointer;font-size:12px;padding:0;">Reset all to firmware defaults</button></div>
 
           <h4 style="margin:24px 0 4px;font-family:'Newsreader',Georgia,serif;font-style:italic;color:var(--on-surface);">Forecast preview</h4>
-          <p style="font-size:12px;color:var(--on-surface-variant);margin:0 0 12px;">Simulated 24-hour projection from the latest live sensor readings. <strong>Solid</strong> lines use the values entered above; <strong>dashed</strong> lines use the values currently saved on the controller &mdash; so you can see what a threshold change does before pushing it. Assumes all actuators enabled.</p>
+          <p style="font-size:12px;color:var(--on-surface-variant);margin:0 0 12px;">48-hour projection from the forecast engine &mdash; live FMI weather and the fitted thermal model. <strong>Solid</strong> lines recompute the forecast with the values entered above; <strong>dashed</strong> lines are the live forecast (values currently saved on the controller), so you can see what a threshold change does before pushing it.</p>
           <canvas id="tuning-forecast-chart" style="width:100%;height:220px;display:block;"></canvas>
           <div id="tuning-forecast-legend" style="display:flex;flex-wrap:wrap;gap:12px;margin-top:8px;font-size:11px;color:var(--on-surface-variant);">
             <span><span style="display:inline-block;width:10px;height:10px;border-radius:2px;background:#e9c349;vertical-align:middle;margin-right:4px;"></span>Tank avg</span>
-            <span><span style="display:inline-block;width:10px;height:10px;border-radius:2px;background:#ef5350;vertical-align:middle;margin-right:4px;"></span>Collector</span>
             <span><span style="display:inline-block;width:10px;height:10px;border-radius:2px;background:#69d0c5;vertical-align:middle;margin-right:4px;"></span>Greenhouse</span>
             <span><span style="display:inline-block;width:10px;height:10px;border-radius:2px;background:#42a5f5;vertical-align:middle;margin-right:4px;"></span>Outdoor</span>
           </div>

--- a/playground/index.html
+++ b/playground/index.html
@@ -667,6 +667,17 @@
           <div id="dc-tuning-list"></div>
           <div style="margin-top:8px;"><button type="button" id="dc-tuning-reset" class="link-btn" style="background:none;border:0;color:var(--secondary);cursor:pointer;font-size:12px;padding:0;">Reset all to firmware defaults</button></div>
 
+          <h4 style="margin:24px 0 4px;font-family:'Newsreader',Georgia,serif;font-style:italic;color:var(--on-surface);">Forecast preview</h4>
+          <p style="font-size:12px;color:var(--on-surface-variant);margin:0 0 12px;">Simulated 24-hour projection from the latest live sensor readings. <strong>Solid</strong> lines use the values entered above; <strong>dashed</strong> lines use the values currently saved on the controller &mdash; so you can see what a threshold change does before pushing it. Assumes all actuators enabled.</p>
+          <canvas id="tuning-forecast-chart" style="width:100%;height:220px;display:block;"></canvas>
+          <div id="tuning-forecast-legend" style="display:flex;flex-wrap:wrap;gap:12px;margin-top:8px;font-size:11px;color:var(--on-surface-variant);">
+            <span><span style="display:inline-block;width:10px;height:10px;border-radius:2px;background:#e9c349;vertical-align:middle;margin-right:4px;"></span>Tank avg</span>
+            <span><span style="display:inline-block;width:10px;height:10px;border-radius:2px;background:#ef5350;vertical-align:middle;margin-right:4px;"></span>Collector</span>
+            <span><span style="display:inline-block;width:10px;height:10px;border-radius:2px;background:#69d0c5;vertical-align:middle;margin-right:4px;"></span>Greenhouse</span>
+            <span><span style="display:inline-block;width:10px;height:10px;border-radius:2px;background:#42a5f5;vertical-align:middle;margin-right:4px;"></span>Outdoor</span>
+          </div>
+          <div id="tuning-forecast-status" style="font-size:11px;color:var(--on-surface-variant);margin-top:6px;"></div>
+
           <div style="margin-top:24px;display:flex;gap:12px;align-items:center;">
             <button class="primary" id="dc-save">Save &amp; Push to Device</button>
             <span id="dc-status" style="font-size:13px;color:var(--on-surface-variant);"></span>

--- a/playground/js/control.js
+++ b/playground/js/control.js
@@ -27,8 +27,13 @@ export async function initControlLogic() {
 }
 
 export class ControlStateMachine {
-  constructor(modesConfig) {
+  constructor(modesConfig, deviceConfig) {
     this.modes = modesConfig;      // system.yaml modes (for valve display names)
+    // Optional device-config object ({ ce, ea, tu, ... }) forwarded to
+    // the control logic as its third `deviceConfig` argument. Null for
+    // the live simulator (no tuning); the Tuning-thresholds forecast
+    // preview passes a config with a `tu` overlay.
+    this.deviceConfig = deviceConfig || null;
     this.currentMode = 'idle';
     this.modeStartTime = 0;
     this.collectorsDrained = false;
@@ -87,7 +92,7 @@ export class ControlStateMachine {
     const prevPeak = this.solarChargePeakTankAvg;
 
     // Delegate decision to the real Shelly control logic
-    const result = _evaluate(shellyState, null);
+    const result = _evaluate(shellyState, null, this.deviceConfig);
     const nextMode = result.nextMode.toLowerCase();
 
     // Update internal state

--- a/playground/js/control.js
+++ b/playground/js/control.js
@@ -27,13 +27,8 @@ export async function initControlLogic() {
 }
 
 export class ControlStateMachine {
-  constructor(modesConfig, deviceConfig) {
+  constructor(modesConfig) {
     this.modes = modesConfig;      // system.yaml modes (for valve display names)
-    // Optional device-config object ({ ce, ea, tu, ... }) forwarded to
-    // the control logic as its third `deviceConfig` argument. Null for
-    // the live simulator (no tuning); the Tuning-thresholds forecast
-    // preview passes a config with a `tu` overlay.
-    this.deviceConfig = deviceConfig || null;
     this.currentMode = 'idle';
     this.modeStartTime = 0;
     this.collectorsDrained = false;
@@ -92,7 +87,7 @@ export class ControlStateMachine {
     const prevPeak = this.solarChargePeakTankAvg;
 
     // Delegate decision to the real Shelly control logic
-    const result = _evaluate(shellyState, null, this.deviceConfig);
+    const result = _evaluate(shellyState, null);
     const nextMode = result.nextMode.toLowerCase();
 
     // Update internal state

--- a/playground/js/forecast.js
+++ b/playground/js/forecast.js
@@ -27,7 +27,7 @@ import { drawHistoryGraph } from './main/history-graph.js';
 
 const ENGINE_STORAGE_KEY = 'forecastEngine';
 
-function getForecastEngine() {
+export function getForecastEngine() {
   try {
     return localStorage.getItem(ENGINE_STORAGE_KEY) === 'ml' ? 'ml' : 'physics';
   } catch (_e) {

--- a/playground/js/main/device-config.js
+++ b/playground/js/main/device-config.js
@@ -5,6 +5,9 @@
 import { store } from '../app-state.js';
 import { renderModeEnablement } from './watchdog-ui.js';
 import { putJson } from './fetch-helpers.js';
+import {
+  initTuningForecast, setForecastBaseline, setForecastEntered,
+} from './tuning-forecast.js';
 
 // Tuning-threshold inputs. Compact key + UI metadata. Mirrors the
 // server-side TUNING_RANGES table in server/lib/device-config.js and
@@ -55,6 +58,11 @@ export function initDeviceConfig() {
 
   // Render tuning inputs once at boot — values populated each load.
   renderTuningInputs();
+  // Each tuning input drives the forecast preview live as the user types.
+  TUNING_FIELDS.forEach((f) => {
+    const input = document.getElementById('dc-tu-' + f.key);
+    if (input) input.addEventListener('input', pushEnteredTuning);
+  });
   const resetBtn = document.getElementById('dc-tuning-reset');
   if (resetBtn) {
     resetBtn.addEventListener('click', () => {
@@ -62,8 +70,12 @@ export function initDeviceConfig() {
         const input = document.getElementById('dc-tu-' + f.key);
         if (input) input.value = '';
       });
+      pushEnteredTuning();
     });
   }
+
+  // Forecast preview under the tuning inputs.
+  initTuningForecast();
 
   // "Try anyway" link
   const tryLink = document.getElementById('dc-try-anyway');
@@ -136,6 +148,10 @@ function populateDeviceForm(cfg) {
     if (!input) return;
     input.value = (typeof tu[f.key] === 'number') ? String(tu[f.key]) : '';
   });
+  // Feed the forecast preview: the saved config is the dashed baseline,
+  // the freshly-populated form is the (initially identical) solid line.
+  setForecastBaseline(numericTu(tu));
+  pushEnteredTuning();
 
   // Version & size
   document.getElementById('dc-version').textContent = cfg.v || '-';
@@ -194,6 +210,37 @@ function readTuningFromForm() {
   return hasAny ? tu : null;
 }
 
+// Keep only numeric entries — the forecast simulation treats an absent
+// key as "use firmware default", so nulls/strings must be dropped.
+function numericTu(tu) {
+  const out = {};
+  if (tu) {
+    Object.keys(tu).forEach((k) => {
+      if (typeof tu[k] === 'number') out[k] = tu[k];
+    });
+  }
+  return out;
+}
+
+// Read the tuning form into a sparse numeric map for the forecast
+// simulation: empty fields are omitted (firmware default applies).
+function readTuningForSim() {
+  const tu = {};
+  TUNING_FIELDS.forEach((f) => {
+    const input = document.getElementById('dc-tu-' + f.key);
+    if (!input) return;
+    const raw = input.value.trim();
+    if (raw === '') return;
+    const num = Number(raw);
+    if (Number.isFinite(num)) tu[f.key] = num;
+  });
+  return tu;
+}
+
+function pushEnteredTuning() {
+  setForecastEntered(readTuningForSim());
+}
+
 function setToggle(id, on) {
   const el = document.getElementById(id);
   if (el) el.classList.toggle('active', on);
@@ -236,6 +283,10 @@ function saveDeviceConfig() {
         if (!input) return;
         input.value = (typeof ttu[f.key] === 'number') ? String(ttu[f.key]) : '';
       });
+      // The just-saved values are now the controller's baseline; the
+      // form (post-clamp) is the entered trajectory.
+      setForecastBaseline(numericTu(ttu));
+      pushEnteredTuning();
       setTimeout(() => { status.textContent = ''; }, 3000);
     })
     .catch(err => {

--- a/playground/js/main/device-config.js
+++ b/playground/js/main/device-config.js
@@ -5,9 +5,7 @@
 import { store } from '../app-state.js';
 import { renderModeEnablement } from './watchdog-ui.js';
 import { putJson } from './fetch-helpers.js';
-import {
-  initTuningForecast, setForecastBaseline, setForecastEntered,
-} from './tuning-forecast.js';
+import { initTuningForecast, setForecastEntered } from './tuning-forecast.js';
 
 // Tuning-threshold inputs. Compact key + UI metadata. Mirrors the
 // server-side TUNING_RANGES table in server/lib/device-config.js and
@@ -148,9 +146,9 @@ function populateDeviceForm(cfg) {
     if (!input) return;
     input.value = (typeof tu[f.key] === 'number') ? String(tu[f.key]) : '';
   });
-  // Feed the forecast preview: the saved config is the dashed baseline,
-  // the freshly-populated form is the (initially identical) solid line.
-  setForecastBaseline(numericTu(tu));
+  // Feed the forecast preview with the freshly-populated form values.
+  // The dashed baseline is the live /api/forecast (saved config), so
+  // it needs no client-side input.
   pushEnteredTuning();
 
   // Version & size
@@ -210,20 +208,8 @@ function readTuningFromForm() {
   return hasAny ? tu : null;
 }
 
-// Keep only numeric entries — the forecast simulation treats an absent
-// key as "use firmware default", so nulls/strings must be dropped.
-function numericTu(tu) {
-  const out = {};
-  if (tu) {
-    Object.keys(tu).forEach((k) => {
-      if (typeof tu[k] === 'number') out[k] = tu[k];
-    });
-  }
-  return out;
-}
-
 // Read the tuning form into a sparse numeric map for the forecast
-// simulation: empty fields are omitted (firmware default applies).
+// preview: empty fields are omitted (firmware default applies).
 function readTuningForSim() {
   const tu = {};
   TUNING_FIELDS.forEach((f) => {
@@ -283,9 +269,8 @@ function saveDeviceConfig() {
         if (!input) return;
         input.value = (typeof ttu[f.key] === 'number') ? String(ttu[f.key]) : '';
       });
-      // The just-saved values are now the controller's baseline; the
-      // form (post-clamp) is the entered trajectory.
-      setForecastBaseline(numericTu(ttu));
+      // The saved values are now the live forecast's baseline; refresh
+      // the entered trajectory from the (post-clamp) form.
       pushEnteredTuning();
       setTimeout(() => { status.textContent = ''; }, 3000);
     })

--- a/playground/js/main/tuning-forecast.js
+++ b/playground/js/main/tuning-forecast.js
@@ -1,40 +1,30 @@
 // Forecast preview for the device-view Tuning thresholds section.
 //
-// Runs the real thermal model + control logic forward 24 h from the
-// latest live sensor readings, once for the values typed into the
-// tuning form and once for the values currently saved on the
-// controller, and draws both trajectories on a canvas so the operator
-// can see what a threshold change does before pushing it.
+// Asks the real forecast engine (server-side: FMI weather + fitted
+// thermal coefficients / ML model, see server/lib/forecast/) for two
+// 48 h projections and draws them on a canvas:
+//   - solid lines  — the values typed into the tuning form, sent as the
+//                    `?tu=` what-if override
+//   - dashed lines — the live forecast (values currently saved on the
+//                    controller), i.e. plain /api/forecast
+// so the operator can see what a threshold change does before pushing
+// it. Recomputes (debounced) as the form is edited.
 //
 // External API:
-//   initTuningForecast()        — wire view/resize triggers (call once at boot).
-//   setForecastBaseline(tu)     — set the saved-on-controller tuning map.
-//   setForecastEntered(tu)      — set the typed-into-form tuning map.
-// Both setters schedule a debounced redraw.
+//   initTuningForecast()    — wire view/resize triggers + sync source.
+//   setForecastEntered(tu)  — set the typed-into-form tuning map (sparse,
+//                             numeric short keys); schedules a redraw.
 
 import { store } from '../app-state.js';
-import { ThermalModel } from '../physics.js';
-import { ControlStateMachine } from '../control.js';
-import { SIM_START_HOUR, getDayNightEnv } from '../sim-bootstrap.js';
-import { model, lastLiveFrame, timeSeriesStore } from './state.js';
-
-// 24 h projection at a 30 s integration step. The control logic's
-// timers are all minutes-scale, so 30 s resolves every transition;
-// finer steps only cost compute on the debounced live-recompute.
-const HORIZON_SEC = 24 * 3600;
-const DT = 30;
-// Representative clear-day peak irradiance (W/m²) — matches the
-// simulator's default so the forecast curve reads like the live sim.
-const PEAK_IRRADIANCE = 500;
+import { registerDataSource } from '../sync/registry.js';
+import { getForecastEngine } from '../forecast.js';
 
 // Series colours mirror the main history graph.
-const COLORS = {
-  tank: '#e9c349', collector: '#ef5350', greenhouse: '#69d0c5', outdoor: '#42a5f5',
-};
+const COLORS = { tank: '#e9c349', greenhouse: '#69d0c5', outdoor: '#42a5f5' };
 
-let _baselineTu = {};   // tuning saved on the controller (dashed lines)
-let _enteredTu = {};    // tuning typed into the form (solid lines)
+let _enteredTu = {};    // tuning typed into the form (drives the `?tu=` override)
 let _timer = null;
+let _abort = null;
 
 // ── Public API ───────────────────────────────────────────────────────────────
 
@@ -45,11 +35,14 @@ export function initTuningForecast() {
   window.addEventListener('resize', () => {
     if (store.get('currentView') === 'device') scheduleRender();
   });
-}
-
-export function setForecastBaseline(tu) {
-  _baselineTu = tu || {};
-  scheduleRender();
+  // Refresh on Android resume / tab focus / network recovery / periodic
+  // resync — the underlying weather forecast updates every 30 min.
+  registerDataSource({
+    id: 'tuning-forecast',
+    isActive: () => store.get('phase') === 'live' && store.get('currentView') === 'device',
+    fetch: (signal) => fetchForecasts(signal),
+    applyToStore: (data) => drawForecasts(data),
+  });
 }
 
 export function setForecastEntered(tu) {
@@ -61,134 +54,128 @@ export function setForecastEntered(tu) {
 
 function scheduleRender() {
   if (_timer) clearTimeout(_timer);
-  _timer = setTimeout(() => { _timer = null; renderTuningForecast(); }, 200);
+  _timer = setTimeout(() => { _timer = null; render(); }, 350);
 }
 
-function renderTuningForecast() {
+function render() {
   const canvas = document.getElementById('tuning-forecast-chart');
   const statusEl = document.getElementById('tuning-forecast-status');
   if (!canvas) return;
-  // Skip while the device view is hidden: a display:none canvas has no
+  // Skip while the device view is hidden — a display:none canvas has no
   // layout size. The currentView subscription redraws on entry.
   if (canvas.offsetWidth === 0) return;
 
-  const readings = currentReadings();
-  if (!readings) {
-    clearCanvas(canvas);
-    setStatus(statusEl,
-      'Waiting for live readings — the forecast appears once the controller reports sensor data.');
-    return;
-  }
+  if (_abort) _abort.abort();
+  _abort = new AbortController();
+  const signal = _abort.signal;
+  setStatus(statusEl, 'Computing forecast…');
 
-  let entered, baseline;
-  try {
-    entered = runForecast(readings, _enteredTu);
-    baseline = runForecast(readings, _baselineTu);
-  } catch (err) {
-    clearCanvas(canvas);
-    setStatus(statusEl, 'Forecast unavailable: ' + err.message);
-    return;
-  }
-  setStatus(statusEl, '');
-  draw(canvas, entered, baseline);
-}
-
-// ── Simulation ───────────────────────────────────────────────────────────────
-
-// Latest valid sensor snapshot to seed the simulation from. Prefers the
-// freshest live frame; falls back to the newest history sample. Returns
-// null when no frame has all five temperatures as finite numbers.
-function currentReadings() {
-  const candidates = [];
-  if (lastLiveFrame && lastLiveFrame.state) candidates.push(lastLiveFrame.state);
-  const n = timeSeriesStore.times.length;
-  if (n > 0) candidates.push(timeSeriesStore.values[n - 1]);
-  for (let i = 0; i < candidates.length; i++) {
-    const c = candidates[i];
-    const r = {
-      t_tank_top: c.t_tank_top,
-      t_tank_bottom: c.t_tank_bottom,
-      t_collector: c.t_collector,
-      t_greenhouse: c.t_greenhouse,
-      t_outdoor: c.t_outdoor,
-    };
-    let ok = true;
-    for (const k in r) {
-      if (typeof r[k] !== 'number' || !isFinite(r[k])) { ok = false; break; }
-    }
-    if (ok) return r;
-  }
-  return null;
-}
-
-// Synthetic day/night environment shifted so sim-time 0 maps to the
-// current hour-of-day, with the outdoor curve's base picked so it is
-// continuous with the latest outdoor reading.
-function makeEnv(currentOutdoor) {
-  const now = new Date();
-  const currentHour = now.getHours() + now.getMinutes() / 60;
-  const offsetSec = (currentHour - SIM_START_HOUR) * 3600;
-  const baseOutdoor = currentOutdoor - 5 * Math.cos((currentHour - 15) / 24 * 2 * Math.PI);
-  return function (simTime) {
-    return getDayNightEnv(simTime + offsetSec, baseOutdoor, PEAK_IRRADIANCE);
-  };
-}
-
-// Run the model + control logic forward HORIZON_SEC from `initial`,
-// applying `tu` as a tuning overlay. ce/ea are forced fully-enabled so
-// the forecast isolates the effect of the thresholds themselves rather
-// than the actuator-enable mask.
-function runForecast(initial, tu) {
-  const m = new ThermalModel(model && model.p ? model.p : undefined);
-  m.reset({
-    t_tank_top: initial.t_tank_top,
-    t_tank_bottom: initial.t_tank_bottom,
-    t_collector: initial.t_collector,
-    t_greenhouse: initial.t_greenhouse,
-    t_outdoor: initial.t_outdoor,
-  });
-  const ctrl = new ControlStateMachine(null, { ce: true, ea: 31, tu: tu || {} });
-  const getEnv = makeEnv(initial.t_outdoor);
-  const points = [];
-  const steps = Math.floor(HORIZON_SEC / DT);
-  for (let i = 0; i < steps; i++) {
-    const env = getEnv(m.state.simTime);
-    const sensors = {
-      t_collector: m.state.t_collector,
-      t_tank_top: m.state.t_tank_top,
-      t_tank_bottom: m.state.t_tank_bottom,
-      t_greenhouse: m.state.t_greenhouse,
-      t_outdoor: m.state.t_outdoor,
-    };
-    const result = ctrl.evaluate(sensors, m.state.simTime);
-    m.step(DT, env, result.actuators, result.mode);
-    points.push({
-      t: m.state.simTime,
-      tank: (m.state.t_tank_top + m.state.t_tank_bottom) / 2,
-      collector: m.state.t_collector,
-      greenhouse: m.state.t_greenhouse,
-      outdoor: m.state.t_outdoor,
+  fetchForecasts(signal)
+    .then((data) => {
+      if (signal.aborted) return;
+      drawForecasts(data);
+    })
+    .catch((err) => {
+      if (signal.aborted || (err && err.name === 'AbortError')) return;
+      clearCanvas(canvas);
+      setStatus(statusEl, 'Forecast unavailable: ' + err.message);
     });
+}
+
+// Build the /api/forecast URL — engine-aware, with an optional `tu`
+// what-if override. Mirrors playground/js/forecast.js's engine choice.
+function forecastUrl(tu) {
+  const params = new URLSearchParams();
+  if (getForecastEngine() === 'ml') params.set('engine', 'ml');
+  if (tu) params.set('tu', JSON.stringify(tu));
+  const qs = params.toString();
+  return '/api/forecast' + (qs ? '?' + qs : '');
+}
+
+function fetchOne(url, signal) {
+  return fetch(url, { signal }).then((r) => {
+    if (!r.ok) throw new Error('HTTP ' + r.status);
+    return r.json();
+  });
+}
+
+// Fetch the baseline (live device-config tuning) and the entered
+// (what-if `?tu=`) forecasts in parallel.
+function fetchForecasts(signal) {
+  return Promise.all([
+    fetchOne(forecastUrl(null), signal),
+    fetchOne(forecastUrl(_enteredTu), signal),
+  ]).then(([baseline, entered]) => ({ baseline, entered }));
+}
+
+// ── Series extraction ────────────────────────────────────────────────────────
+
+function isNum(v) { return typeof v === 'number' && !Number.isNaN(v); }
+
+// Pull a [timeMs, value] series out of an array of forecast points.
+function seriesOf(arr, tsKey, valKey) {
+  const out = [];
+  if (!Array.isArray(arr)) return out;
+  for (let i = 0; i < arr.length; i++) {
+    const t = Date.parse(arr[i][tsKey]);
+    const v = arr[i][valKey];
+    if (!Number.isNaN(t) && isNum(v)) out.push([t, v]);
   }
-  return points;
+  return out;
+}
+
+function tankSeries(resp) {
+  const fc = resp && resp.forecast;
+  return fc ? seriesOf(fc.tankTrajectory, 'ts', 'avg') : [];
+}
+function greenhouseSeries(resp) {
+  const fc = resp && resp.forecast;
+  return fc ? seriesOf(fc.greenhouseTrajectory, 'ts', 'temp') : [];
+}
+function outdoorSeries(resp) {
+  return resp ? seriesOf(resp.weather, 'validAt', 'temperature') : [];
 }
 
 // ── Canvas rendering ─────────────────────────────────────────────────────────
-
-function clearCanvas(canvas) {
-  const dpr = window.devicePixelRatio || 1;
-  const dw = canvas.offsetWidth;
-  const dh = canvas.offsetHeight;
-  canvas.width = dw * dpr;
-  canvas.height = dh * dpr;
-  canvas.getContext('2d').clearRect(0, 0, canvas.width, canvas.height);
-}
 
 function setStatus(el, text) {
   if (el) el.textContent = text;
 }
 
-function draw(canvas, entered, baseline) {
+function clearCanvas(canvas) {
+  const dpr = window.devicePixelRatio || 1;
+  canvas.width = canvas.offsetWidth * dpr;
+  canvas.height = canvas.offsetHeight * dpr;
+  canvas.getContext('2d').clearRect(0, 0, canvas.width, canvas.height);
+}
+
+function drawForecasts(data) {
+  const canvas = document.getElementById('tuning-forecast-chart');
+  const statusEl = document.getElementById('tuning-forecast-status');
+  if (!canvas || canvas.offsetWidth === 0) return;
+
+  const entered = data && data.entered;
+  const baseline = data && data.baseline;
+
+  const series = {
+    enteredTank: tankSeries(entered),
+    enteredGh: greenhouseSeries(entered),
+    baselineTank: tankSeries(baseline),
+    baselineGh: greenhouseSeries(baseline),
+    outdoor: outdoorSeries(entered),
+  };
+
+  if (series.enteredTank.length < 2 && series.enteredGh.length < 2) {
+    clearCanvas(canvas);
+    setStatus(statusEl,
+      'No forecast data yet — weather forecast not available for this device.');
+    return;
+  }
+  setStatus(statusEl, '');
+  draw(canvas, series);
+}
+
+function draw(canvas, series) {
   const ctx = canvas.getContext('2d');
   const dpr = window.devicePixelRatio || 1;
   const dw = canvas.offsetWidth;
@@ -205,21 +192,27 @@ function draw(canvas, entered, baseline) {
   const ph = dh - pad.top - pad.bottom;
   if (pw <= 0 || ph <= 0) return;
 
-  // Y range spans both runs, padded and snapped to 5° steps.
+  const all = [
+    series.enteredTank, series.enteredGh,
+    series.baselineTank, series.baselineGh, series.outdoor,
+  ];
+
+  // Time + temperature range across every plotted series.
+  let tMin = Infinity;
+  let tMax = -Infinity;
   let lo = Infinity;
   let hi = -Infinity;
-  const runs = [entered, baseline];
-  for (let r = 0; r < runs.length; r++) {
-    const pts = runs[r];
-    for (let i = 0; i < pts.length; i++) {
-      const vals = [pts[i].tank, pts[i].collector, pts[i].greenhouse, pts[i].outdoor];
-      for (let k = 0; k < 4; k++) {
-        if (vals[k] < lo) lo = vals[k];
-        if (vals[k] > hi) hi = vals[k];
-      }
+  for (let s = 0; s < all.length; s++) {
+    for (let i = 0; i < all[s].length; i++) {
+      const t = all[s][i][0];
+      const v = all[s][i][1];
+      if (t < tMin) tMin = t;
+      if (t > tMax) tMax = t;
+      if (v < lo) lo = v;
+      if (v > hi) hi = v;
     }
   }
-  if (!isFinite(lo) || !isFinite(hi)) return;
+  if (!isFinite(tMin) || !isFinite(lo) || tMax <= tMin) return;
   if (hi - lo < 10) hi = lo + 10;
   const span = hi - lo;
   const yMin = Math.floor((lo - span * 0.08) / 5) * 5;
@@ -242,47 +235,39 @@ function draw(canvas, entered, baseline) {
     ctx.fillText(Math.round(yMin + frac * (yMax - yMin)) + '°', pad.left - 4, y);
   }
 
-  // X-axis labels — hour-of-day every 6 h from "now".
+  // X-axis labels — hour-of-day every 12 h.
   ctx.textAlign = 'center';
   ctx.textBaseline = 'alphabetic';
-  const now = new Date();
-  const startHour = now.getHours() + now.getMinutes() / 60;
-  for (let h = 0; h <= 24; h += 6) {
-    const x = pad.left + (h / 24) * pw;
-    const tod = Math.floor((startHour + h) % 24);
-    ctx.fillText((tod < 10 ? '0' : '') + tod + ':00', x, dh - 6);
+  const HOUR = 3600 * 1000;
+  const firstTick = Math.ceil(tMin / (12 * HOUR)) * 12 * HOUR;
+  for (let t = firstTick; t <= tMax; t += 12 * HOUR) {
+    const x = pad.left + ((t - tMin) / (tMax - tMin)) * pw;
+    const h = new Date(t).getHours();
+    ctx.fillText((h < 10 ? '0' : '') + h + ':00', x, dh - 6);
   }
 
-  const xOf = function (t) { return pad.left + (t / HORIZON_SEC) * pw; };
-  const yOf = function (v) { return pad.top + ph - ((v - yMin) / (yMax - yMin)) * ph; };
+  const xOf = (t) => pad.left + ((t - tMin) / (tMax - tMin)) * pw;
+  const yOf = (v) => pad.top + ph - ((v - yMin) / (yMax - yMin)) * ph;
 
-  const series = [
-    { key: 'outdoor', color: COLORS.outdoor, width: 1 },
-    { key: 'collector', color: COLORS.collector, width: 1.5 },
-    { key: 'greenhouse', color: COLORS.greenhouse, width: 1.5 },
-    { key: 'tank', color: COLORS.tank, width: 2 },
-  ];
-  // Baseline first (dashed, faint) so the entered (solid) lines sit on top.
-  // Outdoor is environment-driven and identical for both runs — drawn once.
-  for (let s = 0; s < series.length; s++) {
-    if (series[s].key === 'outdoor') continue;
-    drawLine(ctx, baseline, series[s].key, xOf, yOf, series[s].color, series[s].width, true);
-  }
-  for (let s = 0; s < series.length; s++) {
-    drawLine(ctx, entered, series[s].key, xOf, yOf, series[s].color, series[s].width, false);
-  }
+  // Baseline first (dashed, faint), entered on top (solid). Outdoor is
+  // weather-driven and identical for both runs — drawn once.
+  drawLine(ctx, series.outdoor, xOf, yOf, COLORS.outdoor, 1, false, 0.55);
+  drawLine(ctx, series.baselineTank, xOf, yOf, COLORS.tank, 2, true, 0.4);
+  drawLine(ctx, series.baselineGh, xOf, yOf, COLORS.greenhouse, 1.5, true, 0.4);
+  drawLine(ctx, series.enteredTank, xOf, yOf, COLORS.tank, 2, false, 0.95);
+  drawLine(ctx, series.enteredGh, xOf, yOf, COLORS.greenhouse, 1.5, false, 0.95);
 }
 
-function drawLine(ctx, pts, key, xOf, yOf, color, width, dashed) {
+function drawLine(ctx, pts, xOf, yOf, color, width, dashed, alpha) {
   if (pts.length < 2) return;
   ctx.save();
   ctx.beginPath();
   ctx.strokeStyle = color;
   ctx.lineWidth = width;
-  ctx.globalAlpha = dashed ? 0.4 : 0.95;
+  ctx.globalAlpha = alpha;
   if (dashed) ctx.setLineDash([4, 3]);
-  ctx.moveTo(xOf(pts[0].t), yOf(pts[0][key]));
-  for (let i = 1; i < pts.length; i++) ctx.lineTo(xOf(pts[i].t), yOf(pts[i][key]));
+  ctx.moveTo(xOf(pts[0][0]), yOf(pts[0][1]));
+  for (let i = 1; i < pts.length; i++) ctx.lineTo(xOf(pts[i][0]), yOf(pts[i][1]));
   ctx.stroke();
   ctx.restore();
 }

--- a/playground/js/main/tuning-forecast.js
+++ b/playground/js/main/tuning-forecast.js
@@ -1,0 +1,288 @@
+// Forecast preview for the device-view Tuning thresholds section.
+//
+// Runs the real thermal model + control logic forward 24 h from the
+// latest live sensor readings, once for the values typed into the
+// tuning form and once for the values currently saved on the
+// controller, and draws both trajectories on a canvas so the operator
+// can see what a threshold change does before pushing it.
+//
+// External API:
+//   initTuningForecast()        — wire view/resize triggers (call once at boot).
+//   setForecastBaseline(tu)     — set the saved-on-controller tuning map.
+//   setForecastEntered(tu)      — set the typed-into-form tuning map.
+// Both setters schedule a debounced redraw.
+
+import { store } from '../app-state.js';
+import { ThermalModel } from '../physics.js';
+import { ControlStateMachine } from '../control.js';
+import { SIM_START_HOUR, getDayNightEnv } from '../sim-bootstrap.js';
+import { model, lastLiveFrame, timeSeriesStore } from './state.js';
+
+// 24 h projection at a 30 s integration step. The control logic's
+// timers are all minutes-scale, so 30 s resolves every transition;
+// finer steps only cost compute on the debounced live-recompute.
+const HORIZON_SEC = 24 * 3600;
+const DT = 30;
+// Representative clear-day peak irradiance (W/m²) — matches the
+// simulator's default so the forecast curve reads like the live sim.
+const PEAK_IRRADIANCE = 500;
+
+// Series colours mirror the main history graph.
+const COLORS = {
+  tank: '#e9c349', collector: '#ef5350', greenhouse: '#69d0c5', outdoor: '#42a5f5',
+};
+
+let _baselineTu = {};   // tuning saved on the controller (dashed lines)
+let _enteredTu = {};    // tuning typed into the form (solid lines)
+let _timer = null;
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+export function initTuningForecast() {
+  store.subscribe('currentView', () => {
+    if (store.get('currentView') === 'device') scheduleRender();
+  });
+  window.addEventListener('resize', () => {
+    if (store.get('currentView') === 'device') scheduleRender();
+  });
+}
+
+export function setForecastBaseline(tu) {
+  _baselineTu = tu || {};
+  scheduleRender();
+}
+
+export function setForecastEntered(tu) {
+  _enteredTu = tu || {};
+  scheduleRender();
+}
+
+// ── Render orchestration ─────────────────────────────────────────────────────
+
+function scheduleRender() {
+  if (_timer) clearTimeout(_timer);
+  _timer = setTimeout(() => { _timer = null; renderTuningForecast(); }, 200);
+}
+
+function renderTuningForecast() {
+  const canvas = document.getElementById('tuning-forecast-chart');
+  const statusEl = document.getElementById('tuning-forecast-status');
+  if (!canvas) return;
+  // Skip while the device view is hidden: a display:none canvas has no
+  // layout size. The currentView subscription redraws on entry.
+  if (canvas.offsetWidth === 0) return;
+
+  const readings = currentReadings();
+  if (!readings) {
+    clearCanvas(canvas);
+    setStatus(statusEl,
+      'Waiting for live readings — the forecast appears once the controller reports sensor data.');
+    return;
+  }
+
+  let entered, baseline;
+  try {
+    entered = runForecast(readings, _enteredTu);
+    baseline = runForecast(readings, _baselineTu);
+  } catch (err) {
+    clearCanvas(canvas);
+    setStatus(statusEl, 'Forecast unavailable: ' + err.message);
+    return;
+  }
+  setStatus(statusEl, '');
+  draw(canvas, entered, baseline);
+}
+
+// ── Simulation ───────────────────────────────────────────────────────────────
+
+// Latest valid sensor snapshot to seed the simulation from. Prefers the
+// freshest live frame; falls back to the newest history sample. Returns
+// null when no frame has all five temperatures as finite numbers.
+function currentReadings() {
+  const candidates = [];
+  if (lastLiveFrame && lastLiveFrame.state) candidates.push(lastLiveFrame.state);
+  const n = timeSeriesStore.times.length;
+  if (n > 0) candidates.push(timeSeriesStore.values[n - 1]);
+  for (let i = 0; i < candidates.length; i++) {
+    const c = candidates[i];
+    const r = {
+      t_tank_top: c.t_tank_top,
+      t_tank_bottom: c.t_tank_bottom,
+      t_collector: c.t_collector,
+      t_greenhouse: c.t_greenhouse,
+      t_outdoor: c.t_outdoor,
+    };
+    let ok = true;
+    for (const k in r) {
+      if (typeof r[k] !== 'number' || !isFinite(r[k])) { ok = false; break; }
+    }
+    if (ok) return r;
+  }
+  return null;
+}
+
+// Synthetic day/night environment shifted so sim-time 0 maps to the
+// current hour-of-day, with the outdoor curve's base picked so it is
+// continuous with the latest outdoor reading.
+function makeEnv(currentOutdoor) {
+  const now = new Date();
+  const currentHour = now.getHours() + now.getMinutes() / 60;
+  const offsetSec = (currentHour - SIM_START_HOUR) * 3600;
+  const baseOutdoor = currentOutdoor - 5 * Math.cos((currentHour - 15) / 24 * 2 * Math.PI);
+  return function (simTime) {
+    return getDayNightEnv(simTime + offsetSec, baseOutdoor, PEAK_IRRADIANCE);
+  };
+}
+
+// Run the model + control logic forward HORIZON_SEC from `initial`,
+// applying `tu` as a tuning overlay. ce/ea are forced fully-enabled so
+// the forecast isolates the effect of the thresholds themselves rather
+// than the actuator-enable mask.
+function runForecast(initial, tu) {
+  const m = new ThermalModel(model && model.p ? model.p : undefined);
+  m.reset({
+    t_tank_top: initial.t_tank_top,
+    t_tank_bottom: initial.t_tank_bottom,
+    t_collector: initial.t_collector,
+    t_greenhouse: initial.t_greenhouse,
+    t_outdoor: initial.t_outdoor,
+  });
+  const ctrl = new ControlStateMachine(null, { ce: true, ea: 31, tu: tu || {} });
+  const getEnv = makeEnv(initial.t_outdoor);
+  const points = [];
+  const steps = Math.floor(HORIZON_SEC / DT);
+  for (let i = 0; i < steps; i++) {
+    const env = getEnv(m.state.simTime);
+    const sensors = {
+      t_collector: m.state.t_collector,
+      t_tank_top: m.state.t_tank_top,
+      t_tank_bottom: m.state.t_tank_bottom,
+      t_greenhouse: m.state.t_greenhouse,
+      t_outdoor: m.state.t_outdoor,
+    };
+    const result = ctrl.evaluate(sensors, m.state.simTime);
+    m.step(DT, env, result.actuators, result.mode);
+    points.push({
+      t: m.state.simTime,
+      tank: (m.state.t_tank_top + m.state.t_tank_bottom) / 2,
+      collector: m.state.t_collector,
+      greenhouse: m.state.t_greenhouse,
+      outdoor: m.state.t_outdoor,
+    });
+  }
+  return points;
+}
+
+// ── Canvas rendering ─────────────────────────────────────────────────────────
+
+function clearCanvas(canvas) {
+  const dpr = window.devicePixelRatio || 1;
+  const dw = canvas.offsetWidth;
+  const dh = canvas.offsetHeight;
+  canvas.width = dw * dpr;
+  canvas.height = dh * dpr;
+  canvas.getContext('2d').clearRect(0, 0, canvas.width, canvas.height);
+}
+
+function setStatus(el, text) {
+  if (el) el.textContent = text;
+}
+
+function draw(canvas, entered, baseline) {
+  const ctx = canvas.getContext('2d');
+  const dpr = window.devicePixelRatio || 1;
+  const dw = canvas.offsetWidth;
+  const dh = canvas.offsetHeight;
+  canvas.width = dw * dpr;
+  canvas.height = dh * dpr;
+  ctx.scale(dpr, dpr);
+  ctx.clearRect(0, 0, dw, dh);
+  ctx.lineJoin = 'round';
+  ctx.lineCap = 'round';
+
+  const pad = { top: 12, right: 12, bottom: 22, left: 34 };
+  const pw = dw - pad.left - pad.right;
+  const ph = dh - pad.top - pad.bottom;
+  if (pw <= 0 || ph <= 0) return;
+
+  // Y range spans both runs, padded and snapped to 5° steps.
+  let lo = Infinity;
+  let hi = -Infinity;
+  const runs = [entered, baseline];
+  for (let r = 0; r < runs.length; r++) {
+    const pts = runs[r];
+    for (let i = 0; i < pts.length; i++) {
+      const vals = [pts[i].tank, pts[i].collector, pts[i].greenhouse, pts[i].outdoor];
+      for (let k = 0; k < 4; k++) {
+        if (vals[k] < lo) lo = vals[k];
+        if (vals[k] > hi) hi = vals[k];
+      }
+    }
+  }
+  if (!isFinite(lo) || !isFinite(hi)) return;
+  if (hi - lo < 10) hi = lo + 10;
+  const span = hi - lo;
+  const yMin = Math.floor((lo - span * 0.08) / 5) * 5;
+  const yMax = Math.ceil((hi + span * 0.08) / 5) * 5;
+
+  // Grid lines + Y-axis labels.
+  ctx.font = '10px Manrope, sans-serif';
+  ctx.fillStyle = '#a5abb9';
+  ctx.strokeStyle = 'rgba(255,255,255,0.06)';
+  ctx.lineWidth = 1;
+  ctx.textAlign = 'right';
+  ctx.textBaseline = 'middle';
+  for (let i = 0; i <= 4; i++) {
+    const frac = i / 4;
+    const y = pad.top + ph - frac * ph;
+    ctx.beginPath();
+    ctx.moveTo(pad.left, y);
+    ctx.lineTo(pad.left + pw, y);
+    ctx.stroke();
+    ctx.fillText(Math.round(yMin + frac * (yMax - yMin)) + '°', pad.left - 4, y);
+  }
+
+  // X-axis labels — hour-of-day every 6 h from "now".
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'alphabetic';
+  const now = new Date();
+  const startHour = now.getHours() + now.getMinutes() / 60;
+  for (let h = 0; h <= 24; h += 6) {
+    const x = pad.left + (h / 24) * pw;
+    const tod = Math.floor((startHour + h) % 24);
+    ctx.fillText((tod < 10 ? '0' : '') + tod + ':00', x, dh - 6);
+  }
+
+  const xOf = function (t) { return pad.left + (t / HORIZON_SEC) * pw; };
+  const yOf = function (v) { return pad.top + ph - ((v - yMin) / (yMax - yMin)) * ph; };
+
+  const series = [
+    { key: 'outdoor', color: COLORS.outdoor, width: 1 },
+    { key: 'collector', color: COLORS.collector, width: 1.5 },
+    { key: 'greenhouse', color: COLORS.greenhouse, width: 1.5 },
+    { key: 'tank', color: COLORS.tank, width: 2 },
+  ];
+  // Baseline first (dashed, faint) so the entered (solid) lines sit on top.
+  // Outdoor is environment-driven and identical for both runs — drawn once.
+  for (let s = 0; s < series.length; s++) {
+    if (series[s].key === 'outdoor') continue;
+    drawLine(ctx, baseline, series[s].key, xOf, yOf, series[s].color, series[s].width, true);
+  }
+  for (let s = 0; s < series.length; s++) {
+    drawLine(ctx, entered, series[s].key, xOf, yOf, series[s].color, series[s].width, false);
+  }
+}
+
+function drawLine(ctx, pts, key, xOf, yOf, color, width, dashed) {
+  if (pts.length < 2) return;
+  ctx.save();
+  ctx.beginPath();
+  ctx.strokeStyle = color;
+  ctx.lineWidth = width;
+  ctx.globalAlpha = dashed ? 0.4 : 0.95;
+  if (dashed) ctx.setLineDash([4, 3]);
+  ctx.moveTo(xOf(pts[0].t), yOf(pts[0][key]));
+  for (let i = 1; i < pts.length; i++) ctx.lineTo(xOf(pts[i].t), yOf(pts[i][key]));
+  ctx.stroke();
+  ctx.restore();
+}

--- a/server/lib/forecast/forecast-handler.js
+++ b/server/lib/forecast/forecast-handler.js
@@ -14,6 +14,7 @@ const { fitEmpiricalCoefficients, computeSustainForecast } = require('./sustain-
 const { ALGORITHM_VERSION } = require('./version');
 const deviceConfig = require('../device-config');
 const { jsonResponse } = require('../http-handlers');
+const { parseTuningOverride } = require('./tuning-override');
 
 const CACHE_TTL_MS         = 60 * 1000;     // 60 s response cache
 const COEFF_CACHE_TTL_MS   = 60 * 60 * 1000; // 1 h coefficient cache
@@ -276,11 +277,11 @@ function createForecastHandler(opts) {
   // forecast response object and hands it to callback(err, response).
   // The HTTP handler `handle()` and the prediction-capture scheduler
   // share this path so they always see the same numbers.
-  function compute(callback) {
+  function compute(callback, overrideTuning) {
     if (!pool) { callback(new Error('Database not available')); return; }
 
     const now = Date.now();
-    if (_responseCache && (now - _responseCachedAt) < CACHE_TTL_MS) {
+    if (!overrideTuning && _responseCache && (now - _responseCachedAt) < CACHE_TTL_MS) {
       callback(null, _responseCache);
       return;
     }
@@ -316,7 +317,7 @@ function createForecastHandler(opts) {
         // effectiveTuning returns SHORT keys (geT, gxT, ehE) — same shape as
         // tu — and merges user overrides over the control-logic defaults.
         const dcfg     = deviceConfig.getConfig() || {};
-        const tuning   = deviceConfig.effectiveTuning(dcfg.tu || {});
+        const tuning   = deviceConfig.effectiveTuning(overrideTuning || dcfg.tu || {});
         const forecastConfig = {
           spaceHeaterKw:   configFromYaml.spaceHeaterKw,
           transferFeeCKwh: configFromYaml.transferFeeCKwh,
@@ -371,7 +372,7 @@ function createForecastHandler(opts) {
           // forecast, so a tuning analysis can correlate prediction
           // shifts with config / fit changes.
           algorithmVersion: ALGORITHM_VERSION,
-          tu:               dcfg.tu || {},
+          tu:               overrideTuning || dcfg.tu || {},
           coefficients:     coeff || null,
           weather,
           prices,
@@ -382,8 +383,7 @@ function createForecastHandler(opts) {
         // missing service or DB read failure ships without it — the
         // rest of the forecast is still useful.
         attachPredictions(baseResponse, function (response) {
-          _responseCache    = response;
-          _responseCachedAt = Date.now();
+          if (!overrideTuning) { _responseCache = response; _responseCachedAt = Date.now(); }
           callback(null, response);
         });
       });
@@ -438,7 +438,7 @@ function createForecastHandler(opts) {
         return;
       }
       jsonResponse(res, 200, response);
-    });
+    }, parseTuningOverride(req.url));
   }
 
   // Pre-warm the coefficient cache. The 14d history fit is the dominant

--- a/server/lib/forecast/ml/ml-forecast-handler.js
+++ b/server/lib/forecast/ml/ml-forecast-handler.js
@@ -15,6 +15,7 @@ const zlib = require('zlib');
 const { computeMlForecast } = require('./ml-forecast');
 const deviceConfig = require('../../device-config');
 const { jsonResponse } = require('../../http-handlers');
+const { parseTuningOverride } = require('../tuning-override');
 
 const CACHE_TTL_MS = 60 * 1000;
 const MODEL_PATH = path.join(__dirname, 'forecast-model.json.gz');
@@ -111,12 +112,12 @@ function createMlForecastHandler(opts) {
 
   // ── Compute ──
 
-  function compute(callback) {
+  function compute(callback, overrideTuning) {
     if (!pool) { callback(new Error('Database not available')); return; }
     if (!model) { callback(new Error('ML model not available')); return; }
 
     const nowMs = Date.now();
-    if (cache && (nowMs - cachedAt) < CACHE_TTL_MS) { callback(null, cache); return; }
+    if (!overrideTuning && cache && (nowMs - cachedAt) < CACHE_TTL_MS) { callback(null, cache); return; }
 
     // Each section degrades to empty on a query failure rather than
     // sinking the whole forecast — a transient DB hiccup still yields a
@@ -133,7 +134,7 @@ function createMlForecastHandler(opts) {
       if (pending > 0) return;
 
       const dcfg = deviceConfig.getConfig() || {};
-      const tuning = deviceConfig.effectiveTuning(dcfg.tu || {});
+      const tuning = deviceConfig.effectiveTuning(overrideTuning || dcfg.tu || {});
       const config = {
         spaceHeaterKw: typeof spaceHeater.assumed_continuous_power_kw === 'number'
           ? spaceHeater.assumed_continuous_power_kw : 1,
@@ -173,18 +174,19 @@ function createMlForecastHandler(opts) {
         return;
       }
 
-      cache = {
+      const response = {
         generatedAt: forecast.generatedAt,
         engine: 'ml',
         algorithmVersion: 'ml',
         mlTrainedAt: model.trainedAt || null,
-        tu: dcfg.tu || {},
+        tu: overrideTuning || dcfg.tu || {},
         weather,
         prices,
         forecast,
       };
-      cachedAt = Date.now();
-      callback(null, cache);
+      // A what-if preview must not poison the live-forecast cache.
+      if (!overrideTuning) { cache = response; cachedAt = Date.now(); }
+      callback(null, response);
     }
 
     queryLatestSensors(function got(err, s) { if (s) sensors = s; onPart(err, 'sensors'); });
@@ -207,7 +209,7 @@ function createMlForecastHandler(opts) {
         return;
       }
       jsonResponse(res, 200, response);
-    });
+    }, parseTuningOverride(req.url));
   }
 
   return { handle, compute, modelLoaded: !!model };

--- a/server/lib/forecast/tuning-override.js
+++ b/server/lib/forecast/tuning-override.js
@@ -1,0 +1,52 @@
+'use strict';
+
+/**
+ * Parse an optional `tu` query parameter from a forecast request URL.
+ *
+ * The Tuning-thresholds forecast preview asks the engine for a what-if
+ * projection — "what would the forecast look like with these thresholds"
+ * — without saving the values to the device. It passes the candidate
+ * tuning map as `?tu=<json>`; both forecast engines run with it instead
+ * of the live device-config tuning.
+ *
+ * Returns:
+ *   - null  when no `tu` param is present (→ use live device-config tuning)
+ *           or the value is unparseable (graceful fallback to the live forecast)
+ *   - a clamped sparse short-key map (possibly {}) when one is present.
+ *     {} is meaningful: "every threshold at its firmware default".
+ *
+ * Values are clamped to TUNING_RANGES so the preview matches what the
+ * device would actually run after server-side clamping on save.
+ */
+
+const { TUNING_RANGES } = require('../device-config');
+
+function parseTuningOverride(reqUrl) {
+  let raw;
+  try {
+    raw = new URL(reqUrl, 'http://localhost').searchParams.get('tu');
+  } catch (e) {
+    return null;
+  }
+  if (raw === null) return null;
+
+  let obj;
+  try {
+    obj = JSON.parse(raw);
+  } catch (e) {
+    return null;
+  }
+  if (!obj || typeof obj !== 'object' || Array.isArray(obj)) return null;
+
+  const out = {};
+  Object.keys(TUNING_RANGES).forEach(function (k) {
+    const v = obj[k];
+    if (typeof v === 'number' && isFinite(v)) {
+      const r = TUNING_RANGES[k];
+      out[k] = v < r.min ? r.min : (v > r.max ? r.max : v);
+    }
+  });
+  return out;
+}
+
+module.exports = { parseTuningOverride };

--- a/tests/forecast-api.test.js
+++ b/tests/forecast-api.test.js
@@ -316,4 +316,68 @@ describe('GET /api/forecast handler', () => {
     const handler = createForecastHandler({ pool: null, log, systemYaml: {} });
     handler.prewarm();
   });
+
+  // The Tuning-thresholds forecast preview asks /api/forecast?tu=<json>
+  // for a what-if projection. The override must reach the engine, be
+  // clamped, and never poison the live-forecast cache.
+  function fullPool() {
+    return makePool({
+      'sensor_readings_30s': makeSensorReadings30sRows(),
+      'state_events':        [{ mode: 'idle' }],
+      'weather_forecasts':   makeWeatherRows(),
+      'spot_prices':         makePriceRows(),
+    });
+  }
+
+  function handleAndWait(handler, url, done, assertFn) {
+    const res = fakeRes();
+    handler.handle(fakeReq(url), res);
+    const deadline = Date.now() + 2000;
+    (function poll() {
+      if (res.written.status !== null) { assertFn(res.written); done(); }
+      else if (Date.now() < deadline) setImmediate(poll);
+      else done(new Error('handler did not respond: ' + url));
+    })();
+  }
+
+  it('?tu= override threads custom thresholds into the response', function (t, done) {
+    const handler = createForecastHandler({ pool: fullPool(), log: makeLog(), systemYaml: {} });
+    const url = '/api/forecast?tu=' + encodeURIComponent(JSON.stringify({ geT: 20 }));
+    handleAndWait(handler, url, done, function (written) {
+      assert.equal(written.status, 200);
+      assert.equal(written.body.tu.geT, 20, 'response tu reflects the override');
+    });
+  });
+
+  it('?tu= override clamps out-of-range thresholds', function (t, done) {
+    const handler = createForecastHandler({ pool: fullPool(), log: makeLog(), systemYaml: {} });
+    const url = '/api/forecast?tu=' + encodeURIComponent(JSON.stringify({ geT: 999 }));
+    handleAndWait(handler, url, done, function (written) {
+      assert.equal(written.status, 200);
+      assert.equal(written.body.tu.geT, 25, 'geT clamped to its 0–25 range');
+    });
+  });
+
+  it('a ?tu= preview does not poison the live-forecast cache', function (t, done) {
+    const handler = createForecastHandler({ pool: fullPool(), log: makeLog(), systemYaml: {} });
+    // 1. Plain call — populates the 60 s response cache.
+    handleAndWait(handler, '/api/forecast', function (e1) {
+      if (e1) return done(e1);
+      // 2. Preview call — must recompute (bypass cache) and echo the override.
+      const url = '/api/forecast?tu=' + encodeURIComponent(JSON.stringify({ geT: 20 }));
+      handleAndWait(handler, url, function (e2) {
+        if (e2) return done(e2);
+        // 3. Plain call again — the cached live forecast, untouched by step 2.
+        handleAndWait(handler, '/api/forecast', done, function (written) {
+          assert.equal(written.status, 200);
+          assert.equal(written.body.tu.geT, undefined, 'live cache not poisoned by the preview');
+        });
+      }, function (written) {
+        assert.equal(written.status, 200);
+        assert.equal(written.body.tu.geT, 20, 'preview recomputed despite the warm cache');
+      });
+    }, function (written) {
+      assert.equal(written.status, 200);
+    });
+  });
 });

--- a/tests/frontend/tuning-forecast.spec.js
+++ b/tests/frontend/tuning-forecast.spec.js
@@ -4,14 +4,44 @@ import { test, expect } from './fixtures.js';
 /**
  * Frontend tests for the Tuning-thresholds forecast preview.
  *
- * The device view's Tuning section renders a 24 h simulated projection
- * from the latest live readings: a solid trajectory for the values
- * typed into the form and a dashed one for the values saved on the
- * controller. The preview re-simulates live as the user edits a
- * threshold.
+ * The device view's Tuning section asks the real forecast engine for
+ * two 48 h projections: a dashed baseline (plain /api/forecast, live
+ * device-config tuning) and a solid "entered" line (/api/forecast?tu=…,
+ * the values typed into the form). It recomputes as a threshold is
+ * edited.
  */
 
-const DEFAULT_CONFIG = { ce: true, ea: 31, fm: null, we: {}, wz: {}, wb: {}, v: 1 };
+const DEFAULT_CONFIG = { ce: true, ea: 31, fm: null, we: {}, wz: {}, wb: {}, tu: { geT: 11 }, v: 1 };
+
+/** Build a forecast-engine response whose greenhouse line tracks geT. */
+function buildForecast(geT) {
+  const now = Date.now();
+  const tank = [];
+  const gh = [];
+  const weather = [];
+  for (let h = 0; h < 48; h++) {
+    const ts = new Date(now + h * 3600000).toISOString();
+    tank.push({ ts, top: 45 - h * 0.2, bottom: 40 - h * 0.2, avg: 42.5 - h * 0.2 });
+    gh.push({ ts, temp: 8 + (geT - 10) * 0.6 + Math.sin(h / 6) });
+    weather.push({ validAt: ts, temperature: 5 + 4 * Math.sin(h / 8) });
+  }
+  return {
+    generatedAt: new Date(now).toISOString(),
+    tu: {},
+    weather,
+    prices: [],
+    forecast: {
+      horizonHours: 48,
+      tankTrajectory: tank,
+      greenhouseTrajectory: gh,
+      hoursUntilBackupNeeded: null,
+      electricKwh: 0,
+      electricCostEur: 0,
+      modelConfidence: 'medium',
+      notes: [],
+    },
+  };
+}
 
 /** Mock WebSocket so the app sees a live connection with sensor data. */
 async function mockLiveConnection(page) {
@@ -47,16 +77,16 @@ async function mockLiveConnection(page) {
   });
 }
 
-/** Set up API mocks and navigate to the device view. */
-async function setupDeviceView(page, initialConfig) {
-  const config = { ...DEFAULT_CONFIG, ...initialConfig };
+/** Set up API mocks and navigate to the device view. Captures forecast URLs. */
+async function setupDeviceView(page) {
+  const forecastUrls = [];
 
   await mockLiveConnection(page);
 
   await page.route('**/api/device-config', async (route) => {
     if (route.request().method() === 'GET') {
       await route.fulfill({
-        status: 200, contentType: 'application/json', body: JSON.stringify(config),
+        status: 200, contentType: 'application/json', body: JSON.stringify(DEFAULT_CONFIG),
       });
     } else {
       await route.continue();
@@ -66,17 +96,34 @@ async function setupDeviceView(page, initialConfig) {
     status: 200, contentType: 'application/json', body: '[]',
   }));
 
+  // The forecast engine — baseline (no tu) uses geT 11; the what-if
+  // variant echoes the geT carried in the `?tu=` override.
+  await page.route('**/api/forecast**', async (route) => {
+    const url = route.request().url();
+    forecastUrls.push(url);
+    let geT = 11;
+    const m = url.match(/[?&]tu=([^&]+)/);
+    if (m) {
+      try {
+        const tu = JSON.parse(decodeURIComponent(m[1]));
+        if (typeof tu.geT === 'number') geT = tu.geT;
+      } catch (e) { /* fall back to baseline geT */ }
+    }
+    await route.fulfill({
+      status: 200, contentType: 'application/json', body: JSON.stringify(buildForecast(geT)),
+    });
+  });
+
   await page.goto('/playground/', { waitUntil: 'domcontentloaded' });
   await page.waitForFunction(() => window.__initComplete === true);
 
   await page.locator('.sidebar-nav [data-view="device"]').click();
   await expect(page.locator('#device-config-form')).toBeVisible();
+
+  return { forecastUrls };
 }
 
-/**
- * Read a fingerprint of the forecast canvas: how many pixels are
- * painted, plus a cheap hash so two renders can be compared.
- */
+/** Fingerprint the forecast canvas: painted-pixel count + a cheap hash. */
 async function canvasFingerprint(page) {
   return page.evaluate(() => {
     const c = /** @type {HTMLCanvasElement} */ (
@@ -98,38 +145,44 @@ async function canvasFingerprint(page) {
 test.describe('Tuning forecast preview', () => {
 
   test('renders a forecast graph on the device view', async ({ page }) => {
-    await setupDeviceView(page, { tu: { geT: 11 } });
+    const { forecastUrls } = await setupDeviceView(page);
 
     await expect(page.locator('#tuning-forecast-chart')).toBeVisible();
 
-    // The canvas paints once the simulation has run (debounced ~200 ms).
     await expect.poll(
       async () => (await canvasFingerprint(page)).painted,
-      { timeout: 4000 },
+      { timeout: 5000 },
     ).toBeGreaterThan(200);
 
-    // No error / waiting message once readings are available.
     await expect(page.locator('#tuning-forecast-status')).toHaveText('');
+
+    // Both a baseline (no override) and a what-if (`?tu=`) request fired.
+    expect(forecastUrls.some(u => /[?&]tu=/.test(u))).toBe(true);
+    expect(forecastUrls.some(u => !/[?&]tu=/.test(u))).toBe(true);
   });
 
-  test('re-simulates when a tuning threshold is edited', async ({ page }) => {
-    await setupDeviceView(page, { tu: { geT: 11 } });
+  test('re-fetches with the ?tu= override when a threshold is edited', async ({ page }) => {
+    const { forecastUrls } = await setupDeviceView(page);
 
     await expect.poll(
       async () => (await canvasFingerprint(page)).painted,
-      { timeout: 4000 },
+      { timeout: 5000 },
     ).toBeGreaterThan(200);
     const before = await canvasFingerprint(page);
+    const urlsBefore = forecastUrls.length;
 
-    // Pull the greenhouse-heating enter threshold well above the
-    // current greenhouse temperature — the entered trajectory diverges
-    // from the saved-config baseline.
+    // Raise the greenhouse-heating enter threshold — the what-if
+    // trajectory diverges from the saved-config baseline.
     await page.locator('#dc-tu-geT').fill('22');
 
     await expect.poll(
       async () => (await canvasFingerprint(page)).hash,
-      { timeout: 4000 },
+      { timeout: 5000 },
     ).not.toBe(before.hash);
+
+    // The recompute carried geT=22 in the override.
+    const newUrls = forecastUrls.slice(urlsBefore);
+    expect(newUrls.some(u => /tu=.*22/.test(decodeURIComponent(u)))).toBe(true);
   });
 
 });

--- a/tests/frontend/tuning-forecast.spec.js
+++ b/tests/frontend/tuning-forecast.spec.js
@@ -1,0 +1,135 @@
+// @ts-check
+import { test, expect } from './fixtures.js';
+
+/**
+ * Frontend tests for the Tuning-thresholds forecast preview.
+ *
+ * The device view's Tuning section renders a 24 h simulated projection
+ * from the latest live readings: a solid trajectory for the values
+ * typed into the form and a dashed one for the values saved on the
+ * controller. The preview re-simulates live as the user edits a
+ * threshold.
+ */
+
+const DEFAULT_CONFIG = { ce: true, ea: 31, fm: null, we: {}, wz: {}, wb: {}, v: 1 };
+
+/** Mock WebSocket so the app sees a live connection with sensor data. */
+async function mockLiveConnection(page) {
+  await page.addInitScript(() => {
+    const OrigWS = window.WebSocket;
+    // @ts-ignore
+    window.WebSocket = function () {
+      const fake = {
+        readyState: 0, onopen: null, onmessage: null, onclose: null, onerror: null,
+        close: function () { this.readyState = 3; },
+        send: function () {},
+      };
+      setTimeout(function () {
+        fake.readyState = 1;
+        if (fake.onopen) fake.onopen(new Event('open'));
+        if (fake.onmessage) {
+          fake.onmessage({ data: JSON.stringify({ type: 'connection', status: 'connected' }) });
+          fake.onmessage({ data: JSON.stringify({
+            type: 'state',
+            data: {
+              mode: 'idle',
+              temps: { collector: 25, tank_top: 40, tank_bottom: 35, greenhouse: 18, outdoor: 10 },
+              valves: {}, actuators: { pump: false, fan: false, space_heater: false },
+              controls_enabled: true,
+            },
+          }) });
+        }
+      }, 50);
+      return fake;
+    };
+    // @ts-ignore
+    window.WebSocket.prototype = OrigWS.prototype;
+  });
+}
+
+/** Set up API mocks and navigate to the device view. */
+async function setupDeviceView(page, initialConfig) {
+  const config = { ...DEFAULT_CONFIG, ...initialConfig };
+
+  await mockLiveConnection(page);
+
+  await page.route('**/api/device-config', async (route) => {
+    if (route.request().method() === 'GET') {
+      await route.fulfill({
+        status: 200, contentType: 'application/json', body: JSON.stringify(config),
+      });
+    } else {
+      await route.continue();
+    }
+  });
+  await page.route('**/api/history**', route => route.fulfill({
+    status: 200, contentType: 'application/json', body: '[]',
+  }));
+
+  await page.goto('/playground/', { waitUntil: 'domcontentloaded' });
+  await page.waitForFunction(() => window.__initComplete === true);
+
+  await page.locator('.sidebar-nav [data-view="device"]').click();
+  await expect(page.locator('#device-config-form')).toBeVisible();
+}
+
+/**
+ * Read a fingerprint of the forecast canvas: how many pixels are
+ * painted, plus a cheap hash so two renders can be compared.
+ */
+async function canvasFingerprint(page) {
+  return page.evaluate(() => {
+    const c = /** @type {HTMLCanvasElement} */ (
+      document.getElementById('tuning-forecast-chart'));
+    const ctx = c.getContext('2d');
+    const data = ctx.getImageData(0, 0, c.width, c.height).data;
+    let painted = 0;
+    let hash = 0;
+    for (let i = 3; i < data.length; i += 4) {
+      if (data[i] !== 0) painted++;
+    }
+    for (let i = 0; i < data.length; i += 263) {
+      hash = (hash * 31 + data[i]) >>> 0;
+    }
+    return { painted, hash };
+  });
+}
+
+test.describe('Tuning forecast preview', () => {
+
+  test('renders a forecast graph on the device view', async ({ page }) => {
+    await setupDeviceView(page, { tu: { geT: 11 } });
+
+    await expect(page.locator('#tuning-forecast-chart')).toBeVisible();
+
+    // The canvas paints once the simulation has run (debounced ~200 ms).
+    await expect.poll(
+      async () => (await canvasFingerprint(page)).painted,
+      { timeout: 4000 },
+    ).toBeGreaterThan(200);
+
+    // No error / waiting message once readings are available.
+    await expect(page.locator('#tuning-forecast-status')).toHaveText('');
+  });
+
+  test('re-simulates when a tuning threshold is edited', async ({ page }) => {
+    await setupDeviceView(page, { tu: { geT: 11 } });
+
+    await expect.poll(
+      async () => (await canvasFingerprint(page)).painted,
+      { timeout: 4000 },
+    ).toBeGreaterThan(200);
+    const before = await canvasFingerprint(page);
+
+    // Pull the greenhouse-heating enter threshold well above the
+    // current greenhouse temperature — the entered trajectory diverges
+    // from the saved-config baseline.
+    await page.locator('#dc-tu-geT').fill('22');
+
+    await expect.poll(
+      async () => (await canvasFingerprint(page)).hash,
+      { timeout: 4000 },
+    ).not.toBe(before.hash);
+  });
+
+});

--- a/tests/ml-forecast-handler.test.js
+++ b/tests/ml-forecast-handler.test.js
@@ -1,0 +1,98 @@
+'use strict';
+
+// GET /api/forecast?engine=ml — `tu` what-if override.
+//
+// The ML engine mirrors the physics engine's tuning-override support so
+// the Tuning-thresholds forecast preview works regardless of which
+// engine the operator has selected.
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { createMlForecastHandler } = require('../server/lib/forecast/ml/ml-forecast-handler.js');
+
+function makeLog() {
+  const stub = () => () => {};
+  return { info: stub(), warn: stub(), error: stub() };
+}
+
+function fakeRes() {
+  const written = { status: null, body: null };
+  return {
+    written,
+    writeHead(s) { written.status = s; },
+    end(b) { written.body = b ? JSON.parse(b) : null; },
+  };
+}
+
+function fakeReq(url) { return { url, method: 'GET' }; }
+
+function makePool() {
+  const now = new Date('2026-05-04T10:00:00Z');
+  const weather = [];
+  const prices = [];
+  for (let h = 0; h < 48; h++) {
+    const validAt = new Date(now.getTime() + h * 3600000);
+    weather.push({ valid_at: validAt, temperature: 6, radiationGlobal: 120, windSpeed: 2, precipitation: 0 });
+    prices.push({ valid_at: validAt, priceCKwh: 10 });
+  }
+  return {
+    query(sql, _params, cb) {
+      let rows = [];
+      if (sql.includes('weather_forecasts')) rows = weather;
+      else if (sql.includes('spot_prices')) rows = prices;
+      else if (sql.includes('state_events')) rows = [{ mode: 'idle' }];
+      else if (sql.includes('sensor_readings_30s')) {
+        rows = [
+          { sensor_id: 'tank_top', value: 45 },
+          { sensor_id: 'tank_bottom', value: 38 },
+          { sensor_id: 'greenhouse', value: 12 },
+        ];
+      }
+      cb(null, { rows });
+    },
+  };
+}
+
+function handleAndWait(handler, url, done, assertFn) {
+  const res = fakeRes();
+  handler.handle(fakeReq(url), res);
+  const deadline = Date.now() + 2000;
+  (function poll() {
+    if (res.written.status !== null) { assertFn(res.written); done(); }
+    else if (Date.now() < deadline) setImmediate(poll);
+    else done(new Error('handler did not respond: ' + url));
+  })();
+}
+
+describe('GET /api/forecast?engine=ml — tu override', () => {
+  it('threads a ?tu= override into the ML forecast response', function (t, done) {
+    const handler = createMlForecastHandler({ pool: makePool(), log: makeLog(), systemYaml: {} });
+    if (!handler.modelLoaded) { done(); return; } // model artifact missing — skip
+    const url = '/api/forecast?engine=ml&tu=' + encodeURIComponent(JSON.stringify({ geT: 20 }));
+    handleAndWait(handler, url, done, function (written) {
+      assert.equal(written.status, 200);
+      assert.equal(written.body.tu.geT, 20, 'response tu reflects the override');
+    });
+  });
+
+  it('a ?tu= preview does not poison the live ML cache', function (t, done) {
+    const handler = createMlForecastHandler({ pool: makePool(), log: makeLog(), systemYaml: {} });
+    if (!handler.modelLoaded) { done(); return; }
+    handleAndWait(handler, '/api/forecast?engine=ml', function (e1) {
+      if (e1) return done(e1);
+      const url = '/api/forecast?engine=ml&tu=' + encodeURIComponent(JSON.stringify({ geT: 20 }));
+      handleAndWait(handler, url, function (e2) {
+        if (e2) return done(e2);
+        handleAndWait(handler, '/api/forecast?engine=ml', done, function (written) {
+          assert.equal(written.status, 200);
+          assert.equal(written.body.tu.geT, undefined, 'live cache not poisoned by the preview');
+        });
+      }, function (written) {
+        assert.equal(written.status, 200);
+        assert.equal(written.body.tu.geT, 20, 'preview recomputed despite the warm cache');
+      });
+    }, function (written) {
+      assert.equal(written.status, 200);
+    });
+  });
+});

--- a/tests/tuning-override.test.js
+++ b/tests/tuning-override.test.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { parseTuningOverride } = require('../server/lib/forecast/tuning-override.js');
+
+describe('parseTuningOverride', () => {
+  it('returns null when no tu query param is present', () => {
+    assert.equal(parseTuningOverride('/api/forecast'), null);
+    assert.equal(parseTuningOverride('/api/forecast?engine=ml'), null);
+  });
+
+  it('returns null on unparseable JSON (graceful fallback to live forecast)', () => {
+    assert.equal(parseTuningOverride('/api/forecast?tu=not-json'), null);
+    assert.equal(parseTuningOverride('/api/forecast?tu=%7Bbroken'), null);
+  });
+
+  it('returns null when tu is not a plain object', () => {
+    assert.equal(parseTuningOverride('/api/forecast?tu=' + encodeURIComponent('[1,2]')), null);
+    assert.equal(parseTuningOverride('/api/forecast?tu=42'), null);
+  });
+
+  it('returns an empty map for tu={} (meaning: every threshold at default)', () => {
+    assert.deepEqual(parseTuningOverride('/api/forecast?tu=' + encodeURIComponent('{}')), {});
+  });
+
+  it('extracts known numeric tuning keys', () => {
+    const url = '/api/forecast?tu=' + encodeURIComponent(JSON.stringify({ geT: 13, ehE: 8 }));
+    assert.deepEqual(parseTuningOverride(url), { geT: 13, ehE: 8 });
+  });
+
+  it('clamps out-of-range values to TUNING_RANGES', () => {
+    const url = '/api/forecast?tu=' + encodeURIComponent(JSON.stringify({ geT: 999, ehE: -5 }));
+    // geT range 0–25, ehE range 0–20.
+    assert.deepEqual(parseTuningOverride(url), { geT: 25, ehE: 0 });
+  });
+
+  it('drops unknown keys and non-numeric values', () => {
+    const url = '/api/forecast?tu=' + encodeURIComponent(JSON.stringify({
+      geT: 12, bogus: 5, gxT: 'warm', ehE: null,
+    }));
+    assert.deepEqual(parseTuningOverride(url), { geT: 12 });
+  });
+});


### PR DESCRIPTION
## Summary

Adds a forecast preview to the device view's **Tuning thresholds** section. As you edit a threshold, it recomputes a 48-hour projection live so you can see the effect before pushing it to the controller.

- **Server**: both forecast engines (physics and ML) accept an optional `?tu=<json>` query parameter — a sparse tuning-threshold override, clamped to `TUNING_RANGES`. When present, the engine recomputes with those thresholds instead of the live device-config tuning. The override response is never cached, so a what-if preview cannot poison the live `/api/forecast`. Shared parser in `server/lib/forecast/tuning-override.js`.
- **Client**: the preview fetches `/api/forecast` twice — a dashed baseline (live device-config tuning, "saved on the controller") and a solid line recomputed with the entered form values via `?tu=`. It runs on the real FMI weather + fitted thermal coefficients (or the ML model, matching the engine selected in Settings), seeded server-side from current sensor readings. Plots Tank avg / Greenhouse / Outdoor over 48 h. Registered as a sync source so it refreshes on resume/focus/periodic resync.
- `forecast-handler.js` kept net-zero on line count to stay within its 600-line hard cap.

## Test plan

- [x] `npm run lint` / `npm run knip` / `check:file-size --strict` — clean
- [x] Unit suite — `tests/tuning-override.test.js` (parser), `tests/forecast-api.test.js` (physics `?tu=` override + clamping + cache isolation), `tests/ml-forecast-handler.test.js` (ML `?tu=` override + cache isolation)
- [x] Frontend Playwright — `tests/frontend/tuning-forecast.spec.js`: renders the graph on the device view; editing a threshold re-fetches with the `?tu=` override and the canvas changes
- [x] Full frontend + e2e suites pass; `tuning-forecast.js` at 97.8% coverage

https://claude.ai/code/session_01AF6GH2JJUXzsvpKV8ctzuU

---
_Generated by [Claude Code](https://claude.ai/code/session_01AF6GH2JJUXzsvpKV8ctzuU)_