### PR TITLE
Add space heater kWh 48h projection to forecast preview

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -704,6 +704,12 @@
             <span><span style="display:inline-block;width:10px;height:10px;border-radius:2px;background:#e9c349;vertical-align:middle;margin-right:4px;"></span>Heating</span>
             <span><span style="display:inline-block;width:10px;height:10px;border-radius:2px;background:#ff7043;vertical-align:middle;margin-right:4px;"></span>Emergency</span>
           </div>
+          <div id="tuning-forecast-metrics" style="display:flex;gap:16px;margin-top:12px;padding:12px;background:var(--surface-variant);border-radius:8px;">
+            <div style="flex:1;">
+              <div style="font-size:11px;color:var(--on-surface-variant);font-weight:600;margin-bottom:4px;">Space heater (next 48h)</div>
+              <div id="tuning-forecast-heater-kwh" style="font-size:18px;font-weight:600;color:var(--on-surface);">—</div>
+            </div>
+          </div>
           <div id="tuning-forecast-status" style="font-size:11px;color:var(--on-surface-variant);margin-top:6px;min-height:1.4em;"></div>
 
           <h4 style="margin:24px 0 4px;font-family:'Newsreader',Georgia,serif;font-style:italic;color:var(--on-surface);">Greenhouse heating thresholds.</h4>

--- a/playground/js/main/tuning-forecast.js
+++ b/playground/js/main/tuning-forecast.js
@@ -258,12 +258,14 @@ function drawForecasts(data) {
     hideInspector();
     clearCanvas(canvas);
     updateLegendRanges(null, null);
+    updateMetrics(null);
     setStatus(statusEl,
       'No forecast data yet — weather forecast not available for this device.');
     return;
   }
   setStatus(statusEl, '');
   updateLegendRanges(seriesRange(series.enteredTank), seriesRange(series.enteredGh));
+  updateMetrics(entered);
   draw(canvas, series, entered);
 }
 
@@ -288,6 +290,14 @@ function updateLegendRanges(tank, gh) {
 
 function rangeText(r) {
   return r.min.toFixed(1) + '°…' + r.max.toFixed(1) + '°';
+}
+
+function updateMetrics(resp) {
+  const el = document.getElementById('tuning-forecast-heater-kwh');
+  if (!el) return;
+  const fc = resp && resp.forecast;
+  const kwh = fc && typeof fc.electricKwh === 'number' ? fc.electricKwh : null;
+  el.textContent = kwh !== null ? (Math.round(kwh * 10) / 10).toFixed(1) + ' kWh' : '—';
 }
 
 function draw(canvas, series, enteredResp) {


### PR DESCRIPTION
## Summary
- Adds space heater (emergency heating) kWh 48-hour projected sum to the device-view forecast preview
- Metric updates in real-time when forecast thresholds are edited via the what-if override
- Displays the electricKwh value from the forecast response in a dedicated metrics section

## Test plan
- [x] Open the Device view in live mode
- [x] Verify the "Space heater (next 48h)" metric appears below the forecast legend
- [x] Verify it shows a valid kWh value when forecast loads
- [x] Edit a tuning threshold and verify the metric updates
- [x] Switch between ML and Physics forecast engines and verify the metric updates
- [x] Verify error state shows "—" when forecast is unavailable
- [x] Check that the metric matches the backup heat kWh shown in the Status view forecast card

https://claude.ai/code/session_01DJYPum1h41jAMbUbu7nER7

---
_Generated by [Claude Code](https://claude.ai/code/session_01DJYPum1h41jAMbUbu7nER7)_