### PR TITLE
Fix daily energy balance + show temperature deltas

### DIFF
--- a/playground/js/energy-balance.js
+++ b/playground/js/energy-balance.js
@@ -38,19 +38,52 @@ function lastIdxAtOrBefore(points, ts) {
   return 0;
 }
 
-function bucketRange(points, modes, energy, startIdx, endIdx) {
+// Bucket the tank-energy change across [startIdx, endIdx] by the *net*
+// change within each contiguous run of one mode — NOT the sum of every
+// sample-to-sample delta. The 30 s tank signal is quantised to 0.1 °C and
+// carries ±0.5 K of sensor jitter; summing the magnitude of each delta is
+// the signal's total variation, which over thousands of samples accretes
+// tens of phantom kWh (a flat night "leaked" 6 kWh and "gathered" 3 kWh of
+// nonexistent solar). Net-per-segment telescopes those wiggles away: a run
+// is scored only by its endpoints, so noise cancels and gain is tied to the
+// mode that was actually running.
+//   - solar_charging: net rise → gathered (a net fall → leakage)
+//   - heating modes:  net fall → heating
+//   - everything else: net fall → leakage
+// A positive swing outside solar_charging is discarded (you cannot gather
+// solar at night), so gathered − heating − leakage tracks, but does not
+// exactly equal, the raw endpoint-to-endpoint change.
+function bucketRange(modes, energy, startIdx, endIdx) {
   let gathered = 0, heating = 0, leakage = 0;
-  for (let i = startIdx + 1; i <= endIdx; i++) {
-    if (energy[i] === null || energy[i - 1] === null) continue;
-    const d = energy[i] - energy[i - 1];
-    if (d > 0) {
-      gathered += d;
-    } else if (d < 0) {
-      const loss = -d;
-      if (HEATING_MODES[modes[i]]) heating += loss;
-      else leakage += loss;
+  let segMode = null, segStartE = null, lastE = null;
+  function commit(net) {
+    if (segMode === 'solar_charging') {
+      if (net > 0) gathered += net; else leakage += -net;
+    } else if (HEATING_MODES[segMode]) {
+      if (net < 0) heating += -net;
+    } else {
+      if (net < 0) leakage += -net;
     }
   }
+  for (let i = startIdx; i <= endIdx; i++) {
+    const e = energy[i];
+    const m = modes[i];
+    if (e === null) {
+      // Data gap — close the open segment and don't bridge across it.
+      if (segMode !== null && segStartE !== null && lastE !== null) commit(lastE - segStartE);
+      segMode = null; segStartE = null; lastE = null;
+      continue;
+    }
+    if (segMode === null) { segMode = m; segStartE = e; lastE = e; continue; }
+    if (m !== segMode) {
+      commit(lastE - segStartE);
+      // The boundary delta (this sample vs. the previous run's last sample)
+      // belongs to the new mode, matching the old per-sample attribution.
+      segMode = m; segStartE = lastE;
+    }
+    lastE = e;
+  }
+  if (segMode !== null && segStartE !== null && lastE !== null) commit(lastE - segStartE);
   return { gathered, heating, leakage };
 }
 
@@ -165,7 +198,7 @@ export function computeEnergyBalance(points, events, nowMs) {
 
   let night = null;
   if (nightEndIdx > nightStartIdx) {
-    const b = bucketRange(points, modes, energy, nightStartIdx, nightEndIdx);
+    const b = bucketRange(modes, energy, nightStartIdx, nightEndIdx);
     // A "night" is ongoing when it runs up to nowMs (no day after it, or
     // this day is completed).
     const nightComplete = dayStartIdx !== -1 && !dayComplete;
@@ -182,7 +215,7 @@ export function computeEnergyBalance(points, events, nowMs) {
 
   let day = null;
   if (dayStartIdx !== -1 && dayEndIdx > dayStartIdx) {
-    const b = bucketRange(points, modes, energy, dayStartIdx, dayEndIdx);
+    const b = bucketRange(modes, energy, dayStartIdx, dayEndIdx);
     day = {
       startTs: points[dayStartIdx].ts,
       endTs: points[dayEndIdx].ts,

--- a/playground/js/main/balance-card.js
+++ b/playground/js/main/balance-card.js
@@ -15,6 +15,7 @@ import {
   editorialDaySentence,
   editorialNightSentence,
 } from '../energy-balance.js';
+import { tankKwhToDeltaC } from '../physics.js';
 import { helsinkiParts } from './time-format.js';
 import { registerDataSource } from '../sync/registry.js';
 
@@ -150,6 +151,21 @@ function fmtBalanceWindow(startTs, endTs, complete) {
   return fmt(startTs) + ' → ' + (complete ? fmt(endTs) : 'now');
 }
 
+// "Δ28°C" — the tank temperature swing equivalent to a kWh figure, shown
+// beside it so the energy has an intuitive companion. Follows the figure's
+// own sign convention: signed for Net (which flips), bare magnitude for
+// Gathered/Released (the label carries the direction).
+function deltaCHtml(kwh, { sign = false } = {}) {
+  const rounded = Math.round(tankKwhToDeltaC(kwh));
+  let txt;
+  if (sign && rounded !== 0) {
+    txt = 'Δ' + (rounded > 0 ? '+' : '−') + Math.abs(rounded) + '°C';
+  } else {
+    txt = 'Δ' + Math.abs(rounded) + '°C';
+  }
+  return '<span class="balance-stat-delta">' + txt + '</span>';
+}
+
 function statHtml(label, kwh, { sign = false, extra = '' } = {}) {
   const val = fmtBalanceKwh(kwh, { sign });
   const cls = sign
@@ -159,7 +175,8 @@ function statHtml(label, kwh, { sign = false, extra = '' } = {}) {
   return '<div class="balance-stat">' +
     '<span class="balance-stat-label">' + label + '</span>' +
     '<div><span class="balance-stat-value' + cls + '">' + val + '</span>' +
-    '<span class="balance-stat-unit">kWh</span></div>' +
+    '<span class="balance-stat-unit">kWh</span>' +
+    deltaCHtml(kwh, { sign }) + '</div>' +
     capHtml +
     '</div>';
 }
@@ -182,7 +199,8 @@ export function releasedStatHtml(heatingKwh, leakageKwh) {
   return '<div class="balance-stat">' +
     '<span class="balance-stat-label">Released</span>' +
     '<div><span class="balance-stat-value">' + fmtBalanceKwh(total) + '</span>' +
-    '<span class="balance-stat-unit">kWh</span></div>' +
+    '<span class="balance-stat-unit">kWh</span>' +
+    deltaCHtml(total) + '</div>' +
     (caption ? '<span class="balance-stat-caption">' + caption + '</span>' : '') +
     '</div>';
 }

--- a/playground/js/main/balance-card.js
+++ b/playground/js/main/balance-card.js
@@ -164,7 +164,7 @@ function statHtml(label, kwh, { sign = false, extra = '' } = {}) {
     '</div>';
 }
 
-function releasedStatHtml(heatingKwh, leakageKwh) {
+export function releasedStatHtml(heatingKwh, leakageKwh) {
   const total = heatingKwh + leakageKwh;
   const heating = heatingKwh >= 0.05;
   const leakage = leakageKwh >= 0.05;
@@ -181,7 +181,7 @@ function releasedStatHtml(heatingKwh, leakageKwh) {
   }
   return '<div class="balance-stat">' +
     '<span class="balance-stat-label">Released</span>' +
-    '<div><span class="balance-stat-value">−' + fmtBalanceKwh(total) + '</span>' +
+    '<div><span class="balance-stat-value">' + fmtBalanceKwh(total) + '</span>' +
     '<span class="balance-stat-unit">kWh</span></div>' +
     (caption ? '<span class="balance-stat-caption">' + caption + '</span>' : '') +
     '</div>';

--- a/playground/js/physics.js
+++ b/playground/js/physics.js
@@ -26,6 +26,16 @@ export function tankStoredEnergyKwh(avgTankC) {
   return TANK_VOLUME_L * WATER_SPECIFIC_HEAT_KJ * dT / 3600;
 }
 
+// Inverse slope of tankStoredEnergyKwh: convert a stored-energy amount
+// (kWh) back to the tank temperature swing (K) that produced it. The 12 °C
+// baseline cancels for a delta, so this is a pure scale (~2.867 K/kWh).
+// Lets the balance card show "Δ28°C" alongside each kWh figure. Sign is
+// preserved so a net loss reads as a negative swing.
+export function tankKwhToDeltaC(kwh) {
+  if (typeof kwh !== 'number' || !isFinite(kwh)) return 0;
+  return kwh * 3600 / (TANK_VOLUME_L * WATER_SPECIFIC_HEAT_KJ);
+}
+
 // System parameters (from system.yaml, with sensible defaults)
 const DEFAULTS = {
   collector_area: 4.0,          // m²

--- a/playground/public/style.css
+++ b/playground/public/style.css
@@ -1046,6 +1046,13 @@ select, input, textarea { max-width: 100%; }
   margin-left: 2px;
 }
 
+.balance-stat-delta {
+  font-size: 13px;
+  color: var(--on-surface-variant);
+  font-weight: 400;
+  margin-left: 8px;
+}
+
 .balance-stat-caption {
   font-family: 'Newsreader', Georgia, serif;
   font-style: italic;

--- a/server/lib/energy-balance.js
+++ b/server/lib/energy-balance.js
@@ -42,42 +42,78 @@ function sortModeEvents(events) {
     .sort(function (a, b) { return a.ts - b.ts; });
 }
 
-// Walk points (which include a pre-window leading edge from getHistory's
-// UNION) and credit each tank-energy delta to the mode active at the
-// later sample. Positive deltas → gathered, negative → heating (during
-// heating modes) or leakage (otherwise). Same algorithm as
-// playground/js/energy-balance.js bucketRange().
+// Bucket the tank-energy change by the *net* change within each contiguous
+// run of one mode — NOT the sum of every sample-to-sample delta. The 30 s
+// tank signal is quantised to 0.1 °C and carries ±0.5 K of sensor jitter;
+// summing each delta's magnitude is the signal's total variation, which over
+// thousands of samples accretes tens of phantom kWh (a flat night reported
+// 6 kWh "to air" and 3 kWh of nonexistent solar "gathered"). Scoring each
+// run by its endpoints telescopes the wiggles away and ties gain to the mode
+// that was actually running. Mirrors playground/js/energy-balance.js
+// bucketRange(); keep the two in sync.
+//   - solar_charging: net rise → gathered (a net fall → leakage)
+//   - heating modes:  net fall → heating
+//   - everything else: net fall → leakage
+// `points` includes a pre-window leading edge from getHistory's UNION; the
+// first counted segment is seeded from the sample just before windowStart so
+// the energy change across the window boundary is captured.
 function bucketEnergyByMode(points, modeEvents, windowStart) {
+  // Per-point mode (forward-walking event cursor) and tank energy.
+  const modes = new Array(points.length);
+  const energy = new Array(points.length);
   let pMode = 'idle';
   let evIdx = 0;
-  let gatheredWh = 0;
-  let heatingLossWh = 0;
-  let leakageLossWh = 0;
-  let prevEnergy = null;
+  let firstIn = points.length;
   for (let i = 0; i < points.length; i++) {
     const p = points[i];
     while (evIdx < modeEvents.length && modeEvents[evIdx].ts <= p.ts) {
       pMode = modeEvents[evIdx].to || pMode;
       evIdx++;
     }
-    if (typeof p.tank_top !== 'number' || typeof p.tank_bottom !== 'number') {
-      prevEnergy = null;
+    modes[i] = pMode;
+    energy[i] = (typeof p.tank_top === 'number' && typeof p.tank_bottom === 'number')
+      ? tankStoredEnergyKwh((p.tank_top + p.tank_bottom) / 2)
+      : null;
+    if (firstIn === points.length && p.ts >= windowStart) firstIn = i;
+  }
+  if (firstIn >= points.length) {
+    return { gatheredWh: 0, heatingLossWh: 0, leakageLossWh: 0 };
+  }
+  const base = firstIn > 0 ? firstIn - 1 : 0;
+
+  let gathered = 0, heating = 0, leakage = 0;
+  let segMode = null, segStartE = null, lastE = null;
+  function commit(net) {
+    if (segMode === 'solar_charging') {
+      if (net > 0) gathered += net; else leakage += -net;
+    } else if (HEATING_MODES[segMode]) {
+      if (net < 0) heating += -net;
+    } else {
+      if (net < 0) leakage += -net;
+    }
+  }
+  for (let i = base; i < points.length; i++) {
+    const e = energy[i];
+    const m = modes[i];
+    if (e === null) {
+      if (segMode !== null && segStartE !== null && lastE !== null) commit(lastE - segStartE);
+      segMode = null; segStartE = null; lastE = null;
       continue;
     }
-    const e = tankStoredEnergyKwh((p.tank_top + p.tank_bottom) / 2);
-    if (prevEnergy !== null && p.ts >= windowStart) {
-      const d = e - prevEnergy;
-      if (d > 0) {
-        gatheredWh += d * 1000;
-      } else if (d < 0) {
-        const lossWh = -d * 1000;
-        if (HEATING_MODES[pMode]) heatingLossWh += lossWh;
-        else leakageLossWh += lossWh;
-      }
+    if (segMode === null) { segMode = m; segStartE = e; lastE = e; continue; }
+    if (m !== segMode) {
+      commit(lastE - segStartE);
+      segMode = m; segStartE = lastE;
     }
-    prevEnergy = e;
+    lastE = e;
   }
-  return { gatheredWh, heatingLossWh, leakageLossWh };
+  if (segMode !== null && segStartE !== null && lastE !== null) commit(lastE - segStartE);
+
+  return {
+    gatheredWh: gathered * 1000,
+    heatingLossWh: heating * 1000,
+    leakageLossWh: leakage * 1000,
+  };
 }
 
 function computeOvernightFromHistory(points, events, now) {

--- a/server/lib/energy-balance.js
+++ b/server/lib/energy-balance.js
@@ -25,6 +25,15 @@ function tankStoredEnergyKwh(avgTankC) {
   return 300 * 4.186 * dT / 3600;
 }
 
+// Inverse slope of tankStoredEnergyKwh: kWh → equivalent tank temperature
+// swing (K), sign preserved. Must stay in sync with tankKwhToDeltaC() in
+// playground/js/physics.js. Used by the notification bodies to show the
+// temperature delta beside each kWh figure.
+function tankKwhToDeltaC(kwh) {
+  if (typeof kwh !== 'number' || !isFinite(kwh)) return 0;
+  return kwh * 3600 / (300 * 4.186);
+}
+
 // Window for the 12:00 noon "Overnight Heating Report" — reaches back
 // to ~18:00 the previous evening, capturing the full night plus
 // pre-sunset leakage. Positive solar deltas inside the window are
@@ -194,6 +203,7 @@ function fetchAndCompute(db, now, fromHistory, callback) {
 module.exports = {
   HEATING_MODES,
   tankStoredEnergyKwh,
+  tankKwhToDeltaC,
   computeOvernightFromHistory,
   computeDailyFromHistory,
   computeOvernightStats,

--- a/server/lib/notification-bodies.js
+++ b/server/lib/notification-bodies.js
@@ -7,7 +7,16 @@
  * unit-tested without spinning up the alert/offline state machine.
  */
 
+const { tankKwhToDeltaC } = require('./energy-balance.js');
+
 function fmtKwh(wh) { return (Math.round(wh) / 1000).toFixed(1); }
+
+// "<n> kWh (Δ<d>°C)" — the energy figure plus the equivalent tank
+// temperature swing, so the abstract kWh has an intuitive companion. The
+// label/verb around it carries direction, so the swing is a magnitude.
+function fmtKwhDelta(wh) {
+  return fmtKwh(wh) + ' kWh (Δ' + Math.round(Math.abs(tankKwhToDeltaC(wh / 1000))) + '°C)';
+}
 
 // Threshold below which we treat an accumulator as "held steady" and don't
 // mention it. 50 Wh = 0.05 kWh, which rounds to 0.1 at display resolution.
@@ -19,38 +28,39 @@ function buildEveningBody(gatheredWh, heatingLossWh, leakageLossWh) {
   const leakage = leakageLossWh >= KWH_NOISE_FLOOR_WH;
   const netWh = gatheredWh - heatingLossWh - leakageLossWh;
   const netSign = netWh >= 0 ? '+' : '−';
-  const netAbs = fmtKwh(Math.abs(netWh));
+  const netDeltaC = Math.round(Math.abs(tankKwhToDeltaC(netWh / 1000)));
+  // "net +0.8 kWh, Δ+2°C" — the net keeps its sign on both figures.
+  const net = 'net ' + netSign + fmtKwh(Math.abs(netWh)) + ' kWh, Δ' + netSign + netDeltaC + '°C';
 
   if (!gained) {
     if (!heating && !leakage) return 'Tank energy held steady today.';
     if (heating && leakage) {
-      return 'No solar gain today. The greenhouse drew ' + fmtKwh(heatingLossWh) +
-        ' kWh from the tank; another ' + fmtKwh(leakageLossWh) + ' kWh slipped to air.';
+      return 'No solar gain today. The greenhouse drew ' + fmtKwhDelta(heatingLossWh) +
+        ' from the tank; another ' + fmtKwhDelta(leakageLossWh) + ' slipped to air.';
     }
     if (heating) {
-      return 'No solar gain today. The greenhouse drew ' + fmtKwh(heatingLossWh) +
-        ' kWh from the tank.';
+      return 'No solar gain today. The greenhouse drew ' + fmtKwhDelta(heatingLossWh) +
+        ' from the tank.';
     }
-    return 'No solar gain today. The tank released ' + fmtKwh(leakageLossWh) + ' kWh to air.';
+    return 'No solar gain today. The tank released ' + fmtKwhDelta(leakageLossWh) + ' to air.';
   }
 
   // We gathered something.
   if (!heating && !leakage) {
-    return 'Today your collectors gathered ' + fmtKwh(gatheredWh) + ' kWh. The tank is holding steady.';
+    return 'Today your collectors gathered ' + fmtKwhDelta(gatheredWh) + '. The tank is holding steady.';
   }
   if (heating && leakage) {
-    return 'Today your collectors gathered ' + fmtKwh(gatheredWh) +
-      ' kWh. The greenhouse drew ' + fmtKwh(heatingLossWh) + ' kWh of warmth, ' +
-      fmtKwh(leakageLossWh) + ' kWh slipped to air (net ' + netSign + netAbs + ' kWh).';
+    return 'Today your collectors gathered ' + fmtKwhDelta(gatheredWh) +
+      '. The greenhouse drew ' + fmtKwhDelta(heatingLossWh) + ' of warmth, ' +
+      fmtKwhDelta(leakageLossWh) + ' slipped to air (' + net + ').';
   }
   if (heating) {
-    return 'Today your collectors gathered ' + fmtKwh(gatheredWh) +
-      ' kWh. The greenhouse drew ' + fmtKwh(heatingLossWh) +
-      ' kWh of warmth (net ' + netSign + netAbs + ' kWh).';
+    return 'Today your collectors gathered ' + fmtKwhDelta(gatheredWh) +
+      '. The greenhouse drew ' + fmtKwhDelta(heatingLossWh) +
+      ' of warmth (' + net + ').';
   }
-  return 'Today your collectors gathered ' + fmtKwh(gatheredWh) +
-    ' kWh. ' + fmtKwh(leakageLossWh) + ' kWh slipped to air since peak (net ' +
-    netSign + netAbs + ' kWh).';
+  return 'Today your collectors gathered ' + fmtKwhDelta(gatheredWh) +
+    '. ' + fmtKwhDelta(leakageLossWh) + ' slipped to air since peak (' + net + ').';
 }
 
 function buildNoonBody(minutes, heatingLossWh, leakageLossWh, heatingDisabled) {
@@ -60,7 +70,7 @@ function buildNoonBody(minutes, heatingLossWh, leakageLossWh, heatingDisabled) {
   if (heatingDisabled) {
     if (!leakage) return 'Greenhouse heating is resting. The tank held steady overnight.';
     return 'Greenhouse heating is resting. Overnight the tank released ' +
-      fmtKwh(leakageLossWh) + ' kWh to air.';
+      fmtKwhDelta(leakageLossWh) + ' to air.';
   }
 
   if (minutes > 0) {
@@ -68,15 +78,15 @@ function buildNoonBody(minutes, heatingLossWh, leakageLossWh, heatingDisabled) {
     const mins = minutes % 60;
     const duration = hrs > 0 ? hrs + 'h ' + mins + 'min' : mins + ' minutes';
     const tail = heating
-      ? ' — ' + fmtKwh(heatingLossWh) + ' kWh delivered' +
-        (leakage ? ', ' + fmtKwh(leakageLossWh) + ' kWh slipped to air' : '') + '.'
+      ? ' — ' + fmtKwhDelta(heatingLossWh) + ' delivered' +
+        (leakage ? ', ' + fmtKwhDelta(leakageLossWh) + ' slipped to air' : '') + '.'
       : '.';
     return 'Overnight the greenhouse drew warmth for ' + duration + tail;
   }
 
   if (!leakage) return 'No heating was needed overnight. The greenhouse stayed warm.';
   return 'No heating was needed overnight. The tank released ' +
-    fmtKwh(leakageLossWh) + ' kWh to air.';
+    fmtKwhDelta(leakageLossWh) + ' to air.';
 }
 
 module.exports = {

--- a/tests/balance-card.test.mjs
+++ b/tests/balance-card.test.mjs
@@ -1,0 +1,22 @@
+// Tests for the "Today's balance" card stat renderers.
+
+import test from 'node:test';
+import assert from 'node:assert';
+import { releasedStatHtml } from '../playground/js/main/balance-card.js';
+
+test('Released stat shows a bare magnitude (no double-negative)', () => {
+  // The "Released" label already conveys that energy left the tank, so the
+  // value must NOT carry a redundant minus sign. Mirrors how "Gathered" is
+  // shown unsigned. (Net today keeps its sign — that one genuinely flips.)
+  const html = releasedStatHtml(1.4, 0.35); // total 1.75 → "1.8"
+  assert.match(html, /balance-stat-label">Released/);
+  assert.match(html, /balance-stat-value">1\.8</, 'value should render as a bare magnitude');
+  assert.doesNotMatch(html, /balance-stat-value">−/, 'value must not be prefixed with a minus');
+  // Caption still splits the destinations.
+  assert.match(html, /1\.4 to greenhouse · 0\.4 to air/);
+});
+
+test('Released caption collapses to a single destination when only one is significant', () => {
+  assert.match(releasedStatHtml(0, 2.0), /balance-stat-caption">to air/);
+  assert.match(releasedStatHtml(2.0, 0), /balance-stat-caption">to greenhouse/);
+});

--- a/tests/balance-card.test.mjs
+++ b/tests/balance-card.test.mjs
@@ -16,6 +16,13 @@ test('Released stat shows a bare magnitude (no double-negative)', () => {
   assert.match(html, /1\.4 to greenhouse · 0\.4 to air/);
 });
 
+test('Released stat shows the equivalent tank temperature swing', () => {
+  // 1.75 kWh ≈ 5 K swing (1.75 · 2.867). Magnitude only, like the kWh.
+  const html = releasedStatHtml(1.4, 0.35);
+  assert.match(html, /balance-stat-delta">Δ5°C</);
+  assert.doesNotMatch(html, /Δ−/, 'released swing is a magnitude, not signed');
+});
+
 test('Released caption collapses to a single destination when only one is significant', () => {
   assert.match(releasedStatHtml(0, 2.0), /balance-stat-caption">to air/);
   assert.match(releasedStatHtml(2.0, 0), /balance-stat-caption">to greenhouse/);

--- a/tests/energy-balance.test.js
+++ b/tests/energy-balance.test.js
@@ -3,6 +3,7 @@ const assert = require('node:assert');
 
 const {
   tankStoredEnergyKwh,
+  tankKwhToDeltaC,
   computeOvernightFromHistory,
   computeDailyFromHistory,
   computeOvernightStats,
@@ -25,6 +26,21 @@ describe('energy-balance', () => {
     it('returns 0 for non-finite input', () => {
       assert.strictEqual(tankStoredEnergyKwh(NaN), 0);
       assert.strictEqual(tankStoredEnergyKwh(undefined), 0);
+    });
+  });
+
+  describe('tankKwhToDeltaC', () => {
+    it('is the inverse slope of tankStoredEnergyKwh (≈2.867 K per kWh)', () => {
+      // 1 kWh ↔ 3600 / (300 · 4.186) ≈ 2.867 K
+      assert.ok(Math.abs(tankKwhToDeltaC(1) - 2.8667) < 0.001, 'got ' + tankKwhToDeltaC(1));
+      // round-trips a known energy: tankStoredEnergyKwh(30) ≈ 6.279 kWh → 18 K span
+      assert.ok(Math.abs(tankKwhToDeltaC(tankStoredEnergyKwh(30)) - 18) < 0.01);
+    });
+
+    it('preserves sign and returns 0 for non-finite input', () => {
+      assert.ok(tankKwhToDeltaC(-2.4) < 0);
+      assert.strictEqual(tankKwhToDeltaC(NaN), 0);
+      assert.strictEqual(tankKwhToDeltaC(undefined), 0);
     });
   });
 

--- a/tests/energy-balance.test.js
+++ b/tests/energy-balance.test.js
@@ -232,6 +232,50 @@ describe('energy-balance', () => {
       assert.strictEqual(stats.leakageLossWh, 0);
     });
 
+    it('rejects sensor noise: a jittery flat idle day creates no energy', () => {
+      // The whole 24 h window is idle and the tank holds a flat 30 °C avg,
+      // but the 30 s signal jitters ±0.5 K. The old per-sample algorithm
+      // summed the magnitude of every wiggle, manufacturing kWh of phantom
+      // "gathered" and "leaked" energy out of pure noise. With net-per-mode
+      // bucketing the flat trend yields ~0 in every bucket.
+      const now = Date.now();
+      const HOUR = 3600 * 1000;
+      const events = [{ ts: now - 25 * HOUR, type: 'mode', to: 'idle' }];
+      const points = [{ ts: now - 25 * HOUR, tank_top: 31, tank_bottom: 29 }]; // leading edge, avg 30
+      const N = 48;
+      for (let i = 0; i <= N; i++) {
+        const jitter = (i % 2 === 0) ? 0.5 : -0.5;
+        const avg = 30 + jitter;
+        points.push({ ts: now - 24 * HOUR + (i / N) * 24 * HOUR, tank_top: avg + 1, tank_bottom: avg - 1 });
+      }
+      const stats = computeDailyFromHistory(points, events, now);
+      assert.ok(stats.gatheredWh < 100, 'gatheredWh should be ~0, got ' + stats.gatheredWh);
+      assert.ok(stats.leakageLossWh < 100, 'leakageLossWh should be ~0, got ' + stats.leakageLossWh);
+      assert.strictEqual(stats.heatingLossWh, 0);
+    });
+
+    it('attributes only net cooling to leakage under a noisy downtrend', () => {
+      // Idle window, tank cools 30 → 27 avg (−3 K ≈ 1046 Wh) with ±0.5 K
+      // jitter riding the trend. Leakage must track the net 3 K, and no
+      // positive jitter may be miscredited as solar "gathered".
+      const now = Date.now();
+      const HOUR = 3600 * 1000;
+      const events = [{ ts: now - 25 * HOUR, type: 'mode', to: 'idle' }];
+      const points = [{ ts: now - 25 * HOUR, tank_top: 31, tank_bottom: 29 }]; // leading edge, avg 30
+      const N = 48;
+      for (let i = 0; i <= N; i++) {
+        const trend = 30 - 3 * (i / N);
+        const jitter = (i % 2 === 0) ? 0.5 : -0.5;
+        const avg = trend + jitter;
+        points.push({ ts: now - 24 * HOUR + (i / N) * 24 * HOUR, tank_top: avg + 1, tank_bottom: avg - 1 });
+      }
+      const stats = computeDailyFromHistory(points, events, now);
+      assert.ok(stats.gatheredWh < 100, 'gatheredWh should be ~0, got ' + stats.gatheredWh);
+      assert.ok(stats.leakageLossWh > 850 && stats.leakageLossWh < 1200,
+        'leakageLossWh=' + stats.leakageLossWh);
+      assert.strictEqual(stats.heatingLossWh, 0);
+    });
+
     it('computeDailyStats fetches both queries and returns stats', () => {
       const now = Date.now();
       const { points, events } = buildDayScenario(now);

--- a/tests/energy-balance.test.mjs
+++ b/tests/energy-balance.test.mjs
@@ -178,6 +178,34 @@ test('user-data sanity check: 21 Apr charging day', () => {
     'day net ' + result.day.netKwh);
 });
 
+test('sensor noise within one mode does not inflate buckets (net, not total variation)', () => {
+  // A pure-idle night where the tank cools 35 → 30 avg (−5 K, ≈1.74 kWh
+  // real standby loss) but the 30 s sensor signal jitters ±0.5 K around
+  // that trend. Summing the magnitude of every sample-to-sample delta
+  // (the old behaviour) accumulates the jitter into phantom "gathered"
+  // energy at night and a wildly over-counted leakage. The balance must
+  // reflect only the net change per mode segment.
+  const t0 = Date.parse('2026-04-21T18:00:00Z');
+  const points = [];
+  const N = 60; // ~ every 15 min over 15 h
+  for (let i = 0; i <= N; i++) {
+    const trend = 35 - 5 * (i / N);          // 35 → 30 avg
+    const jitter = (i % 2 === 0) ? 0.5 : -0.5; // ±0.5 K sawtooth
+    const avg = trend + jitter;
+    points.push(pt(t0 + (i / N) * 15 * HOUR, avg + 1, avg - 1));
+  }
+  const result = computeEnergyBalance(points, [], t0 + 15 * HOUR);
+  assert.ok(result.night, 'expected an ongoing night');
+  // No sun at night → gathered must be ~0, not the jitter sum.
+  assert.ok(result.night.gatheredKwh < 0.1,
+    'night gathered should be ~0, got ' + result.night.gatheredKwh);
+  // Leakage tracks the real 5 K net cooling (≈1.74 kWh), not the
+  // total-variation blow-up.
+  assert.ok(result.night.leakageKwh > 1.4 && result.night.leakageKwh < 2.1,
+    'night leakage ' + result.night.leakageKwh);
+  assert.strictEqual(result.night.heatingKwh, 0);
+});
+
 test('DAY_GAP_MS is exported and sensible (≥ 1 h, ≤ 3 h)', () => {
   assert.ok(DAY_GAP_MS >= HOUR);
   assert.ok(DAY_GAP_MS <= 3 * HOUR);

--- a/tests/notifications.test.js
+++ b/tests/notifications.test.js
@@ -517,28 +517,28 @@ describe('notifications', () => {
       it('sunny day with only leakage', () => {
         // 6.5 kWh gathered, 2.5 kWh leakage, no heating
         const body = notifications.buildEveningBody(6500, 0, 2500);
-        assert.match(body, /gathered 6\.5 kWh/);
-        assert.match(body, /2\.5 kWh slipped to air/);
-        assert.match(body, /net \+4\.0 kWh/);
+        assert.match(body, /gathered 6\.5 kWh \(Δ19°C\)/);
+        assert.match(body, /2\.5 kWh \(Δ7°C\) slipped to air/);
+        assert.match(body, /net \+4\.0 kWh, Δ\+11°C/);
       });
 
       it('cloudy day with pure leakage loss', () => {
         const body = notifications.buildEveningBody(0, 0, 1400);
         assert.match(body, /No solar gain today/);
-        assert.match(body, /released 1\.4 kWh to air/);
+        assert.match(body, /released 1\.4 kWh \(Δ4°C\) to air/);
       });
 
       it('day with both heating and leakage losses', () => {
         const body = notifications.buildEveningBody(3400, 1900, 700);
-        assert.match(body, /gathered 3\.4 kWh/);
-        assert.match(body, /greenhouse drew 1\.9 kWh/);
-        assert.match(body, /0\.7 kWh slipped to air/);
-        assert.match(body, /net \+0\.8 kWh/);
+        assert.match(body, /gathered 3\.4 kWh \(Δ10°C\)/);
+        assert.match(body, /greenhouse drew 1\.9 kWh \(Δ5°C\)/);
+        assert.match(body, /0\.7 kWh \(Δ2°C\) slipped to air/);
+        assert.match(body, /net \+0\.8 kWh, Δ\+2°C/);
       });
 
       it('net negative day shows the minus sign', () => {
         const body = notifications.buildEveningBody(800, 3200, 0);
-        assert.match(body, /net −2\.4 kWh/);
+        assert.match(body, /net −2\.4 kWh, Δ−7°C/);
       });
 
       it('flat day with everything below noise floor', () => {
@@ -549,7 +549,7 @@ describe('notifications', () => {
       it('cloudy with only heating losses', () => {
         const body = notifications.buildEveningBody(0, 1800, 0);
         assert.match(body, /No solar gain today/);
-        assert.match(body, /greenhouse drew 1\.8 kWh from the tank/);
+        assert.match(body, /greenhouse drew 1\.8 kWh \(Δ5°C\) from the tank/);
       });
     });
 
@@ -557,7 +557,7 @@ describe('notifications', () => {
       it('heating disabled, tank cooled to air', () => {
         const body = notifications.buildNoonBody(0, 0, 1800, /*heatingDisabled*/ true);
         assert.match(body, /Greenhouse heating is resting/);
-        assert.match(body, /released 1\.8 kWh to air/);
+        assert.match(body, /released 1\.8 kWh \(Δ5°C\) to air/);
       });
 
       it('heating disabled, tank held steady', () => {
@@ -570,14 +570,14 @@ describe('notifications', () => {
         // 225 minutes = 3h 45min
         const body = notifications.buildNoonBody(225, 2800, 1400, false);
         assert.match(body, /3h 45min/);
-        assert.match(body, /2\.8 kWh delivered/);
-        assert.match(body, /1\.4 kWh slipped to air/);
+        assert.match(body, /2\.8 kWh \(Δ8°C\) delivered/);
+        assert.match(body, /1\.4 kWh \(Δ4°C\) slipped to air/);
       });
 
       it('heating enabled but did not run, only leakage', () => {
         const body = notifications.buildNoonBody(0, 0, 1600, false);
         assert.match(body, /No heating was needed overnight/);
-        assert.match(body, /released 1\.6 kWh to air/);
+        assert.match(body, /released 1\.6 kWh \(Δ5°C\) to air/);
       });
 
       it('heating enabled, did not run, everything quiet', () => {


### PR DESCRIPTION
## Summary

- **Fix noise-inflated daily energy balance.** The balance card and the noon/evening push reports summed the magnitude of every 30 s tank-energy delta — the signal's *total variation*, not its net change. On a signal quantised to 0.1 °C with ~0.5 K jitter this manufactured huge phantom flows (validated against 48 h of real public-history data: 24 h reported flow ~23 kWh vs. a tank swing only physically allowing ~9.6 kWh, plus ~3 kWh of impossible "solar gathered at night"). Now each contiguous run of one mode is scored by its endpoints, so the wiggles telescope away and gain is tied to the mode actually running. Mirrored on client (`playground/js/energy-balance.js`) and server (`server/lib/energy-balance.js`).
- **Drop the redundant minus on "Released."** The label already states the direction; the value is now a bare magnitude (matching "Gathered"). "Net today" keeps its genuine ± sign.
- **Show the tank temperature delta beside each kWh figure.** The kWh numbers derive from tank temperature change, so each is paired with its equivalent swing (`Δ28°C`) on the status card and inline `(Δ5°C)` in the push reports. Added sign-preserving `tankKwhToDeltaC()` mirrored on client and server.

## Test plan

- [x] `npm run lint` / `npm run knip` — clean
- [x] `npm run check:file-size -- --strict` / `check:assets -- --strict` — 0 over hard cap, all assets referenced
- [x] `npm run test:unit` — 1249 pass (added noise-rejection, conversion, and rendering tests)
- [x] `npx playwright test` — 351 pass
- [x] Frontend coverage gate — 58 files, all ≥50%
- [x] Status card rendered in a real browser to confirm layout (Δ°C on the value line, no wrapping)

https://claude.ai/code/session_01FgzhsQ4M62uLuMcQRfE4io

---
_Generated by [Claude Code](https://claude.ai/code/session_01FgzhsQ4M62uLuMcQRfE4io)_