### PR TITLE
Dual-knob sliders for greenhouse + emergency heat thresholds

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -682,6 +682,9 @@
           </div>
           <div id="tuning-forecast-container" style="position:relative;">
             <canvas id="tuning-forecast-chart" style="width:100%;height:220px;display:block;"></canvas>
+            <div class="forecast-loading" id="tuning-forecast-loading" hidden aria-live="polite" aria-busy="true">
+              <div class="forecast-loading-spinner" role="status" aria-label="Computing forecast"></div>
+            </div>
             <div class="graph-inspector" id="tuning-forecast-inspector">
               <div class="graph-inspector-time" id="tfi-time"></div>
               <div class="graph-inspector-row"><span class="graph-inspector-dot" style="background:#e9c349;"></span><span>Tank avg</span><span class="graph-inspector-val" id="tfi-tank"></span></div>
@@ -701,15 +704,15 @@
             <span><span style="display:inline-block;width:10px;height:10px;border-radius:2px;background:#e9c349;vertical-align:middle;margin-right:4px;"></span>Heating</span>
             <span><span style="display:inline-block;width:10px;height:10px;border-radius:2px;background:#ff7043;vertical-align:middle;margin-right:4px;"></span>Emergency</span>
           </div>
-          <div id="tuning-forecast-status" style="font-size:11px;color:var(--on-surface-variant);margin-top:6px;"></div>
+          <div id="tuning-forecast-status" style="font-size:11px;color:var(--on-surface-variant);margin-top:6px;min-height:1.4em;"></div>
 
           <h4 style="margin:24px 0 4px;font-family:'Newsreader',Georgia,serif;font-style:italic;color:var(--on-surface);">Greenhouse heating thresholds.</h4>
           <p style="font-size:12px;color:var(--on-surface-variant);margin:0 0 12px;">Drag the knobs to set when tank-fed greenhouse heating starts (lower knob) and stops (upper knob). The forecast above recomputes live.</p>
-          <div id="dc-greenhouse-heat-slider" class="temp-dual-slider" data-lo-key="geT" data-hi-key="gxT" data-lo-label="Heat enter" data-hi-label="Heat exit"></div>
+          <div id="dc-greenhouse-heat-slider" class="temp-dual-slider" data-lo-key="geT" data-hi-key="gxT" data-lo-label="Heat enter" data-hi-label="Heat exit" data-slider-min="5" data-slider-max="20"></div>
 
           <h4 style="margin:20px 0 4px;font-family:'Newsreader',Georgia,serif;font-style:italic;color:var(--on-surface);">Emergency heater thresholds.</h4>
           <p style="font-size:12px;color:var(--on-surface-variant);margin:0 0 12px;">Drag the knobs to set when the electric space heater fires (lower knob) and stops (upper knob).</p>
-          <div id="dc-emergency-heat-slider" class="temp-dual-slider" data-lo-key="ehE" data-hi-key="ehX" data-lo-label="Heater enter" data-hi-label="Heater exit"></div>
+          <div id="dc-emergency-heat-slider" class="temp-dual-slider" data-lo-key="ehE" data-hi-key="ehX" data-lo-label="Heater enter" data-hi-label="Heater exit" data-slider-min="5" data-slider-max="20"></div>
 
           <div style="margin-top:24px;display:flex;gap:12px;align-items:center;">
             <button class="primary" id="dc-save">Save &amp; Push to Device</button>

--- a/playground/index.html
+++ b/playground/index.html
@@ -692,9 +692,9 @@
             </div>
             <div class="graph-crosshair" id="tuning-forecast-crosshair"></div>
           </div>
-          <div id="tuning-forecast-legend" style="display:flex;flex-wrap:wrap;gap:12px;margin-top:8px;font-size:11px;color:var(--on-surface-variant);">
-            <span><span style="display:inline-block;width:10px;height:10px;border-radius:2px;background:#e9c349;vertical-align:middle;margin-right:4px;"></span>Tank avg</span>
-            <span><span style="display:inline-block;width:10px;height:10px;border-radius:2px;background:#69d0c5;vertical-align:middle;margin-right:4px;"></span>Greenhouse</span>
+          <div id="tuning-forecast-legend" style="display:flex;flex-wrap:wrap;gap:8px 12px;margin-top:8px;font-size:11px;color:var(--on-surface-variant);">
+            <span><span style="display:inline-block;width:10px;height:10px;border-radius:2px;background:#e9c349;vertical-align:middle;margin-right:4px;"></span>Tank avg <span class="forecast-legend-range" id="tfl-tank-range"></span></span>
+            <span><span style="display:inline-block;width:10px;height:10px;border-radius:2px;background:#69d0c5;vertical-align:middle;margin-right:4px;"></span>Greenhouse <span class="forecast-legend-range" id="tfl-gh-range"></span></span>
             <span><span style="display:inline-block;width:10px;height:10px;border-radius:2px;background:#42a5f5;vertical-align:middle;margin-right:4px;"></span>Outdoor</span>
             <span style="opacity:0.5;">|</span>
             <span><span style="display:inline-block;width:10px;height:10px;border-radius:2px;background:#ee7d77;vertical-align:middle;margin-right:4px;"></span>Charging</span>
@@ -702,6 +702,14 @@
             <span><span style="display:inline-block;width:10px;height:10px;border-radius:2px;background:#ff7043;vertical-align:middle;margin-right:4px;"></span>Emergency</span>
           </div>
           <div id="tuning-forecast-status" style="font-size:11px;color:var(--on-surface-variant);margin-top:6px;"></div>
+
+          <h4 style="margin:24px 0 4px;font-family:'Newsreader',Georgia,serif;font-style:italic;color:var(--on-surface);">Greenhouse heating thresholds.</h4>
+          <p style="font-size:12px;color:var(--on-surface-variant);margin:0 0 12px;">Drag the knobs to set when tank-fed greenhouse heating starts (lower knob) and stops (upper knob). The forecast above recomputes live.</p>
+          <div id="dc-greenhouse-heat-slider" class="temp-dual-slider" data-lo-key="geT" data-hi-key="gxT" data-lo-label="Heat enter" data-hi-label="Heat exit"></div>
+
+          <h4 style="margin:20px 0 4px;font-family:'Newsreader',Georgia,serif;font-style:italic;color:var(--on-surface);">Emergency heater thresholds.</h4>
+          <p style="font-size:12px;color:var(--on-surface-variant);margin:0 0 12px;">Drag the knobs to set when the electric space heater fires (lower knob) and stops (upper knob).</p>
+          <div id="dc-emergency-heat-slider" class="temp-dual-slider" data-lo-key="ehE" data-hi-key="ehX" data-lo-label="Heater enter" data-hi-label="Heater exit"></div>
 
           <div style="margin-top:24px;display:flex;gap:12px;align-items:center;">
             <button class="primary" id="dc-save">Save &amp; Push to Device</button>

