### PR TITLE
Add video walkthrough section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,18 @@
 
 ![Thermal simulation playground showing 24h of simulated data](tests/frontend/screenshots/readme-hero.png)
 
+## Video Walkthrough
+
+A three-part tour of the system:
+
+1. **Hardware tour** — solar collectors, insulated 300 L tank, pump and valve manifold, sensors, and the Shelly-based controller running JavaScript: <https://www.youtube.com/shorts/mBVhaG1TZ9Q>
+2. **App walkthrough** — current mode, sensor history, tank energy storage, and mode timeline: <https://www.youtube.com/shorts/zDSO4PRq0j8>
+3. **Simulation & flow view** — physics-based simulation mode and the live valve/energy flow visualization: <https://www.youtube.com/shorts/vDfq7Sa74N4>
+
+[![Hardware tour](https://img.youtube.com/vi/mBVhaG1TZ9Q/hqdefault.jpg)](https://www.youtube.com/shorts/mBVhaG1TZ9Q)
+[![App walkthrough](https://img.youtube.com/vi/zDSO4PRq0j8/hqdefault.jpg)](https://www.youtube.com/shorts/zDSO4PRq0j8)
+[![Simulation & flow view](https://img.youtube.com/vi/vDfq7Sa74N4/hqdefault.jpg)](https://www.youtube.com/shorts/vDfq7Sa74N4)
+
 Solar thermal heating system for a greenhouse in Southwest Finland.
 
 ## What This Is


### PR DESCRIPTION
## Summary

Added a new "Video Walkthrough" section to the README that introduces three short-form videos covering the system's hardware, app interface, and simulation capabilities.

## Changes

- Added a structured "Video Walkthrough" section with three parts:
  1. **Hardware tour** — solar collectors, tank, pump, valve manifold, sensors, and Shelly controller
  2. **App walkthrough** — current mode, sensor history, tank energy storage, and mode timeline
  3. **Simulation & flow view** — physics-based simulation and live valve/energy flow visualization
- Included YouTube video links and thumbnail images for each walkthrough
- Positioned the new section prominently after the hero image and before the existing "What This Is" section

## Details

The video walkthrough provides new users with a quick visual introduction to the system before diving into detailed documentation. Each video is linked with both text and clickable thumbnail images, making it easy for users to explore the hardware, operational interface, and simulation features.

https://claude.ai/code/session_01MD2oVarvQqhpxgx5MZ5MUy