--- a/playground/js/main/device-config.js
+++ b/playground/js/main/device-config.js
@@ -275,13 +275,18 @@ function initDualTemperatureSlider(containerId) {
   const hiHidden = container.querySelector('#dc-tu-' + hiKey);
 
   function clamp(v, lo, hi) { return Math.max(lo, Math.min(hi, v)); }
-  function pct(v) { return ((v - sMin) / (sMax - sMin)) * 100; }
+  function frac(v) { return (v - sMin) / (sMax - sMin); }
 
+  // 14 px thumb-radius inset on each side of the rail — the fill bar
+  // lives in the same coordinate space as the rail and the thumb
+  // centers, so they all align at every value.
   function paint() {
     const lo = Number(loRange.value);
     const hi = Number(hiRange.value);
-    fill.style.left = pct(lo) + '%';
-    fill.style.width = Math.max(0, pct(hi) - pct(lo)) + '%';
+    const loF = frac(lo);
+    const widthF = Math.max(0, frac(hi) - loF);
+    fill.style.left = 'calc(14px + ' + loF + ' * (100% - 28px))';
+    fill.style.width = 'calc(' + widthF + ' * (100% - 28px))';
     const loRaw = loHidden.value;
     const hiRaw = hiHidden.value;
     const loDefault = loRaw === '';
@@ -357,8 +362,9 @@ function initDualTemperatureSlider(containerId) {
     const r = wrap.getBoundingClientRect();
     if (r.width <= 0) return;
     const px = e.clientX - r.left;
-    const loX = (pct(Number(loRange.value)) / 100) * r.width;
-    const hiX = (pct(Number(hiRange.value)) / 100) * r.width;
+    // Thumb X centers live in the rail's 14 px-inset coordinate space.
+    const loX = 14 + frac(Number(loRange.value)) * (r.width - 28);
+    const hiX = 14 + frac(Number(hiRange.value)) * (r.width - 28);
     if (Math.abs(px - loX) < Math.abs(px - hiX)) {
       loRange.style.zIndex = '4'; hiRange.style.zIndex = '3';
     } else {

--- a/playground/js/main/device-config.js
+++ b/playground/js/main/device-config.js
@@ -217,10 +217,21 @@ function initDualTemperatureSlider(containerId) {
   const hiField = TUNING_FIELDS.find((f) => f.key === hiKey);
   if (!loField || !hiField) return;
 
-  const sMin = Math.min(loField.min, hiField.min);
-  const sMax = Math.max(loField.max, hiField.max);
+  // Slider range — by default the union of the two field ranges, but
+  // each container may narrow it via data-slider-min / data-slider-max
+  // (the typical operator-tweak range, not the full hardware range).
+  const sMin = container.dataset.sliderMin !== undefined
+    ? Number(container.dataset.sliderMin) : Math.min(loField.min, hiField.min);
+  const sMax = container.dataset.sliderMax !== undefined
+    ? Number(container.dataset.sliderMax) : Math.max(loField.max, hiField.max);
   const step = Math.min(loField.step, hiField.step);
   const minGap = step;
+  // Effective per-knob bounds: intersect the field's own [min, max]
+  // with the slider's visual [sMin, sMax]. This is what clamp() uses.
+  const loLo = Math.max(sMin, loField.min);
+  const loHi = Math.min(sMax, loField.max);
+  const hiLo = Math.max(sMin, hiField.min);
+  const hiHi = Math.min(sMax, hiField.max);
   const loLabel = container.dataset.loLabel || loField.label;
   const hiLabel = container.dataset.hiLabel || hiField.label;
 
@@ -293,23 +304,46 @@ function initDualTemperatureSlider(containerId) {
     paint();
   }
 
+  // Push behavior: when one knob invades the other's space, shove the
+  // other knob along instead of clamping the moving one. Final values
+  // are kept within their own field bounds AND the slider's visual
+  // range. If the receiving knob hits its ceiling/floor, the moving
+  // knob clamps so the one-step gap is preserved.
   function commitLo() {
-    const hi = Number(hiRange.value);
-    let lo = Number(loRange.value);
-    lo = clamp(lo, loField.min, Math.min(loField.max, hi - minGap));
+    let lo = clamp(Number(loRange.value), loLo, loHi);
+    let hi = Number(hiRange.value);
+    const origHi = hi;
+    if (lo > hi - minGap) {
+      hi = clamp(lo + minGap, hiLo, hiHi);
+      if (lo > hi - minGap) lo = hi - minGap;
+    }
     loRange.value = String(lo);
+    hiRange.value = String(hi);
     loHidden.value = String(lo);
     loHidden.dispatchEvent(new Event('input', { bubbles: true }));
+    if (hi !== origHi) {
+      hiHidden.value = String(hi);
+      hiHidden.dispatchEvent(new Event('input', { bubbles: true }));
+    }
     paint();
   }
 
   function commitHi() {
-    const lo = Number(loRange.value);
-    let hi = Number(hiRange.value);
-    hi = clamp(hi, Math.max(hiField.min, lo + minGap), hiField.max);
+    let hi = clamp(Number(hiRange.value), hiLo, hiHi);
+    let lo = Number(loRange.value);
+    const origLo = lo;
+    if (hi < lo + minGap) {
+      lo = clamp(hi - minGap, loLo, loHi);
+      if (hi < lo + minGap) hi = lo + minGap;
+    }
+    loRange.value = String(lo);
     hiRange.value = String(hi);
     hiHidden.value = String(hi);
     hiHidden.dispatchEvent(new Event('input', { bubbles: true }));
+    if (lo !== origLo) {
+      loHidden.value = String(lo);
+      loHidden.dispatchEvent(new Event('input', { bubbles: true }));
+    }
     paint();
   }
 

--- a/playground/js/main/device-config.js
+++ b/playground/js/main/device-config.js
@@ -25,6 +25,11 @@ const TUNING_FIELDS = [
   { key: 'ohT', label: 'Overheat drain (°C)',            defaultValue: 95, min: 70, max: 100, step: 1,   group: 'Safety',             help: 'Drain collectors if circulation cannot keep collector below this.' },
 ];
 
+// Keys handled by the dual-knob sliders under the forecast preview
+// instead of the regular Tuning thresholds list above.
+const SLIDER_KEYS = new Set(['geT', 'gxT', 'ehE', 'ehX']);
+const SLIDER_CONTAINERS = ['dc-greenhouse-heat-slider', 'dc-emergency-heat-slider'];
+
 // Last-known wb (mode-ban map). Updated on form load and via the
 // 'wb-changed' DOM event dispatched by renderModeEnablement, which
 // fires on initial render AND on every WS-driven mode-enablement
@@ -56,7 +61,14 @@ export function initDeviceConfig() {
 
   // Render tuning inputs once at boot — values populated each load.
   renderTuningInputs();
+  // The Greenhouse-heating (geT/gxT) and Emergency-heater (ehE/ehX)
+  // pairs live under the forecast preview as dual-knob sliders. Their
+  // hidden number inputs are created here so the rest of this module
+  // can keep reading dc-tu-<key>.value without caring about the UI.
+  SLIDER_CONTAINERS.forEach(initDualTemperatureSlider);
   // Each tuning input drives the forecast preview live as the user types.
+  // Includes the hidden slider inputs — the slider dispatches 'input'
+  // events on them after every drag, so the listener still fires.
   TUNING_FIELDS.forEach((f) => {
     const input = document.getElementById('dc-tu-' + f.key);
     if (input) input.addEventListener('input', pushEnteredTuning);
@@ -68,6 +80,7 @@ export function initDeviceConfig() {
         const input = document.getElementById('dc-tu-' + f.key);
         if (input) input.value = '';
       });
+      syncSliderUI();
       pushEnteredTuning();
     });
   }
@@ -146,6 +159,9 @@ function populateDeviceForm(cfg) {
     if (!input) return;
     input.value = (typeof tu[f.key] === 'number') ? String(tu[f.key]) : '';
   });
+  // Hidden slider inputs were just rewritten — push the new values into
+  // the slider thumb positions before refreshing the forecast preview.
+  syncSliderUI();
   // Feed the forecast preview with the freshly-populated form values.
   // The dashed baseline is the live /api/forecast (saved config), so
   // it needs no client-side input.
@@ -160,10 +176,13 @@ function renderTuningInputs() {
   const list = document.getElementById('dc-tuning-list');
   if (!list) return;
   // Group fields under their group heading. Iteration order in
-  // TUNING_FIELDS already matches the desired UI order.
+  // TUNING_FIELDS already matches the desired UI order. Fields handled
+  // by a dual-knob slider are skipped here — their hidden inputs live
+  // inside the slider container.
   let html = '';
   let lastGroup = null;
   TUNING_FIELDS.forEach((f) => {
+    if (SLIDER_KEYS.has(f.key)) return;
     if (f.group !== lastGroup) {
       html += '<div style="font-size:11px;font-weight:600;color:var(--on-surface-variant);margin:12px 0 4px;text-transform:uppercase;letter-spacing:0.5px;">'
         + escapeText(f.group) + '</div>';
@@ -179,6 +198,155 @@ function renderTuningInputs() {
       + '<p style="font-size:11px;color:var(--on-surface-variant);margin:-4px 0 4px;">' + escapeText(f.help) + '</p>';
   });
   list.innerHTML = html;
+}
+
+// Dual-knob range slider for a pair of related tuning thresholds
+// (enter/exit). The visible thumbs drive hidden number inputs that
+// share IDs with the rest of the tuning form, so every other code
+// path (read, save, reset) keeps working untouched.
+//
+// Each thumb is clamped to its own field's [min, max] *and* kept at
+// least one step away from the other thumb, mirroring the server-side
+// invariant gxT > geT (and ehX > ehE).
+function initDualTemperatureSlider(containerId) {
+  const container = document.getElementById(containerId);
+  if (!container) return;
+  const loKey = container.dataset.loKey;
+  const hiKey = container.dataset.hiKey;
+  const loField = TUNING_FIELDS.find((f) => f.key === loKey);
+  const hiField = TUNING_FIELDS.find((f) => f.key === hiKey);
+  if (!loField || !hiField) return;
+
+  const sMin = Math.min(loField.min, hiField.min);
+  const sMax = Math.max(loField.max, hiField.max);
+  const step = Math.min(loField.step, hiField.step);
+  const minGap = step;
+  const loLabel = container.dataset.loLabel || loField.label;
+  const hiLabel = container.dataset.hiLabel || hiField.label;
+
+  container.innerHTML = ''
+    + '<div class="temp-dual-slider-readouts">'
+    +   '<div class="temp-dual-slider-readout">'
+    +     '<span class="temp-dual-slider-readout-label">' + escapeText(loLabel) + '</span>'
+    +     '<span class="temp-dual-slider-readout-value" data-role="lo-readout">—</span>'
+    +   '</div>'
+    +   '<div class="temp-dual-slider-readout temp-dual-slider-readout--right">'
+    +     '<span class="temp-dual-slider-readout-label">' + escapeText(hiLabel) + '</span>'
+    +     '<span class="temp-dual-slider-readout-value" data-role="hi-readout">—</span>'
+    +   '</div>'
+    + '</div>'
+    + '<div class="temp-dual-slider-track-wrap" data-role="track-wrap">'
+    +   '<div class="temp-dual-slider-track"></div>'
+    +   '<div class="temp-dual-slider-range" data-role="fill"></div>'
+    +   '<input type="range" class="temp-dual-slider-input temp-dual-slider-input--lo"'
+    +     ' min="' + sMin + '" max="' + sMax + '" step="' + step + '"'
+    +     ' value="' + loField.defaultValue + '"'
+    +     ' aria-label="' + escapeText(loLabel) + '" data-role="lo-range">'
+    +   '<input type="range" class="temp-dual-slider-input temp-dual-slider-input--hi"'
+    +     ' min="' + sMin + '" max="' + sMax + '" step="' + step + '"'
+    +     ' value="' + hiField.defaultValue + '"'
+    +     ' aria-label="' + escapeText(hiLabel) + '" data-role="hi-range">'
+    + '</div>'
+    + '<div class="temp-dual-slider-scale">'
+    +   '<span>' + sMin + '°C</span>'
+    +   '<span>' + sMax + '°C</span>'
+    + '</div>'
+    + '<input type="hidden" id="dc-tu-' + loKey + '" data-tu-key="' + loKey + '">'
+    + '<input type="hidden" id="dc-tu-' + hiKey + '" data-tu-key="' + hiKey + '">';
+
+  const loRange = container.querySelector('[data-role="lo-range"]');
+  const hiRange = container.querySelector('[data-role="hi-range"]');
+  const loReadout = container.querySelector('[data-role="lo-readout"]');
+  const hiReadout = container.querySelector('[data-role="hi-readout"]');
+  const fill = container.querySelector('[data-role="fill"]');
+  const wrap = container.querySelector('[data-role="track-wrap"]');
+  const loHidden = container.querySelector('#dc-tu-' + loKey);
+  const hiHidden = container.querySelector('#dc-tu-' + hiKey);
+
+  function clamp(v, lo, hi) { return Math.max(lo, Math.min(hi, v)); }
+  function pct(v) { return ((v - sMin) / (sMax - sMin)) * 100; }
+
+  function paint() {
+    const lo = Number(loRange.value);
+    const hi = Number(hiRange.value);
+    fill.style.left = pct(lo) + '%';
+    fill.style.width = Math.max(0, pct(hi) - pct(lo)) + '%';
+    const loRaw = loHidden.value;
+    const hiRaw = hiHidden.value;
+    const loDefault = loRaw === '';
+    const hiDefault = hiRaw === '';
+    const loShown = loDefault ? loField.defaultValue : Number(loRaw);
+    const hiShown = hiDefault ? hiField.defaultValue : Number(hiRaw);
+    loReadout.textContent = formatTemp(loShown);
+    hiReadout.textContent = formatTemp(hiShown);
+    loReadout.classList.toggle('temp-dual-slider-readout-value--default', loDefault);
+    hiReadout.classList.toggle('temp-dual-slider-readout-value--default', hiDefault);
+  }
+
+  function syncFromHidden() {
+    const loRaw = loHidden.value;
+    const hiRaw = hiHidden.value;
+    const loVal = loRaw === '' ? loField.defaultValue : Number(loRaw);
+    const hiVal = hiRaw === '' ? hiField.defaultValue : Number(hiRaw);
+    loRange.value = String(loVal);
+    hiRange.value = String(hiVal);
+    paint();
+  }
+
+  function commitLo() {
+    const hi = Number(hiRange.value);
+    let lo = Number(loRange.value);
+    lo = clamp(lo, loField.min, Math.min(loField.max, hi - minGap));
+    loRange.value = String(lo);
+    loHidden.value = String(lo);
+    loHidden.dispatchEvent(new Event('input', { bubbles: true }));
+    paint();
+  }
+
+  function commitHi() {
+    const lo = Number(loRange.value);
+    let hi = Number(hiRange.value);
+    hi = clamp(hi, Math.max(hiField.min, lo + minGap), hiField.max);
+    hiRange.value = String(hi);
+    hiHidden.value = String(hi);
+    hiHidden.dispatchEvent(new Event('input', { bubbles: true }));
+    paint();
+  }
+
+  loRange.addEventListener('input', commitLo);
+  hiRange.addEventListener('input', commitHi);
+
+  // When two thumbs overlap the upper one covers the lower one. Before
+  // a touch lands, lift whichever thumb is closer to the touch point
+  // above the other so either can always be grabbed.
+  wrap.addEventListener('pointerdown', (e) => {
+    const r = wrap.getBoundingClientRect();
+    if (r.width <= 0) return;
+    const px = e.clientX - r.left;
+    const loX = (pct(Number(loRange.value)) / 100) * r.width;
+    const hiX = (pct(Number(hiRange.value)) / 100) * r.width;
+    if (Math.abs(px - loX) < Math.abs(px - hiX)) {
+      loRange.style.zIndex = '4'; hiRange.style.zIndex = '3';
+    } else {
+      hiRange.style.zIndex = '4'; loRange.style.zIndex = '3';
+    }
+  });
+
+  container._syncFromHidden = syncFromHidden;
+  syncFromHidden();
+}
+
+function formatTemp(v) {
+  if (typeof v !== 'number' || !Number.isFinite(v)) return '—';
+  const s = (v === Math.floor(v)) ? v.toFixed(0) : v.toFixed(1);
+  return s + '°';
+}
+
+function syncSliderUI() {
+  SLIDER_CONTAINERS.forEach((id) => {
+    const c = document.getElementById(id);
+    if (c && typeof c._syncFromHidden === 'function') c._syncFromHidden();
+  });
 }
 
 function escapeText(s) {
@@ -269,6 +437,7 @@ function saveDeviceConfig() {
         if (!input) return;
         input.value = (typeof ttu[f.key] === 'number') ? String(ttu[f.key]) : '';
       });
+      syncSliderUI();
       // The saved values are now the live forecast's baseline; refresh
       // the entered trajectory from the (post-clamp) form.
       pushEnteredTuning();

--- a/playground/js/main/tuning-forecast.js
+++ b/playground/js/main/tuning-forecast.js
@@ -121,19 +121,28 @@ function render() {
   _abort = new AbortController();
   const signal = _abort.signal;
   hideInspector();
-  setStatus(statusEl, 'Computing forecast…');
+  showLoading(true);
+  setStatus(statusEl, '');
 
   fetchForecasts(signal)
     .then((data) => {
       if (signal.aborted) return;
+      showLoading(false);
       drawForecasts(data);
     })
     .catch((err) => {
       if (signal.aborted || (err && err.name === 'AbortError')) return;
+      showLoading(false);
       _chart = null;
       clearCanvas(canvas);
+      updateLegendRanges(null, null);
       setStatus(statusEl, 'Forecast unavailable: ' + err.message);
     });
+}
+
+function showLoading(on) {
+  const el = document.getElementById('tuning-forecast-loading');
+  if (el) el.hidden = !on;
 }
 
 // Build the /api/forecast URL — engine-aware, with an optional `tu`

--- a/playground/js/main/tuning-forecast.js
+++ b/playground/js/main/tuning-forecast.js
@@ -244,12 +244,37 @@ function drawForecasts(data) {
     _chart = null;
     hideInspector();
     clearCanvas(canvas);
+    updateLegendRanges(null, null);
     setStatus(statusEl,
       'No forecast data yet — weather forecast not available for this device.');
     return;
   }
   setStatus(statusEl, '');
+  updateLegendRanges(seriesRange(series.enteredTank), seriesRange(series.enteredGh));
   draw(canvas, series, entered);
+}
+
+// Min/max of a [timeMs, value] series, or null if empty.
+function seriesRange(pts) {
+  if (!pts || pts.length === 0) return null;
+  let min = Infinity;
+  let max = -Infinity;
+  for (let i = 0; i < pts.length; i++) {
+    const v = pts[i][1];
+    if (v < min) min = v;
+    if (v > max) max = v;
+  }
+  if (!isFinite(min)) return null;
+  return { min, max };
+}
+
+function updateLegendRanges(tank, gh) {
+  setText('tfl-tank-range', tank ? rangeText(tank) : '');
+  setText('tfl-gh-range', gh ? rangeText(gh) : '');
+}
+
+function rangeText(r) {
+  return r.min.toFixed(1) + '°…' + r.max.toFixed(1) + '°';
 }
 
 function draw(canvas, series, enteredResp) {

--- a/playground/public/style.css
+++ b/playground/public/style.css
@@ -2051,15 +2051,19 @@ button.primary.disabled {
 .temp-dual-slider-track-wrap {
   position: relative;
   height: 44px;
-  margin: 0 14px;
   touch-action: pan-y;
 }
 
+/* The visual rail is inset by one thumb-radius (14 px) on each
+ * side. The native range input spans the wrap edge-to-edge, so the
+ * thumb center sits at exactly the rail's start at value=min and at
+ * the rail's end at value=max — no overhang trick, no cumulative
+ * x-axis drift at higher values. */
 .temp-dual-slider-track {
   position: absolute;
   top: 50%;
-  left: 0;
-  right: 0;
+  left: 14px;
+  right: 14px;
   height: 6px;
   margin-top: -3px;
   background: var(--surface-container);
@@ -2076,14 +2080,17 @@ button.primary.disabled {
   background: var(--secondary);
   border-radius: 3px;
   pointer-events: none;
+  /* left + width set inline via JS using calc(14px + frac * (100% - 28px))
+   * so the fill shares the rail's 14 px insets and aligns with the
+   * thumb centers at every position. */
 }
 
 .temp-dual-slider-input {
   position: absolute;
   top: 0;
-  left: -14px;
-  right: -14px;
-  width: calc(100% + 28px);
+  left: 0;
+  right: 0;
+  width: 100%;
   height: 100%;
   margin: 0;
   padding: 0;
@@ -2160,7 +2167,9 @@ button.primary.disabled {
 .temp-dual-slider-scale {
   display: flex;
   justify-content: space-between;
-  padding: 0;
+  /* Match the rail's 14 px insets so each end label sits beneath
+   * the corresponding thumb extreme. */
+  padding: 0 14px;
   margin-top: 4px;
   font-size: 11px;
   color: var(--on-surface-variant);

--- a/playground/public/style.css
+++ b/playground/public/style.css
@@ -1999,6 +1999,183 @@ button.primary.disabled {
   height: 16px;
 }
 
+/* ── Dual-knob temperature slider (device view, under forecast preview) ── */
+
+.temp-dual-slider {
+  padding: 8px 0 12px;
+}
+
+.temp-dual-slider-readouts {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 12px;
+  margin-bottom: 14px;
+}
+
+.temp-dual-slider-readout {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.temp-dual-slider-readout--right {
+  align-items: flex-end;
+  text-align: right;
+}
+
+.temp-dual-slider-readout-label {
+  font-family: 'Manrope', sans-serif;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--on-surface-variant);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.temp-dual-slider-readout-value {
+  font-family: 'Manrope', sans-serif;
+  font-size: 24px;
+  font-weight: 600;
+  color: var(--secondary);
+  font-variant-numeric: tabular-nums;
+  line-height: 1.1;
+}
+
+.temp-dual-slider-readout-value--default {
+  color: var(--on-surface-variant);
+  font-weight: 500;
+}
+
+.temp-dual-slider-track-wrap {
+  position: relative;
+  height: 44px;
+  margin: 0 14px;
+  touch-action: pan-y;
+}
+
+.temp-dual-slider-track {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  right: 0;
+  height: 6px;
+  margin-top: -3px;
+  background: var(--surface-container);
+  border: 1px solid var(--outline-variant);
+  border-radius: 3px;
+  pointer-events: none;
+}
+
+.temp-dual-slider-range {
+  position: absolute;
+  top: 50%;
+  height: 6px;
+  margin-top: -3px;
+  background: var(--secondary);
+  border-radius: 3px;
+  pointer-events: none;
+}
+
+.temp-dual-slider-input {
+  position: absolute;
+  top: 0;
+  left: -14px;
+  right: -14px;
+  width: calc(100% + 28px);
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  background: transparent;
+  appearance: none;
+  -webkit-appearance: none;
+  pointer-events: none;
+}
+
+.temp-dual-slider-input--lo { z-index: 3; }
+.temp-dual-slider-input--hi { z-index: 4; }
+
+.temp-dual-slider-input::-webkit-slider-runnable-track {
+  background: transparent;
+  border: 0;
+  height: 6px;
+}
+
+.temp-dual-slider-input::-moz-range-track {
+  background: transparent;
+  border: 0;
+  height: 6px;
+}
+
+.temp-dual-slider-input::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: var(--secondary);
+  border: 2px solid var(--bg-card);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.45);
+  cursor: grab;
+  pointer-events: auto;
+  margin-top: -11px;
+  transition: transform 0.1s ease;
+}
+
+.temp-dual-slider-input::-moz-range-thumb {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: var(--secondary);
+  border: 2px solid var(--bg-card);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.45);
+  cursor: grab;
+  pointer-events: auto;
+  transition: transform 0.1s ease;
+}
+
+.temp-dual-slider-input:active::-webkit-slider-thumb {
+  transform: scale(1.18);
+  cursor: grabbing;
+}
+
+.temp-dual-slider-input:active::-moz-range-thumb {
+  transform: scale(1.18);
+  cursor: grabbing;
+}
+
+.temp-dual-slider-input:focus { outline: none; }
+
+.temp-dual-slider-input:focus-visible::-webkit-slider-thumb {
+  outline: 2px solid var(--secondary);
+  outline-offset: 3px;
+}
+
+.temp-dual-slider-input:focus-visible::-moz-range-thumb {
+  outline: 2px solid var(--secondary);
+  outline-offset: 3px;
+}
+
+.temp-dual-slider-scale {
+  display: flex;
+  justify-content: space-between;
+  padding: 0;
+  margin-top: 4px;
+  font-size: 11px;
+  color: var(--on-surface-variant);
+  font-variant-numeric: tabular-nums;
+}
+
+/* Forecast-preview legend min/max badge (Tank avg + Greenhouse). */
+.forecast-legend-range {
+  color: var(--on-surface);
+  font-variant-numeric: tabular-nums;
+  margin-left: 2px;
+}
+
+.forecast-legend-range:empty { display: none; }
+
 /* ── Relay Toggle Board ── */
 
 .relay-board {

--- a/playground/public/style.css
+++ b/playground/public/style.css
@@ -2176,6 +2176,44 @@ button.primary.disabled {
 
 .forecast-legend-range:empty { display: none; }
 
+/* Loading overlay on the forecast-preview canvas. Absolutely
+ * positioned over the existing 220 px chart so toggling it never
+ * changes the surrounding layout — it covers the canvas with a
+ * blurred backdrop + centered spinner while the forecast fetch is
+ * in flight, then unhides the rendered chart underneath. */
+.forecast-loading {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(12, 14, 18, 0.45);
+  backdrop-filter: blur(2px);
+  -webkit-backdrop-filter: blur(2px);
+  border-radius: 4px;
+  pointer-events: none;
+  z-index: 5;
+}
+
+.forecast-loading[hidden] { display: none; }
+
+.forecast-loading-spinner {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: 3px solid var(--outline-variant);
+  border-top-color: var(--secondary);
+  animation: forecast-loading-spin 0.9s linear infinite;
+}
+
+@keyframes forecast-loading-spin {
+  to { transform: rotate(360deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .forecast-loading-spinner { animation-duration: 2.4s; }
+}
+
 /* ── Relay Toggle Board ── */
 
 .relay-board {

--- a/tests/frontend/device-config.spec.js
+++ b/tests/frontend/device-config.spec.js
@@ -859,6 +859,30 @@ test.describe('Device config UI', () => {
     await expect(page.locator('#dc-tu-geT')).toHaveValue('6.5');
   });
 
+  test('slider fill bar aligns with the rail at every value (no x-axis drift)', async ({ page }) => {
+    // Regression: with the original overhang layout the fill bar
+    // (and the thumb centers) drifted left of the rail more and more
+    // at higher values, leaving the value=max thumb visibly short of
+    // the right end. The fix moves both into the same 14 px-inset
+    // coordinate space; this test pins the right edge to the rail's
+    // right edge (within 1 px) at value=max, and the left edge to
+    // the rail's left edge at value=min.
+
+    await setupDeviceView(page, { tu: { geT: 5, gxT: 20 } });
+    await page.locator('#dc-greenhouse-heat-slider').scrollIntoViewIfNeeded();
+    await page.waitForTimeout(50);
+
+    const track = await page
+      .locator('#dc-greenhouse-heat-slider .temp-dual-slider-track')
+      .boundingBox();
+    const fill = await page
+      .locator('#dc-greenhouse-heat-slider .temp-dual-slider-range')
+      .boundingBox();
+
+    expect(Math.abs(fill.x - track.x)).toBeLessThan(1);
+    expect(Math.abs((fill.x + fill.width) - (track.x + track.width))).toBeLessThan(1);
+  });
+
   test('slider visual range is fixed at 5–20 °C with the scale labels matching', async ({ page }) => {
     await setupDeviceView(page);
 

--- a/tests/frontend/device-config.spec.js
+++ b/tests/frontend/device-config.spec.js
@@ -735,6 +735,113 @@ test.describe('Device config UI', () => {
     await expect(banner).toBeVisible();
   });
 
+  // ── Dual-knob temperature sliders ──
+  //
+  // The Greenhouse-heating (geT/gxT) and Emergency-heater (ehE/ehX)
+  // pairs are rendered as dual-knob range sliders under the Forecast
+  // preview, replacing the old number-input rows in the Tuning
+  // thresholds list. They drive hidden `dc-tu-<key>` inputs that the
+  // save handler still reads, so the wire format is unchanged.
+
+  test('dual sliders render under the forecast preview, not in the tuning list', async ({ page }) => {
+    await setupDeviceView(page, {
+      tu: { geT: 11, gxT: 14, ehE: 8, ehX: 13 },
+    });
+
+    // The two slider blocks render, each with two range inputs.
+    await expect(page.locator('#dc-greenhouse-heat-slider .temp-dual-slider-input--lo'))
+      .toBeVisible();
+    await expect(page.locator('#dc-greenhouse-heat-slider .temp-dual-slider-input--hi'))
+      .toBeVisible();
+    await expect(page.locator('#dc-emergency-heat-slider .temp-dual-slider-input--lo'))
+      .toBeVisible();
+    await expect(page.locator('#dc-emergency-heat-slider .temp-dual-slider-input--hi'))
+      .toBeVisible();
+
+    // The four slider keys are NOT rendered as regular rows in the
+    // tuning list — only their hidden inputs (inside the slider
+    // container) exist with those IDs.
+    for (const key of ['geT', 'gxT', 'ehE', 'ehX']) {
+      const inTuningList = await page.locator('#dc-tuning-list #dc-tu-' + key).count();
+      expect(inTuningList).toBe(0);
+    }
+
+    // Initial values from the saved config propagate to the sliders'
+    // range inputs and the readouts.
+    await expect(page.locator('#dc-greenhouse-heat-slider .temp-dual-slider-input--lo'))
+      .toHaveValue('11');
+    await expect(page.locator('#dc-greenhouse-heat-slider .temp-dual-slider-input--hi'))
+      .toHaveValue('14');
+    await expect(page.locator('#dc-emergency-heat-slider .temp-dual-slider-input--lo'))
+      .toHaveValue('8');
+    await expect(page.locator('#dc-emergency-heat-slider .temp-dual-slider-input--hi'))
+      .toHaveValue('13');
+  });
+
+  test('dragging a slider knob saves the new value to the device config', async ({ page }) => {
+    const { putRequests } = await setupDeviceView(page, {
+      tu: { geT: 10, gxT: 12 },
+    });
+
+    // Move the greenhouse heat-enter knob to 7. Range inputs cannot be
+    // .fill()'d in Playwright; drive the value + dispatch 'input'.
+    await page.evaluate(() => {
+      const lo = document.querySelector(
+        '#dc-greenhouse-heat-slider .temp-dual-slider-input--lo');
+      lo.value = '7';
+      lo.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+
+    // The hidden input picks up the new value immediately.
+    await expect(page.locator('#dc-tu-geT')).toHaveValue('7');
+
+    // Push to the device — the PUT carries geT=7 in tu.
+    await page.locator('#dc-save').click();
+    await expect.poll(() => putRequests.length, { timeout: 4000 }).toBeGreaterThan(0);
+    const last = putRequests[putRequests.length - 1];
+    expect(last.tu.geT).toBe(7);
+  });
+
+  test('reset clears slider overrides and the knobs fall back to firmware defaults', async ({ page }) => {
+    await setupDeviceView(page, {
+      tu: { geT: 7, gxT: 9, ehE: 6, ehX: 8 },
+    });
+
+    // Pre-condition: readouts show the override values, not the defaults.
+    const ghLoReadout = page.locator(
+      '#dc-greenhouse-heat-slider [data-role="lo-readout"]');
+    await expect(ghLoReadout).toHaveText('7°');
+    await expect(ghLoReadout).not.toHaveClass(/temp-dual-slider-readout-value--default/);
+
+    // Click "Reset all to firmware defaults".
+    await page.locator('#dc-tuning-reset').click();
+
+    // Hidden inputs are cleared, readouts fall back to the defaults
+    // (10° for geT) and pick up the "default" visual modifier.
+    await expect(page.locator('#dc-tu-geT')).toHaveValue('');
+    await expect(ghLoReadout).toHaveText('10°');
+    await expect(ghLoReadout).toHaveClass(/temp-dual-slider-readout-value--default/);
+  });
+
+  test('slider keeps the heat-exit knob at least one step above heat-enter', async ({ page }) => {
+    await setupDeviceView(page, {
+      tu: { geT: 10, gxT: 12 },
+    });
+
+    // Push the lower knob (geT) up past the upper knob (gxT=12). The
+    // commit logic must clamp lo to hi - 0.5 = 11.5, mirroring the
+    // server-side invariant gxT > geT.
+    await page.evaluate(() => {
+      const lo = document.querySelector(
+        '#dc-greenhouse-heat-slider .temp-dual-slider-input--lo');
+      lo.value = '20';
+      lo.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+
+    await expect(page.locator('#dc-tu-geT')).toHaveValue('11.5');
+    await expect(page.locator('#dc-tu-gxT')).toHaveValue('12');
+  });
+
   test('device view only visible in live mode', async ({ page }) => {
     await page.route('**/api/device-config', route => route.fulfill({
       status: 200, contentType: 'application/json',

--- a/tests/frontend/device-config.spec.js
+++ b/tests/frontend/device-config.spec.js
@@ -823,23 +823,58 @@ test.describe('Device config UI', () => {
     await expect(ghLoReadout).toHaveClass(/temp-dual-slider-readout-value--default/);
   });
 
-  test('slider keeps the heat-exit knob at least one step above heat-enter', async ({ page }) => {
+  test('dragging the lower knob past the upper knob pushes the upper one up', async ({ page }) => {
     await setupDeviceView(page, {
       tu: { geT: 10, gxT: 12 },
     });
 
-    // Push the lower knob (geT) up past the upper knob (gxT=12). The
-    // commit logic must clamp lo to hi - 0.5 = 11.5, mirroring the
-    // server-side invariant gxT > geT.
+    // Push the lower knob (geT) above the upper knob (gxT=12). The
+    // commit logic must shove gxT up so the one-step gap is preserved
+    // (server-side invariant gxT > geT). Target lo=15 leaves room
+    // below the 20 °C slider ceiling, so neither knob hits a wall.
     await page.evaluate(() => {
       const lo = document.querySelector(
         '#dc-greenhouse-heat-slider .temp-dual-slider-input--lo');
-      lo.value = '20';
+      lo.value = '15';
       lo.dispatchEvent(new Event('input', { bubbles: true }));
     });
 
-    await expect(page.locator('#dc-tu-geT')).toHaveValue('11.5');
-    await expect(page.locator('#dc-tu-gxT')).toHaveValue('12');
+    await expect(page.locator('#dc-tu-geT')).toHaveValue('15');
+    await expect(page.locator('#dc-tu-gxT')).toHaveValue('15.5');
+  });
+
+  test('dragging the upper knob below the lower knob pushes the lower one down', async ({ page }) => {
+    await setupDeviceView(page, {
+      tu: { geT: 10, gxT: 12 },
+    });
+
+    await page.evaluate(() => {
+      const hi = document.querySelector(
+        '#dc-greenhouse-heat-slider .temp-dual-slider-input--hi');
+      hi.value = '7';
+      hi.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+
+    await expect(page.locator('#dc-tu-gxT')).toHaveValue('7');
+    await expect(page.locator('#dc-tu-geT')).toHaveValue('6.5');
+  });
+
+  test('slider visual range is fixed at 5–20 °C with the scale labels matching', async ({ page }) => {
+    await setupDeviceView(page);
+
+    for (const containerId of ['#dc-greenhouse-heat-slider', '#dc-emergency-heat-slider']) {
+      await expect(page.locator(containerId + ' .temp-dual-slider-input--lo'))
+        .toHaveAttribute('min', '5');
+      await expect(page.locator(containerId + ' .temp-dual-slider-input--lo'))
+        .toHaveAttribute('max', '20');
+      await expect(page.locator(containerId + ' .temp-dual-slider-input--hi'))
+        .toHaveAttribute('min', '5');
+      await expect(page.locator(containerId + ' .temp-dual-slider-input--hi'))
+        .toHaveAttribute('max', '20');
+      const scale = page.locator(containerId + ' .temp-dual-slider-scale span');
+      await expect(scale.nth(0)).toHaveText('5°C');
+      await expect(scale.nth(1)).toHaveText('20°C');
+    }
   });
 
   test('device view only visible in live mode', async ({ page }) => {

--- a/tests/frontend/tuning-forecast.spec.js
+++ b/tests/frontend/tuning-forecast.spec.js
@@ -176,18 +176,40 @@ test.describe('Tuning forecast preview', () => {
     const before = await canvasFingerprint(page);
     const urlsBefore = forecastUrls.length;
 
-    // Raise the greenhouse-heating enter threshold — the what-if
-    // trajectory diverges from the saved-config baseline.
-    await page.locator('#dc-tu-geT').fill('22');
+    // Drop the greenhouse-heating enter threshold via the dual-knob
+    // slider's lower range input — the what-if trajectory diverges from
+    // the saved-config baseline. The slider drives the hidden #dc-tu-geT
+    // input and dispatches an 'input' event on it. Value (5) stays
+    // below the gxT firmware default (12) so the cross-knob clamp does
+    // not kick in.
+    await page.evaluate(() => {
+      const lo = document.querySelector(
+        '#dc-greenhouse-heat-slider .temp-dual-slider-input--lo');
+      lo.value = '5';
+      lo.dispatchEvent(new Event('input', { bubbles: true }));
+    });
 
     await expect.poll(
       async () => (await canvasFingerprint(page)).hash,
       { timeout: 5000 },
     ).not.toBe(before.hash);
 
-    // The recompute carried geT=22 in the override.
+    // The recompute carried geT=5 in the override.
     const newUrls = forecastUrls.slice(urlsBefore);
-    expect(newUrls.some(u => /tu=.*22/.test(decodeURIComponent(u)))).toBe(true);
+    expect(newUrls.some(u => /"geT":5\b/.test(decodeURIComponent(u)))).toBe(true);
+  });
+
+  test('legend shows the projected min/max for tank and greenhouse', async ({ page }) => {
+    await setupDeviceView(page);
+
+    await expect.poll(
+      async () => (await canvasFingerprint(page)).painted,
+      { timeout: 5000 },
+    ).toBeGreaterThan(200);
+
+    // Both badges are populated with a "min…max" range in °.
+    await expect(page.locator('#tfl-tank-range')).toHaveText(/\d+\.\d+°…\d+\.\d+°/);
+    await expect(page.locator('#tfl-gh-range')).toHaveText(/\d+\.\d+°…\d+\.\d+°/);
   });
 
   test('hover shows the crosshair inspector with projected values', async ({ page }) => {

--- a/tests/frontend/tuning-forecast.spec.js
+++ b/tests/frontend/tuning-forecast.spec.js
@@ -199,6 +199,57 @@ test.describe('Tuning forecast preview', () => {
     expect(newUrls.some(u => /"geT":5\b/.test(decodeURIComponent(u)))).toBe(true);
   });
 
+  test('loading spinner overlays the chart while the forecast is in flight', async ({ page }) => {
+    // Slow the forecast endpoint so the loading state is observable.
+    let unblock;
+    const block = new Promise((resolve) => { unblock = resolve; });
+    await page.route('**/api/forecast**', async (route) => {
+      await block;
+      const url = route.request().url();
+      let geT = 11;
+      const m = url.match(/[?&]tu=([^&]+)/);
+      if (m) {
+        try {
+          const tu = JSON.parse(decodeURIComponent(m[1]));
+          if (typeof tu.geT === 'number') geT = tu.geT;
+        } catch (e) { /* fall back */ }
+      }
+      await route.fulfill({
+        status: 200, contentType: 'application/json',
+        body: JSON.stringify(buildForecast(geT)),
+      });
+    });
+
+    await page.route('**/api/device-config', (r) => r.fulfill({
+      status: 200, contentType: 'application/json', body: JSON.stringify(DEFAULT_CONFIG),
+    }));
+    await page.route('**/api/history**', (r) => r.fulfill({
+      status: 200, contentType: 'application/json', body: '[]',
+    }));
+    await mockLiveConnection(page);
+    await page.goto('/playground/', { waitUntil: 'domcontentloaded' });
+    await page.waitForFunction(() => window.__initComplete === true);
+    await page.locator('.sidebar-nav [data-view="device"]').click();
+    await expect(page.locator('#device-config-form')).toBeVisible();
+
+    // Spinner overlays the chart while fetch is blocked.
+    const spinner = page.locator('#tuning-forecast-loading');
+    await expect(spinner).toBeVisible();
+
+    // The legacy text status no longer carries "Computing forecast…".
+    await expect(page.locator('#tuning-forecast-status'))
+      .not.toContainText('Computing forecast');
+
+    // The status row reserves vertical space so the legend below it
+    // doesn't jump when the message appears/disappears.
+    const minHeight = await page.locator('#tuning-forecast-status').evaluate(
+      (el) => getComputedStyle(el).minHeight);
+    expect(parseFloat(minHeight)).toBeGreaterThan(0);
+
+    unblock();
+    await expect(spinner).toBeHidden();
+  });
+
   test('legend shows the projected min/max for tank and greenhouse', async ({ page }) => {
     await setupDeviceView(page);
 


### PR DESCRIPTION
## Summary
- Replace the four number-input rows for Greenhouse heat enter/exit (`geT`/`gxT`) and Emergency heater enter/exit (`ehE`/`ehX`) with two mobile-friendly dual-knob range sliders, moved under the Forecast preview so the operator can drag a knob and watch the projection redraw.
- Each slider clamps its knobs to the field's own [min, max] *and* keeps a one-step gap between the two — mirroring the server-side invariants `gxT > geT` and `ehX > ehE`. The visible thumbs drive hidden inputs that share the existing `dc-tu-<key>` IDs, so the read/save/reset code paths are untouched.
- Forecast-preview legend grows projected min…max badges for the tank and greenhouse trajectories.

## Test plan
- [x] `npm run test:unit` (1240 pass)
- [x] `npx playwright test` (347 pass — added 4 frontend tests for the slider + legend behaviour, updated 1 that used to `.fill()` the now-hidden input)
- [x] `npm run lint`, `npm run knip`, `npm run check:file-size --strict`, `npm run check:assets --strict`
- [ ] Visual check on the deployed preview pod — drag both sliders, confirm the forecast redraws and the legend min/max updates

https://claude.ai/code/session_01W7RZQAZWwhfrRpY1bphGjC

---
_Generated by [Claude Code](https://claude.ai/code/session_01W7RZQAZWwhfrRpY1bphGjC)_