### PR TITLE
Calibrate simulator tank loss + guard energy code with parity/render tests

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# SessionStart hook for Claude Code on the web.
+#
+# Provisions the repo so the gate suite (lint, knip, unit, Playwright)
+# runs without manual setup. Two things bite every fresh web session,
+# both documented in CLAUDE.md "Test Setup Gotchas":
+#   1. node_modules isn't present in the freshly-cloned container.
+#   2. The sandbox pre-caches ONE Chromium revision under
+#      $PLAYWRIGHT_BROWSERS_PATH, but the repo pins the latest
+#      @playwright/test (which bundles a newer revision), so Playwright
+#      can't find its browser. We install the matching version with
+#      --no-save, leaving package.json/lock on the latest release.
+#
+# Synchronous (no {"async":true} on stdout) so deps are guaranteed ready
+# before the agent runs anything. Remote-only, idempotent, and never
+# hard-fails the session (warnings to stderr, always exit 0). All
+# diagnostics go to stderr — SessionStart stdout is injected into the
+# session context, so we keep stdout empty.
+set -uo pipefail
+
+# Local devs manage their own environment; only act in the web sandbox.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+cd "${CLAUDE_PROJECT_DIR:-.}" || exit 0
+
+# 1. Dependencies. A cached container keeps node_modules between sessions,
+#    so this is a no-op after the first run.
+if [ ! -d node_modules ]; then
+  echo "session-start: installing npm dependencies (npm ci)…" >&2
+  npm ci >&2 || { echo "session-start: npm ci failed — run it manually" >&2; exit 0; }
+fi
+
+# 2. Align Playwright with the sandbox's pre-cached Chromium revision.
+cache_path="${PLAYWRIGHT_BROWSERS_PATH:-}"
+if [ -n "$cache_path" ] && [ -d "$cache_path" ]; then
+  cached=$(ls "$cache_path" 2>/dev/null | grep -E '^chromium-[0-9]+$' | sort -V | tail -1 | sed 's/chromium-//')
+  installed=$(node -pe "const p=require('path').dirname(require.resolve('playwright-core/package.json')); JSON.parse(require('fs').readFileSync(p+'/browsers.json','utf8')).browsers.find(b=>b.name==='chromium').revision" 2>/dev/null || echo "")
+
+  if [ -n "$cached" ] && [ -n "$installed" ] && [ "$cached" != "$installed" ]; then
+    # chromium revision → highest @playwright/test version bundling it.
+    # Mirror of chromium_to_pw_version() in pre-push-gate.sh — keep in sync.
+    case "$cached" in
+      1187) ver="1.55.0" ;;
+      1194) ver="1.56.1" ;;
+      1200) ver="1.57.0" ;;
+      1208) ver="1.58.1" ;;
+      1217) ver="1.59.1" ;;
+      *) ver="" ;;
+    esac
+    # Probe fallback for revisions not in the table (~10 s).
+    if [ -z "$ver" ]; then
+      for v in 1.55.0 1.56.0 1.56.1 1.57.0 1.58.0 1.58.1 1.59.0 1.59.1 1.60.0 1.61.0; do
+        npm pack --silent "playwright-core@$v" >/dev/null 2>&1 || continue
+        rev=$(tar -xOf "playwright-core-$v.tgz" package/browsers.json 2>/dev/null \
+          | node -pe "JSON.parse(require('fs').readFileSync(0,'utf8')).browsers.find(x=>x.name==='chromium').revision" 2>/dev/null)
+        rm -f "playwright-core-$v.tgz"
+        [ "$rev" = "$cached" ] && { ver="$v"; break; }
+      done
+    fi
+    if [ -n "$ver" ]; then
+      echo "session-start: aligning Playwright to cached Chromium $cached (@playwright/test@$ver)…" >&2
+      npm install --no-save "@playwright/test@$ver" "playwright@$ver" >&2 || \
+        echo "session-start: playwright align failed (continuing)" >&2
+    else
+      echo "session-start: no @playwright/test match for Chromium $cached; see CLAUDE.md probe recipe" >&2
+    fi
+  fi
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,16 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Bash",

--- a/knip.json
+++ b/knip.json
@@ -31,8 +31,7 @@
     "tests/**/*.{js,mjs}"
   ],
   "ignore": [
-    "playground/public/**",
-    "shelly/**"
+    "playground/public/**"
   ],
   "ignoreDependencies": [
     "playwright",

--- a/knip.json
+++ b/knip.json
@@ -41,6 +41,7 @@
   ],
   "ignoreUnresolved": [
     "/playground/js/app-state.js",
+    "/playground/js/main/balance-card.js",
     "/playground/js/main/display-update.js",
     "/playground/js/main/history-graph.js",
     "/playground/js/main/state.js"

--- a/playground/assets/bootstrap-history.json
+++ b/playground/assets/bootstrap-history.json
@@ -19,8 +19,8 @@
     {
       "time": 60,
       "values": {
-        "t_tank_top": 11.8955,
-        "t_tank_bottom": 9.104,
+        "t_tank_top": 11.8946,
+        "t_tank_bottom": 9.1032,
         "t_collector": 10.7036,
         "t_greenhouse": 10.9768,
         "t_outdoor": 8.7266
@@ -30,8 +30,8 @@
     {
       "time": 120,
       "values": {
-        "t_tank_top": 11.7982,
-        "t_tank_bottom": 9.2008,
+        "t_tank_top": 11.7965,
+        "t_tank_bottom": 9.1991,
         "t_collector": 11.4006,
         "t_greenhouse": 10.9549,
         "t_outdoor": 8.7477
@@ -41,8 +41,8 @@
     {
       "time": 180,
       "values": {
-        "t_tank_top": 11.7077,
-        "t_tank_bottom": 9.2908,
+        "t_tank_top": 11.7052,
+        "t_tank_bottom": 9.2883,
         "t_collector": 12.0913,
         "t_greenhouse": 10.9343,
         "t_outdoor": 8.7689
@@ -52,9 +52,9 @@
     {
       "time": 240,
       "values": {
-        "t_tank_top": 11.6345,
-        "t_tank_bottom": 9.3747,
-        "t_collector": 11.9156,
+        "t_tank_top": 11.6312,
+        "t_tank_bottom": 9.3714,
+        "t_collector": 11.9148,
         "t_greenhouse": 10.9149,
         "t_outdoor": 8.79
       },
@@ -63,9 +63,9 @@
     {
       "time": 300,
       "values": {
-        "t_tank_top": 11.5591,
-        "t_tank_bottom": 9.4531,
-        "t_collector": 11.5396,
+        "t_tank_top": 11.5551,
+        "t_tank_bottom": 9.4489,
+        "t_collector": 11.5377,
         "t_greenhouse": 10.8967,
         "t_outdoor": 8.8112
       },
@@ -74,9 +74,9 @@
     {
       "time": 360,
       "values": {
-        "t_tank_top": 11.4811,
-        "t_tank_bottom": 9.526,
-        "t_collector": 11.3421,
+        "t_tank_top": 11.4764,
+        "t_tank_bottom": 9.521,
+        "t_collector": 11.3392,
         "t_greenhouse": 10.8797,
         "t_outdoor": 8.8324
       },
@@ -85,9 +85,9 @@
     {
       "time": 420,
       "values": {
-        "t_tank_top": 11.406,
-        "t_tank_bottom": 9.5936,
-        "t_collector": 11.2518,
+        "t_tank_top": 11.4006,
+        "t_tank_bottom": 9.5878,
+        "t_collector": 11.2481,
         "t_greenhouse": 10.8638,
         "t_outdoor": 8.8536
       },
@@ -96,9 +96,9 @@
     {
       "time": 480,
       "values": {
-        "t_tank_top": 11.3365,
-        "t_tank_bottom": 9.6562,
-        "t_collector": 11.2255,
+        "t_tank_top": 11.3304,
+        "t_tank_bottom": 9.6497,
+        "t_collector": 11.2209,
         "t_greenhouse": 10.8491,
         "t_outdoor": 8.8749
       },
@@ -107,9 +107,9 @@
     {
       "time": 540,
       "values": {
-        "t_tank_top": 11.274,
-        "t_tank_bottom": 9.7143,
-        "t_collector": 11.2365,
+        "t_tank_top": 11.2671,
+        "t_tank_bottom": 9.707,
+        "t_collector": 11.2311,
         "t_greenhouse": 10.8354,
         "t_outdoor": 8.8962
       },
@@ -118,9 +118,9 @@
     {
       "time": 600,
       "values": {
-        "t_tank_top": 11.2188,
-        "t_tank_bottom": 9.7682,
-        "t_collector": 11.4566,
+        "t_tank_top": 11.2112,
+        "t_tank_bottom": 9.7603,
+        "t_collector": 11.5445,
         "t_greenhouse": 10.8228,
         "t_outdoor": 8.9174
       },
@@ -129,9 +129,9 @@
     {
       "time": 660,
       "values": {
-        "t_tank_top": 11.1681,
-        "t_tank_bottom": 9.8184,
-        "t_collector": 12.1936,
+        "t_tank_top": 11.1598,
+        "t_tank_bottom": 9.8097,
+        "t_collector": 12.28,
         "t_greenhouse": 10.8112,
         "t_outdoor": 8.9388
       },
@@ -140,9 +140,9 @@
     {
       "time": 720,
       "values": {
-        "t_tank_top": 11.1266,
-        "t_tank_bottom": 9.8651,
-        "t_collector": 12.807,
+        "t_tank_top": 11.1259,
+        "t_tank_bottom": 9.8557,
+        "t_collector": 12.7103,
         "t_greenhouse": 10.8006,
         "t_outdoor": 8.9601
       },
@@ -151,9 +151,9 @@
     {
       "time": 780,
       "values": {
-        "t_tank_top": 11.1362,
-        "t_tank_bottom": 9.9098,
-        "t_collector": 12.2999,
+        "t_tank_top": 11.1315,
+        "t_tank_bottom": 9.8999,
+        "t_collector": 12.237,
         "t_greenhouse": 10.7911,
         "t_outdoor": 8.9814
       },
@@ -162,9 +162,9 @@
     {
       "time": 840,
       "values": {
-        "t_tank_top": 11.1318,
-        "t_tank_bottom": 9.9529,
-        "t_collector": 12.0101,
+        "t_tank_top": 11.1244,
+        "t_tank_bottom": 9.9425,
+        "t_collector": 11.9678,
         "t_greenhouse": 10.7825,
         "t_outdoor": 9.0028
       },
@@ -173,9 +173,9 @@
     {
       "time": 900,
       "values": {
-        "t_tank_top": 11.1208,
-        "t_tank_bottom": 9.9942,
-        "t_collector": 11.8529,
+        "t_tank_top": 11.1116,
+        "t_tank_bottom": 9.9831,
+        "t_collector": 11.8229,
         "t_greenhouse": 10.7748,
         "t_outdoor": 9.0242
       },
@@ -184,9 +184,9 @@
     {
       "time": 960,
       "values": {
-        "t_tank_top": 11.1077,
-        "t_tank_bottom": 10.0337,
-        "t_collector": 11.7762,
+        "t_tank_top": 11.0971,
+        "t_tank_bottom": 10.0219,
+        "t_collector": 11.7536,
         "t_greenhouse": 10.7681,
         "t_outdoor": 9.0456
       },
@@ -195,9 +195,9 @@
     {
       "time": 1020,
       "values": {
-        "t_tank_top": 11.095,
-        "t_tank_bottom": 10.0712,
-        "t_collector": 11.7483,
+        "t_tank_top": 11.0832,
+        "t_tank_bottom": 10.0588,
+        "t_collector": 11.7299,
         "t_greenhouse": 10.7623,
         "t_outdoor": 9.067
       },
@@ -206,9 +206,9 @@
     {
       "time": 1080,
       "values": {
-        "t_tank_top": 11.084,
-        "t_tank_bottom": 10.107,
-        "t_collector": 11.7494,
+        "t_tank_top": 11.0713,
+        "t_tank_bottom": 10.0939,
+        "t_collector": 11.7334,
         "t_greenhouse": 10.7573,
         "t_outdoor": 9.0885
       },
@@ -217,9 +217,9 @@
     {
       "time": 1140,
       "values": {
-        "t_tank_top": 11.0755,
-        "t_tank_bottom": 10.1412,
-        "t_collector": 11.7678,
+        "t_tank_top": 11.062,
+        "t_tank_bottom": 10.1274,
+        "t_collector": 11.7529,
         "t_greenhouse": 10.7532,
         "t_outdoor": 9.1099
       },
@@ -228,9 +228,9 @@
     {
       "time": 1200,
       "values": {
-        "t_tank_top": 11.0697,
-        "t_tank_bottom": 10.174,
-        "t_collector": 11.7962,
+        "t_tank_top": 11.0554,
+        "t_tank_bottom": 10.1594,
+        "t_collector": 11.7818,
         "t_greenhouse": 10.75,
         "t_outdoor": 9.1314
       },
@@ -239,9 +239,9 @@
     {
       "time": 1260,
       "values": {
-        "t_tank_top": 11.0666,
-        "t_tank_bottom": 10.2054,
-        "t_collector": 11.8301,
+        "t_tank_top": 11.0516,
+        "t_tank_bottom": 10.1902,
+        "t_collector": 11.8157,
         "t_greenhouse": 10.7475,
         "t_outdoor": 9.1529
       },
@@ -250,9 +250,9 @@
     {
       "time": 1320,
       "values": {
-        "t_tank_top": 11.0661,
-        "t_tank_bottom": 10.2357,
-        "t_collector": 11.8671,
+        "t_tank_top": 11.0505,
+        "t_tank_bottom": 10.2197,
+        "t_collector": 11.8524,
         "t_greenhouse": 10.7459,
         "t_outdoor": 9.1744
       },
@@ -261,9 +261,9 @@
     {
       "time": 1380,
       "values": {
-        "t_tank_top": 11.0682,
-        "t_tank_bottom": 10.2649,
-        "t_collector": 11.9054,
+        "t_tank_top": 11.052,
+        "t_tank_bottom": 10.2483,
+        "t_collector": 11.8903,
         "t_greenhouse": 10.745,
         "t_outdoor": 9.1959
       },
@@ -272,9 +272,9 @@
     {
       "time": 1440,
       "values": {
-        "t_tank_top": 11.0726,
-        "t_tank_bottom": 10.2932,
-        "t_collector": 11.9442,
+        "t_tank_top": 11.0557,
+        "t_tank_bottom": 10.2759,
+        "t_collector": 11.9286,
         "t_greenhouse": 10.7449,
         "t_outdoor": 9.2175
       },
@@ -283,9 +283,9 @@
     {
       "time": 1500,
       "values": {
-        "t_tank_top": 11.0792,
-        "t_tank_bottom": 10.3207,
-        "t_collector": 11.9829,
+        "t_tank_top": 11.0616,
+        "t_tank_bottom": 10.3027,
+        "t_collector": 11.9668,
         "t_greenhouse": 10.7456,
         "t_outdoor": 9.239
       },
@@ -294,9 +294,9 @@
     {
       "time": 1560,
       "values": {
-        "t_tank_top": 11.0877,
-        "t_tank_bottom": 10.3475,
-        "t_collector": 12.0214,
+        "t_tank_top": 11.0695,
+        "t_tank_bottom": 10.3288,
+        "t_collector": 12.0047,
         "t_greenhouse": 10.7469,
         "t_outdoor": 9.2606
       },
@@ -305,9 +305,9 @@
     {
       "time": 1620,
       "values": {
-        "t_tank_top": 11.0979,
-        "t_tank_bottom": 10.3736,
-        "t_collector": 12.0594,
+        "t_tank_top": 11.0791,
+        "t_tank_bottom": 10.3543,
+        "t_collector": 12.0421,
         "t_greenhouse": 10.749,
         "t_outdoor": 9.2822
       },
@@ -316,9 +316,9 @@
     {
       "time": 1680,
       "values": {
-        "t_tank_top": 11.1098,
-        "t_tank_bottom": 10.3993,
-        "t_collector": 12.0969,
+        "t_tank_top": 11.0903,
+        "t_tank_bottom": 10.3793,
+        "t_collector": 12.079,
         "t_greenhouse": 10.7518,
         "t_outdoor": 9.3038
       },
@@ -327,9 +327,9 @@
     {
       "time": 1740,
       "values": {
-        "t_tank_top": 11.1231,
-        "t_tank_bottom": 10.4244,
-        "t_collector": 12.1339,
+        "t_tank_top": 11.103,
+        "t_tank_bottom": 10.4038,
+        "t_collector": 12.1154,
         "t_greenhouse": 10.7552,
         "t_outdoor": 9.3254
       },
@@ -338,9 +338,9 @@
     {
       "time": 1800,
       "values": {
-        "t_tank_top": 11.1377,
-        "t_tank_bottom": 10.4492,
-        "t_collector": 12.1705,
+        "t_tank_top": 11.117,
+        "t_tank_bottom": 10.428,
+        "t_collector": 12.1513,
         "t_greenhouse": 10.7593,
         "t_outdoor": 9.347
       },
@@ -349,9 +349,9 @@
     {
       "time": 1860,
       "values": {
-        "t_tank_top": 11.1534,
-        "t_tank_bottom": 10.4737,
-        "t_collector": 12.2066,
+        "t_tank_top": 11.1321,
+        "t_tank_bottom": 10.4517,
+        "t_collector": 12.1867,
         "t_greenhouse": 10.764,
         "t_outdoor": 9.3686
       },
@@ -360,9 +360,9 @@
     {
       "time": 1920,
       "values": {
-        "t_tank_top": 11.1703,
-        "t_tank_bottom": 10.4978,
-        "t_collector": 12.2423,
+        "t_tank_top": 11.1483,
+        "t_tank_bottom": 10.4752,
+        "t_collector": 12.2218,
         "t_greenhouse": 10.7694,
         "t_outdoor": 9.3903
       },
@@ -371,9 +371,9 @@
     {
       "time": 1980,
       "values": {
-        "t_tank_top": 11.1881,
-        "t_tank_bottom": 10.5217,
-        "t_collector": 12.2776,
+        "t_tank_top": 11.1655,
+        "t_tank_bottom": 10.4985,
+        "t_collector": 12.2566,
         "t_greenhouse": 10.7754,
         "t_outdoor": 9.412
       },
@@ -382,9 +382,9 @@
     {
       "time": 2040,
       "values": {
-        "t_tank_top": 11.2068,
-        "t_tank_bottom": 10.5455,
-        "t_collector": 12.3127,
+        "t_tank_top": 11.1835,
+        "t_tank_bottom": 10.5216,
+        "t_collector": 12.291,
         "t_greenhouse": 10.7819,
         "t_outdoor": 9.4336
       },
@@ -393,9 +393,9 @@
     {
       "time": 2100,
       "values": {
-        "t_tank_top": 11.2262,
-        "t_tank_bottom": 10.569,
-        "t_collector": 12.3475,
+        "t_tank_top": 11.2024,
+        "t_tank_bottom": 10.5445,
+        "t_collector": 12.3252,
         "t_greenhouse": 10.7891,
         "t_outdoor": 9.4553
       },
@@ -404,9 +404,9 @@
     {
       "time": 2160,
       "values": {
-        "t_tank_top": 11.2464,
-        "t_tank_bottom": 10.5924,
-        "t_collector": 12.3821,
+        "t_tank_top": 11.222,
+        "t_tank_bottom": 10.5672,
+        "t_collector": 12.3591,
         "t_greenhouse": 10.7968,
         "t_outdoor": 9.477
       },
@@ -415,9 +415,9 @@
     {
       "time": 2220,
       "values": {
-        "t_tank_top": 11.2673,
-        "t_tank_bottom": 10.6158,
-        "t_collector": 12.4165,
+        "t_tank_top": 11.2422,
+        "t_tank_bottom": 10.5899,
+        "t_collector": 12.3928,
         "t_greenhouse": 10.8051,
         "t_outdoor": 9.4987
       },
@@ -426,9 +426,9 @@
     {
       "time": 2280,
       "values": {
-        "t_tank_top": 11.2887,
-        "t_tank_bottom": 10.639,
-        "t_collector": 12.4507,
+        "t_tank_top": 11.263,
+        "t_tank_bottom": 10.6125,
+        "t_collector": 12.4264,
         "t_greenhouse": 10.8139,
         "t_outdoor": 9.5204
       },
@@ -437,9 +437,9 @@
     {
       "time": 2340,
       "values": {
-        "t_tank_top": 11.3107,
-        "t_tank_bottom": 10.6622,
-        "t_collector": 12.4848,
+        "t_tank_top": 11.2844,
+        "t_tank_bottom": 10.635,
+        "t_collector": 12.4599,
         "t_greenhouse": 10.8232,
         "t_outdoor": 9.5421
       },
@@ -448,9 +448,9 @@
     {
       "time": 2400,
       "values": {
-        "t_tank_top": 11.3332,
-        "t_tank_bottom": 10.6853,
-        "t_collector": 12.5187,
+        "t_tank_top": 11.3062,
+        "t_tank_bottom": 10.6576,
+        "t_collector": 12.4933,
         "t_greenhouse": 10.833,
         "t_outdoor": 9.5639
       },
@@ -459,9 +459,9 @@
     {
       "time": 2460,
       "values": {
-        "t_tank_top": 11.3562,
-        "t_tank_bottom": 10.7085,
-        "t_collector": 12.5526,
+        "t_tank_top": 11.3285,
+        "t_tank_bottom": 10.6801,
+        "t_collector": 12.5265,
         "t_greenhouse": 10.8434,
         "t_outdoor": 9.5856
       },
@@ -470,9 +470,9 @@
     {
       "time": 2520,
       "values": {
-        "t_tank_top": 11.3795,
-        "t_tank_bottom": 10.7316,
-        "t_collector": 12.5865,
+        "t_tank_top": 11.3513,
+        "t_tank_bottom": 10.7025,
+        "t_collector": 12.5597,
         "t_greenhouse": 10.8542,
         "t_outdoor": 9.6073
       },
@@ -481,9 +481,9 @@
     {
       "time": 2580,
       "values": {
-        "t_tank_top": 11.4033,
-        "t_tank_bottom": 10.7548,
-        "t_collector": 12.6202,
+        "t_tank_top": 11.3744,
+        "t_tank_bottom": 10.7251,
+        "t_collector": 12.5929,
         "t_greenhouse": 10.8656,
         "t_outdoor": 9.6291
       },
@@ -492,9 +492,9 @@
     {
       "time": 2640,
       "values": {
-        "t_tank_top": 11.4274,
-        "t_tank_bottom": 10.778,
-        "t_collector": 12.654,
+        "t_tank_top": 11.3979,
+        "t_tank_bottom": 10.7476,
+        "t_collector": 12.626,
         "t_greenhouse": 10.8773,
         "t_outdoor": 9.6509
       },
@@ -503,9 +503,9 @@
     {
       "time": 2700,
       "values": {
-        "t_tank_top": 11.4519,
-        "t_tank_bottom": 10.8012,
-        "t_collector": 12.6877,
+        "t_tank_top": 11.4217,
+        "t_tank_bottom": 10.7702,
+        "t_collector": 12.6591,
         "t_greenhouse": 10.8896,
         "t_outdoor": 9.6726
       },
@@ -514,9 +514,9 @@
     {
       "time": 2760,
       "values": {
-        "t_tank_top": 11.4767,
-        "t_tank_bottom": 10.8245,
-        "t_collector": 12.7214,
+        "t_tank_top": 11.4459,
+        "t_tank_bottom": 10.7928,
+        "t_collector": 12.6922,
         "t_greenhouse": 10.9023,
         "t_outdoor": 9.6944
       },
@@ -525,9 +525,9 @@
     {
       "time": 2820,
       "values": {
-        "t_tank_top": 11.5017,
-        "t_tank_bottom": 10.8478,
-        "t_collector": 12.7552,
+        "t_tank_top": 11.4703,
+        "t_tank_bottom": 10.8155,
+        "t_collector": 12.7253,
         "t_greenhouse": 10.9154,
         "t_outdoor": 9.7162
       },
@@ -536,9 +536,9 @@
     {
       "time": 2880,
       "values": {
-        "t_tank_top": 11.527,
-        "t_tank_bottom": 10.8712,
-        "t_collector": 12.7889,
+        "t_tank_top": 11.495,
+        "t_tank_bottom": 10.8382,
+        "t_collector": 12.7585,
         "t_greenhouse": 10.9289,
         "t_outdoor": 9.738
       },
@@ -547,9 +547,9 @@
     {
       "time": 2940,
       "values": {
-        "t_tank_top": 11.5526,
-        "t_tank_bottom": 10.8946,
-        "t_collector": 12.8227,
+        "t_tank_top": 11.5199,
+        "t_tank_bottom": 10.8611,
+        "t_collector": 12.7916,
         "t_greenhouse": 10.9429,
         "t_outdoor": 9.7597
       },
@@ -558,9 +558,9 @@
     {
       "time": 3000,
       "values": {
-        "t_tank_top": 11.5784,
-        "t_tank_bottom": 10.9182,
-        "t_collector": 12.8565,
+        "t_tank_top": 11.5451,
+        "t_tank_bottom": 10.884,
+        "t_collector": 12.8248,
         "t_greenhouse": 10.9572,
         "t_outdoor": 9.7815
       },
@@ -569,9 +569,9 @@
     {
       "time": 3060,
       "values": {
-        "t_tank_top": 11.6045,
-        "t_tank_bottom": 10.9418,
-        "t_collector": 12.8904,
+        "t_tank_top": 11.5705,
+        "t_tank_bottom": 10.9069,
+        "t_collector": 12.858,
         "t_greenhouse": 10.9719,
         "t_outdoor": 9.8033
       },
@@ -580,9 +580,9 @@
     {
       "time": 3120,
       "values": {
-        "t_tank_top": 11.6307,
-        "t_tank_bottom": 10.9655,
-        "t_collector": 12.9243,
+        "t_tank_top": 11.5961,
+        "t_tank_bottom": 10.93,
+        "t_collector": 12.8913,
         "t_greenhouse": 10.9871,
         "t_outdoor": 9.8251
       },
@@ -591,9 +591,9 @@
     {
       "time": 3180,
       "values": {
-        "t_tank_top": 11.6572,
-        "t_tank_bottom": 10.9894,
-        "t_collector": 12.9582,
+        "t_tank_top": 11.622,
+        "t_tank_bottom": 10.9532,
+        "t_collector": 12.9246,
         "t_greenhouse": 11.0026,
         "t_outdoor": 9.8469
       },
@@ -602,9 +602,9 @@
     {
       "time": 3240,
       "values": {
-        "t_tank_top": 11.6839,
-        "t_tank_bottom": 11.0133,
-        "t_collector": 12.9922,
+        "t_tank_top": 11.648,
+        "t_tank_bottom": 10.9764,
+        "t_collector": 12.958,
         "t_greenhouse": 11.0184,
         "t_outdoor": 9.8688
       },
@@ -613,9 +613,9 @@
     {
       "time": 3300,
       "values": {
-        "t_tank_top": 11.7107,
-        "t_tank_bottom": 11.0373,
-        "t_collector": 13.0263,
+        "t_tank_top": 11.6742,
+        "t_tank_bottom": 10.9998,
+        "t_collector": 12.9914,
         "t_greenhouse": 11.0346,
         "t_outdoor": 9.8906
       },
@@ -624,9 +624,9 @@
     {
       "time": 3360,
       "values": {
-        "t_tank_top": 11.7377,
-        "t_tank_bottom": 11.0614,
-        "t_collector": 13.0604,
+        "t_tank_top": 11.7006,
+        "t_tank_bottom": 11.0233,
+        "t_collector": 13.0249,
         "t_greenhouse": 11.0512,
         "t_outdoor": 9.9124
       },
@@ -635,9 +635,9 @@
     {
       "time": 3420,
       "values": {
-        "t_tank_top": 11.7649,
-        "t_tank_bottom": 11.0856,
-        "t_collector": 13.0946,
+        "t_tank_top": 11.7271,
+        "t_tank_bottom": 11.0468,
+        "t_collector": 13.0585,
         "t_greenhouse": 11.0681,
         "t_outdoor": 9.9342
       },
@@ -646,9 +646,9 @@
     {
       "time": 3480,
       "values": {
-        "t_tank_top": 11.7923,
-        "t_tank_bottom": 11.1099,
-        "t_collector": 13.1288,
+        "t_tank_top": 11.7538,
+        "t_tank_bottom": 11.0705,
+        "t_collector": 13.0921,
         "t_greenhouse": 11.0853,
         "t_outdoor": 9.956
       },
@@ -657,9 +657,9 @@
     {
       "time": 3540,
       "values": {
-        "t_tank_top": 11.8198,
-        "t_tank_bottom": 11.1344,
-        "t_collector": 13.1631,
+        "t_tank_top": 11.7807,
+        "t_tank_bottom": 11.0943,
+        "t_collector": 13.1258,
         "t_greenhouse": 11.1028,
         "t_outdoor": 9.9778
       },
@@ -668,9 +668,9 @@
     {
       "time": 3600,
       "values": {
-        "t_tank_top": 11.8475,
-        "t_tank_bottom": 11.1589,
-        "t_collector": 13.1975,
+        "t_tank_top": 11.8077,
+        "t_tank_bottom": 11.1182,
+        "t_collector": 13.1596,
         "t_greenhouse": 11.1206,
         "t_outdoor": 9.9996
       },
@@ -679,9 +679,9 @@
     {
       "time": 3660,
       "values": {
-        "t_tank_top": 11.8753,
-        "t_tank_bottom": 11.1836,
-        "t_collector": 13.232,
+        "t_tank_top": 11.8349,
+        "t_tank_bottom": 11.1422,
+        "t_collector": 13.1934,
         "t_greenhouse": 11.1388,
         "t_outdoor": 10.0215
       },
@@ -690,9 +690,9 @@
     {
       "time": 3720,
       "values": {
-        "t_tank_top": 11.9033,
-        "t_tank_bottom": 11.2083,
-        "t_collector": 13.2666,
+        "t_tank_top": 11.8622,
+        "t_tank_bottom": 11.1663,
+        "t_collector": 13.2274,
         "t_greenhouse": 11.1572,
         "t_outdoor": 10.0433
       },
@@ -701,9 +701,9 @@
     {
       "time": 3780,
       "values": {
-        "t_tank_top": 11.9314,
-        "t_tank_bottom": 11.2332,
-        "t_collector": 13.3012,
+        "t_tank_top": 11.8897,
+        "t_tank_bottom": 11.1905,
+        "t_collector": 13.2614,
         "t_greenhouse": 11.1759,
         "t_outdoor": 10.0651
       },
@@ -712,9 +712,9 @@
     {
       "time": 3840,
       "values": {
-        "t_tank_top": 11.9596,
-        "t_tank_bottom": 11.2582,
-        "t_collector": 13.3359,
+        "t_tank_top": 11.9173,
+        "t_tank_bottom": 11.2149,
+        "t_collector": 13.2954,
         "t_greenhouse": 11.1949,
         "t_outdoor": 10.0869
       },
@@ -723,9 +723,9 @@
     {
       "time": 3900,
       "values": {
-        "t_tank_top": 11.988,
-        "t_tank_bottom": 11.2834,
-        "t_collector": 13.3707,
+        "t_tank_top": 11.945,
+        "t_tank_bottom": 11.2393,
+        "t_collector": 13.3296,
         "t_greenhouse": 11.2142,
         "t_outdoor": 10.1087
       },
@@ -734,9 +734,9 @@
     {
       "time": 3960,
       "values": {
-        "t_tank_top": 12.0165,
-        "t_tank_bottom": 11.3086,
-        "t_collector": 13.4056,
+        "t_tank_top": 11.9729,
+        "t_tank_bottom": 11.2639,
+        "t_collector": 13.3638,
         "t_greenhouse": 11.2338,
         "t_outdoor": 10.1305
       },
@@ -745,9 +745,9 @@
     {
       "time": 4020,
       "values": {
-        "t_tank_top": 12.0451,
-        "t_tank_bottom": 11.334,
-        "t_collector": 13.4405,
+        "t_tank_top": 12.0009,
+        "t_tank_bottom": 11.2886,
+        "t_collector": 13.3981,
         "t_greenhouse": 11.2536,
         "t_outdoor": 10.1523
       },
@@ -756,9 +756,9 @@
     {
       "time": 4080,
       "values": {
-        "t_tank_top": 12.0739,
-        "t_tank_bottom": 11.3594,
-        "t_collector": 13.4756,
+        "t_tank_top": 12.029,
+        "t_tank_bottom": 11.3134,
+        "t_collector": 13.4325,
         "t_greenhouse": 11.2736,
         "t_outdoor": 10.1741
       },
@@ -767,9 +767,9 @@
     {
       "time": 4140,
       "values": {
-        "t_tank_top": 12.1028,
-        "t_tank_bottom": 11.385,
-        "t_collector": 13.5107,
+        "t_tank_top": 12.0572,
+        "t_tank_bottom": 11.3383,
+        "t_collector": 13.467,
         "t_greenhouse": 11.2939,
         "t_outdoor": 10.1959
       },
@@ -778,9 +778,9 @@
     {
       "time": 4200,
       "values": {
-        "t_tank_top": 12.1318,
-        "t_tank_bottom": 11.4107,
-        "t_collector": 13.5459,
+        "t_tank_top": 12.0855,
+        "t_tank_bottom": 11.3633,
+        "t_collector": 13.5016,
         "t_greenhouse": 11.3144,
         "t_outdoor": 10.2177
       },
@@ -789,9 +789,9 @@
     {
       "time": 4260,
       "values": {
-        "t_tank_top": 12.1609,
-        "t_tank_bottom": 11.4366,
-        "t_collector": 13.5812,
+        "t_tank_top": 12.114,
+        "t_tank_bottom": 11.3885,
+        "t_collector": 13.5362,
         "t_greenhouse": 11.3352,
         "t_outdoor": 10.2395
       },
@@ -800,9 +800,9 @@
     {
       "time": 4320,
       "values": {
-        "t_tank_top": 12.1902,
-        "t_tank_bottom": 11.4625,
-        "t_collector": 13.6165,
+        "t_tank_top": 12.1426,
+        "t_tank_bottom": 11.4138,
+        "t_collector": 13.5709,
         "t_greenhouse": 11.3562,
         "t_outdoor": 10.2613
       },
@@ -811,9 +811,9 @@
     {
       "time": 4380,
       "values": {
-        "t_tank_top": 12.2196,
-        "t_tank_bottom": 11.4886,
-        "t_collector": 13.652,
+        "t_tank_top": 12.1713,
+        "t_tank_bottom": 11.4392,
+        "t_collector": 13.6057,
         "t_greenhouse": 11.3774,
         "t_outdoor": 10.2831
       },
@@ -822,9 +822,9 @@
     {
       "time": 4440,
       "values": {
-        "t_tank_top": 12.2491,
-        "t_tank_bottom": 11.5147,
-        "t_collector": 13.6875,
+        "t_tank_top": 12.2001,
+        "t_tank_bottom": 11.4647,
+        "t_collector": 13.6406,
         "t_greenhouse": 11.3988,
         "t_outdoor": 10.3049
       },
@@ -833,9 +833,9 @@
     {
       "time": 4500,
       "values": {
-        "t_tank_top": 12.2787,
-        "t_tank_bottom": 11.541,
-        "t_collector": 13.7231,
+        "t_tank_top": 12.2291,
+        "t_tank_bottom": 11.4903,
+        "t_collector": 13.6755,
         "t_greenhouse": 11.4205,
         "t_outdoor": 10.3267
       },
@@ -844,9 +844,9 @@
     {
       "time": 4560,
       "values": {
-        "t_tank_top": 12.3084,
-        "t_tank_bottom": 11.5675,
-        "t_collector": 13.7588,
+        "t_tank_top": 12.2581,
+        "t_tank_bottom": 11.516,
+        "t_collector": 13.7106,
         "t_greenhouse": 11.4423,
         "t_outdoor": 10.3484
       },
@@ -855,9 +855,9 @@
     {
       "time": 4620,
       "values": {
-        "t_tank_top": 12.3382,
-        "t_tank_bottom": 11.594,
-        "t_collector": 13.7945,
+        "t_tank_top": 12.2873,
+        "t_tank_bottom": 11.5419,
+        "t_collector": 13.7457,
         "t_greenhouse": 11.4643,
         "t_outdoor": 10.3702
       },
@@ -866,9 +866,9 @@
     {
       "time": 4680,
       "values": {
-        "t_tank_top": 12.3682,
-        "t_tank_bottom": 11.6207,
-        "t_collector": 13.8304,
+        "t_tank_top": 12.3166,
+        "t_tank_bottom": 11.5678,
+        "t_collector": 13.7809,
         "t_greenhouse": 11.4865,
         "t_outdoor": 10.3919
       },
@@ -877,9 +877,9 @@
     {
       "time": 4740,
       "values": {
-        "t_tank_top": 12.3982,
-        "t_tank_bottom": 11.6474,
-        "t_collector": 13.8663,
+        "t_tank_top": 12.3459,
+        "t_tank_bottom": 11.5939,
+        "t_collector": 13.8161,
         "t_greenhouse": 11.5089,
         "t_outdoor": 10.4137
       },
@@ -888,9 +888,9 @@
     {
       "time": 4800,
       "values": {
-        "t_tank_top": 12.4284,
-        "t_tank_bottom": 11.6743,
-        "t_collector": 13.9023,
+        "t_tank_top": 12.3754,
+        "t_tank_bottom": 11.6201,
+        "t_collector": 13.8515,
         "t_greenhouse": 11.5315,
         "t_outdoor": 10.4354
       },
@@ -899,9 +899,9 @@
     {
       "time": 4860,
       "values": {
-        "t_tank_top": 12.4587,
-        "t_tank_bottom": 11.7013,
-        "t_collector": 13.9384,
+        "t_tank_top": 12.405,
+        "t_tank_bottom": 11.6464,
+        "t_collector": 13.8869,
         "t_greenhouse": 11.5543,
         "t_outdoor": 10.4571
       },
@@ -910,9 +910,9 @@
     {
       "time": 4920,
       "values": {
-        "t_tank_top": 12.489,
-        "t_tank_bottom": 11.7284,
-        "t_collector": 13.9746,
+        "t_tank_top": 12.4347,
+        "t_tank_bottom": 11.6728,
+        "t_collector": 13.9224,
         "t_greenhouse": 11.5772,
         "t_outdoor": 10.4789
       },
@@ -921,9 +921,9 @@
     {
       "time": 4980,
       "values": {
-        "t_tank_top": 12.5195,
-        "t_tank_bottom": 11.7557,
-        "t_collector": 14.0109,
+        "t_tank_top": 12.4645,
+        "t_tank_bottom": 11.6994,
+        "t_collector": 13.958,
         "t_greenhouse": 11.6003,
         "t_outdoor": 10.5006
       },
@@ -932,9 +932,9 @@
     {
       "time": 5040,
       "values": {
-        "t_tank_top": 12.5501,
-        "t_tank_bottom": 11.783,
-        "t_collector": 14.0472,
+        "t_tank_top": 12.4944,
+        "t_tank_bottom": 11.726,
+        "t_collector": 13.9937,
         "t_greenhouse": 11.6236,
         "t_outdoor": 10.5223
       },
@@ -943,9 +943,9 @@
     {
       "time": 5100,
       "values": {
-        "t_tank_top": 12.5808,
-        "t_tank_bottom": 11.8105,
-        "t_collector": 14.0836,
+        "t_tank_top": 12.5244,
+        "t_tank_bottom": 11.7528,
+        "t_collector": 14.0294,
         "t_greenhouse": 11.647,
         "t_outdoor": 10.544
       },
@@ -954,9 +954,9 @@
     {
       "time": 5160,
       "values": {
-        "t_tank_top": 12.6116,
-        "t_tank_bottom": 11.8381,
-        "t_collector": 14.1201,
+        "t_tank_top": 12.5546,
+        "t_tank_bottom": 11.7797,
+        "t_collector": 14.0652,
         "t_greenhouse": 11.6705,
         "t_outdoor": 10.5657
       },
@@ -965,9 +965,9 @@
     {
       "time": 5220,
       "values": {
-        "t_tank_top": 12.6425,
-        "t_tank_bottom": 11.8658,
-        "t_collector": 14.1567,
+        "t_tank_top": 12.5848,
+        "t_tank_bottom": 11.8067,
+        "t_collector": 14.1011,
         "t_greenhouse": 11.6942,
         "t_outdoor": 10.5873
       },
@@ -976,9 +976,9 @@
     {
       "time": 5280,
       "values": {
-        "t_tank_top": 12.6736,
-        "t_tank_bottom": 11.8936,
-        "t_collector": 14.1933,
+        "t_tank_top": 12.6151,
+        "t_tank_bottom": 11.8338,
+        "t_collector": 14.1371,
         "t_greenhouse": 11.7181,
         "t_outdoor": 10.609
       },
@@ -987,9 +987,9 @@
     {
       "time": 5340,
       "values": {
-        "t_tank_top": 12.7047,
-        "t_tank_bottom": 11.9215,
-        "t_collector": 14.23,
+        "t_tank_top": 12.6455,
+        "t_tank_bottom": 11.861,
+        "t_collector": 14.1731,
         "t_greenhouse": 11.7421,
         "t_outdoor": 10.6306
       },
@@ -998,9 +998,9 @@
     {
       "time": 5400,
       "values": {
-        "t_tank_top": 12.7359,
-        "t_tank_bottom": 11.9496,
-        "t_collector": 14.2668,
+        "t_tank_top": 12.676,
+        "t_tank_bottom": 11.8883,
+        "t_collector": 14.2092,
         "t_greenhouse": 11.7662,
         "t_outdoor": 10.6523
       },
@@ -1009,9 +1009,9 @@
     {
       "time": 5460,
       "values": {
-        "t_tank_top": 12.7672,
-        "t_tank_bottom": 11.9777,
-        "t_collector": 14.3037,
+        "t_tank_top": 12.7066,
+        "t_tank_bottom": 11.9158,
+        "t_collector": 14.2454,
         "t_greenhouse": 11.7905,
         "t_outdoor": 10.6739
       },
@@ -1020,9 +1020,9 @@
     {
       "time": 5520,
       "values": {
-        "t_tank_top": 12.7986,
-        "t_tank_bottom": 12.006,
-        "t_collector": 14.3406,
+        "t_tank_top": 12.7373,
+        "t_tank_bottom": 11.9433,
+        "t_collector": 14.2817,
         "t_greenhouse": 11.8148,
         "t_outdoor": 10.6955
       },
@@ -1031,9 +1031,9 @@
     {
       "time": 5580,
       "values": {
-        "t_tank_top": 12.8302,
-        "t_tank_bottom": 12.0344,
-        "t_collector": 14.3777,
+        "t_tank_top": 12.7681,
+        "t_tank_bottom": 11.9709,
+        "t_collector": 14.318,
         "t_greenhouse": 11.8393,
         "t_outdoor": 10.7171
       },
@@ -1042,9 +1042,9 @@
     {
       "time": 5640,
       "values": {
-        "t_tank_top": 12.8618,
-        "t_tank_bottom": 12.0629,
-        "t_collector": 14.4148,
+        "t_tank_top": 12.799,
+        "t_tank_bottom": 11.9987,
+        "t_collector": 14.3544,
         "t_greenhouse": 11.8639,
         "t_outdoor": 10.7387
       },
@@ -1053,9 +1053,9 @@
     {
       "time": 5700,
       "values": {
-        "t_tank_top": 12.8935,
-        "t_tank_bottom": 12.0915,
-        "t_collector": 14.4519,
+        "t_tank_top": 12.83,
+        "t_tank_bottom": 12.0266,
+        "t_collector": 14.3908,
         "t_greenhouse": 11.8887,
         "t_outdoor": 10.7603
       },
@@ -1064,9 +1064,9 @@
     {
       "time": 5760,
       "values": {
-        "t_tank_top": 12.9253,
-        "t_tank_bottom": 12.1202,
-        "t_collector": 14.4892,
+        "t_tank_top": 12.8611,
+        "t_tank_bottom": 12.0546,
+        "t_collector": 14.4274,
         "t_greenhouse": 11.9135,
         "t_outdoor": 10.7818
       },
@@ -1075,9 +1075,9 @@
     {
       "time": 5820,
       "values": {
-        "t_tank_top": 12.9572,
-        "t_tank_bottom": 12.149,
-        "t_collector": 14.5265,
+        "t_tank_top": 12.8923,
+        "t_tank_bottom": 12.0826,
+        "t_collector": 14.464,
         "t_greenhouse": 11.9384,
         "t_outdoor": 10.8034
       },
@@ -1086,9 +1086,9 @@
     {
       "time": 5880,
       "values": {
-        "t_tank_top": 12.9892,
-        "t_tank_bottom": 12.178,
-        "t_collector": 14.5639,
+        "t_tank_top": 12.9236,
+        "t_tank_bottom": 12.1108,
+        "t_collector": 14.5007,
         "t_greenhouse": 11.9635,
         "t_outdoor": 10.8249
       },
@@ -1097,9 +1097,9 @@
     {
       "time": 5940,
       "values": {
-        "t_tank_top": 13.0213,
-        "t_tank_bottom": 12.207,
-        "t_collector": 14.6013,
+        "t_tank_top": 12.955,
+        "t_tank_bottom": 12.1391,
+        "t_collector": 14.5374,
         "t_greenhouse": 11.9886,
         "t_outdoor": 10.8464
       },
@@ -1108,9 +1108,9 @@
     {
       "time": 6000,
       "values": {
-        "t_tank_top": 13.0536,
-        "t_tank_bottom": 12.2362,
-        "t_collector": 14.6388,
+        "t_tank_top": 12.9864,
+        "t_tank_bottom": 12.1675,
+        "t_collector": 14.5742,
         "t_greenhouse": 12.0139,
         "t_outdoor": 10.8679
       },
@@ -1119,9 +1119,9 @@
     {
       "time": 6060,
       "values": {
-        "t_tank_top": 13.0859,
-        "t_tank_bottom": 12.2654,
-        "t_collector": 14.6764,
+        "t_tank_top": 13.018,
+        "t_tank_bottom": 12.196,
+        "t_collector": 14.6111,
         "t_greenhouse": 12.0392,
         "t_outdoor": 10.8894
       },
@@ -1130,9 +1130,9 @@
     {
       "time": 6120,
       "values": {
-        "t_tank_top": 13.1182,
-        "t_tank_bottom": 12.2948,
-        "t_collector": 14.7141,
+        "t_tank_top": 13.0497,
+        "t_tank_bottom": 12.2247,
+        "t_collector": 14.648,
         "t_greenhouse": 12.0646,
         "t_outdoor": 10.9108
       },
@@ -1141,9 +1141,9 @@
     {
       "time": 6180,
       "values": {
-        "t_tank_top": 13.1507,
-        "t_tank_bottom": 12.3243,
-        "t_collector": 14.7518,
+        "t_tank_top": 13.0814,
+        "t_tank_bottom": 12.2534,
+        "t_collector": 14.685,
         "t_greenhouse": 12.0901,
         "t_outdoor": 10.9323
       },
@@ -1152,9 +1152,9 @@
     {
       "time": 6240,
       "values": {
-        "t_tank_top": 13.1833,
-        "t_tank_bottom": 12.3539,
-        "t_collector": 14.7896,
+        "t_tank_top": 13.1132,
+        "t_tank_bottom": 12.2822,
+        "t_collector": 14.7221,
         "t_greenhouse": 12.1157,
         "t_outdoor": 10.9537
       },
@@ -1163,9 +1163,9 @@
     {
       "time": 6300,
       "values": {
-        "t_tank_top": 13.216,
-        "t_tank_bottom": 12.3835,
-        "t_collector": 14.8275,
+        "t_tank_top": 13.1451,
+        "t_tank_bottom": 12.3111,
+        "t_collector": 14.7592,
         "t_greenhouse": 12.1414,
         "t_outdoor": 10.9751
       },
@@ -1174,9 +1174,9 @@
     {
       "time": 6360,
       "values": {
-        "t_tank_top": 13.2488,
-        "t_tank_bottom": 12.4133,
-        "t_collector": 14.8654,
+        "t_tank_top": 13.1772,
+        "t_tank_bottom": 12.3401,
+        "t_collector": 14.7964,
         "t_greenhouse": 12.1671,
         "t_outdoor": 10.9965
       },
@@ -1185,9 +1185,9 @@
     {
       "time": 6420,
       "values": {
-        "t_tank_top": 13.2816,
-        "t_tank_bottom": 12.4432,
-        "t_collector": 14.9034,
+        "t_tank_top": 13.2093,
+        "t_tank_bottom": 12.3693,
+        "t_collector": 14.8337,
         "t_greenhouse": 12.1929,
         "t_outdoor": 11.0179
       },
@@ -1196,9 +1196,9 @@
     {
       "time": 6480,
       "values": {
-        "t_tank_top": 13.3146,
-        "t_tank_bottom": 12.4732,
-        "t_collector": 14.9415,
+        "t_tank_top": 13.2414,
+        "t_tank_bottom": 12.3985,
+        "t_collector": 14.871,
         "t_greenhouse": 12.2188,
         "t_outdoor": 11.0392
       },
@@ -1207,9 +1207,9 @@
     {
       "time": 6540,
       "values": {
-        "t_tank_top": 13.3476,
-        "t_tank_bottom": 12.5034,
-        "t_collector": 14.9796,
+        "t_tank_top": 13.2737,
+        "t_tank_bottom": 12.4278,
+        "t_collector": 14.9084,
         "t_greenhouse": 12.2448,
         "t_outdoor": 11.0605
       },
@@ -1218,9 +1218,9 @@
     {
       "time": 6600,
       "values": {
-        "t_tank_top": 13.3807,
-        "t_tank_bottom": 12.5336,
-        "t_collector": 15.0178,
+        "t_tank_top": 13.3061,
+        "t_tank_bottom": 12.4572,
+        "t_collector": 14.9459,
         "t_greenhouse": 12.2708,
         "t_outdoor": 11.0818
       },
@@ -1229,9 +1229,9 @@
     {
       "time": 6660,
       "values": {
-        "t_tank_top": 13.4139,
-        "t_tank_bottom": 12.5639,
-        "t_collector": 15.0561,
+        "t_tank_top": 13.3385,
+        "t_tank_bottom": 12.4868,
+        "t_collector": 14.9834,
         "t_greenhouse": 12.2968,
         "t_outdoor": 11.1031
       },
@@ -1240,9 +1240,9 @@
     {
       "time": 6720,
       "values": {
-        "t_tank_top": 13.4473,
-        "t_tank_bottom": 12.5943,
-        "t_collector": 15.0944,
+        "t_tank_top": 13.371,
+        "t_tank_bottom": 12.5164,
+        "t_collector": 15.0209,
         "t_greenhouse": 12.323,
         "t_outdoor": 11.1244
       },
@@ -1251,9 +1251,9 @@
     {
       "time": 6780,
       "values": {
-        "t_tank_top": 13.4807,
-        "t_tank_bottom": 12.6248,
-        "t_collector": 15.1328,
+        "t_tank_top": 13.4036,
+        "t_tank_bottom": 12.5461,
+        "t_collector": 15.0585,
         "t_greenhouse": 12.3492,
         "t_outdoor": 11.1456
       },
@@ -1262,9 +1262,9 @@
     {
       "time": 6840,
       "values": {
-        "t_tank_top": 13.5141,
-        "t_tank_bottom": 12.6555,
-        "t_collector": 15.1712,
+        "t_tank_top": 13.4363,
+        "t_tank_bottom": 12.5759,
+        "t_collector": 15.0962,
         "t_greenhouse": 12.3754,
         "t_outdoor": 11.1669
       },
@@ -1273,9 +1273,9 @@
     {
       "time": 6900,
       "values": {
-        "t_tank_top": 13.5477,
-        "t_tank_bottom": 12.6862,
-        "t_collector": 15.2097,
+        "t_tank_top": 13.4691,
+        "t_tank_bottom": 12.6059,
+        "t_collector": 15.134,
         "t_greenhouse": 12.4017,
         "t_outdoor": 11.1881
       },
@@ -1284,9 +1284,9 @@
     {
       "time": 6960,
       "values": {
-        "t_tank_top": 13.5814,
-        "t_tank_bottom": 12.717,
-        "t_collector": 15.2483,
+        "t_tank_top": 13.502,
+        "t_tank_bottom": 12.6359,
+        "t_collector": 15.1717,
         "t_greenhouse": 12.4281,
         "t_outdoor": 11.2093
       },
@@ -1295,9 +1295,9 @@
     {
       "time": 7020,
       "values": {
-        "t_tank_top": 13.6151,
-        "t_tank_bottom": 12.7479,
-        "t_collector": 15.2869,
+        "t_tank_top": 13.5349,
+        "t_tank_bottom": 12.666,
+        "t_collector": 15.2096,
         "t_greenhouse": 12.4545,
         "t_outdoor": 11.2304
       },
@@ -1306,9 +1306,9 @@
     {
       "time": 7080,
       "values": {
-        "t_tank_top": 13.6489,
-        "t_tank_bottom": 12.779,
-        "t_collector": 15.3256,
+        "t_tank_top": 13.5679,
+        "t_tank_bottom": 12.6962,
+        "t_collector": 15.2475,
         "t_greenhouse": 12.4809,
         "t_outdoor": 11.2515
       },
@@ -1317,9 +1317,9 @@
     {
       "time": 7140,
       "values": {
-        "t_tank_top": 13.6828,
-        "t_tank_bottom": 12.8101,
-        "t_collector": 15.3644,
+        "t_tank_top": 13.601,
+        "t_tank_bottom": 12.7265,
+        "t_collector": 15.2855,
         "t_greenhouse": 12.5074,
         "t_outdoor": 11.2727
       },
@@ -1328,9 +1328,9 @@
     {
       "time": 7200,
       "values": {
-        "t_tank_top": 13.7168,
-        "t_tank_bottom": 12.8413,
-        "t_collector": 15.4032,
+        "t_tank_top": 13.6342,
+        "t_tank_bottom": 12.7569,
+        "t_collector": 15.3235,
         "t_greenhouse": 12.5339,
         "t_outdoor": 11.2937
       },
@@ -1339,9 +1339,9 @@
     {
       "time": 7260,
       "values": {
-        "t_tank_top": 13.7509,
-        "t_tank_bottom": 12.8726,
-        "t_collector": 15.442,
+        "t_tank_top": 13.6675,
+        "t_tank_bottom": 12.7874,
+        "t_collector": 15.3615,
         "t_greenhouse": 12.5605,
         "t_outdoor": 11.3148
       },
@@ -1350,9 +1350,9 @@
     {
       "time": 7320,
       "values": {
-        "t_tank_top": 13.7851,
-        "t_tank_bottom": 12.9041,
-        "t_collector": 15.4809,
+        "t_tank_top": 13.7008,
+        "t_tank_bottom": 12.818,
+        "t_collector": 15.3996,
         "t_greenhouse": 12.587,
         "t_outdoor": 11.3358
       },
@@ -1361,9 +1361,9 @@
     {
       "time": 7380,
       "values": {
-        "t_tank_top": 13.8193,
-        "t_tank_bottom": 12.9356,
-        "t_collector": 15.5199,
+        "t_tank_top": 13.7343,
+        "t_tank_bottom": 12.8486,
+        "t_collector": 15.4378,
         "t_greenhouse": 12.6137,
         "t_outdoor": 11.3569
       },
@@ -1372,9 +1372,9 @@
     {
       "time": 7440,
       "values": {
-        "t_tank_top": 13.8537,
-        "t_tank_bottom": 12.9672,
-        "t_collector": 15.5589,
+        "t_tank_top": 13.7677,
+        "t_tank_bottom": 12.8794,
+        "t_collector": 15.476,
         "t_greenhouse": 12.6403,
         "t_outdoor": 11.3778
       },
@@ -1383,9 +1383,9 @@
     {
       "time": 7500,
       "values": {
-        "t_tank_top": 13.8881,
-        "t_tank_bottom": 12.9989,
-        "t_collector": 15.598,
+        "t_tank_top": 13.8013,
+        "t_tank_bottom": 12.9103,
+        "t_collector": 15.5143,
         "t_greenhouse": 12.667,
         "t_outdoor": 11.3988
       },
@@ -1394,9 +1394,9 @@
     {
       "time": 7560,
       "values": {
-        "t_tank_top": 13.9226,
-        "t_tank_bottom": 13.0307,
-        "t_collector": 15.6371,
+        "t_tank_top": 13.835,
+        "t_tank_bottom": 12.9412,
+        "t_collector": 15.5526,
         "t_greenhouse": 12.6937,
         "t_outdoor": 11.4197
       },
@@ -1405,9 +1405,9 @@
     {
       "time": 7620,
       "values": {
-        "t_tank_top": 13.9571,
-        "t_tank_bottom": 13.0626,
-        "t_collector": 15.6763,
+        "t_tank_top": 13.8687,
+        "t_tank_bottom": 12.9722,
+        "t_collector": 15.591,
         "t_greenhouse": 12.7204,
         "t_outdoor": 11.4406
       },
@@ -1416,9 +1416,9 @@
     {
       "time": 7680,
       "values": {
-        "t_tank_top": 13.9918,
-        "t_tank_bottom": 13.0946,
-        "t_collector": 15.7156,
+        "t_tank_top": 13.9025,
+        "t_tank_bottom": 13.0034,
+        "t_collector": 15.6294,
         "t_greenhouse": 12.7472,
         "t_outdoor": 11.4615
       },
@@ -1427,9 +1427,9 @@
     {
       "time": 7740,
       "values": {
-        "t_tank_top": 14.0265,
-        "t_tank_bottom": 13.1267,
-        "t_collector": 15.7548,
+        "t_tank_top": 13.9364,
+        "t_tank_bottom": 13.0346,
+        "t_collector": 15.6679,
         "t_greenhouse": 12.774,
         "t_outdoor": 11.4824
       },
@@ -1438,9 +1438,9 @@
     {
       "time": 7800,
       "values": {
-        "t_tank_top": 14.0613,
-        "t_tank_bottom": 13.1589,
-        "t_collector": 15.7942,
+        "t_tank_top": 13.9703,
+        "t_tank_bottom": 13.0659,
+        "t_collector": 15.7064,
         "t_greenhouse": 12.8007,
         "t_outdoor": 11.5032
       },
@@ -1449,9 +1449,9 @@
     {
       "time": 7860,
       "values": {
-        "t_tank_top": 14.0962,
-        "t_tank_bottom": 13.1911,
-        "t_collector": 15.8336,
+        "t_tank_top": 14.0043,
+        "t_tank_bottom": 13.0973,
+        "t_collector": 15.7449,
         "t_greenhouse": 12.8275,
         "t_outdoor": 11.524
       },
@@ -1460,9 +1460,9 @@
     {
       "time": 7920,
       "values": {
-        "t_tank_top": 14.1311,
-        "t_tank_bottom": 13.2235,
-        "t_collector": 15.873,
+        "t_tank_top": 14.0384,
+        "t_tank_bottom": 13.1288,
+        "t_collector": 15.7835,
         "t_greenhouse": 12.8544,
         "t_outdoor": 11.5447
       },
@@ -1471,9 +1471,9 @@
     {
       "time": 7980,
       "values": {
-        "t_tank_top": 14.1662,
-        "t_tank_bottom": 13.2559,
-        "t_collector": 15.9125,
+        "t_tank_top": 14.0726,
+        "t_tank_bottom": 13.1603,
+        "t_collector": 15.8222,
         "t_greenhouse": 12.8812,
         "t_outdoor": 11.5655
       },
@@ -1482,9 +1482,9 @@
     {
       "time": 8040,
       "values": {
-        "t_tank_top": 14.2013,
-        "t_tank_bottom": 13.2885,
-        "t_collector": 15.9521,
+        "t_tank_top": 14.1068,
+        "t_tank_bottom": 13.192,
+        "t_collector": 15.8608,
         "t_greenhouse": 12.908,
         "t_outdoor": 11.5862
       },
@@ -1493,9 +1493,9 @@
     {
       "time": 8100,
       "values": {
-        "t_tank_top": 14.2365,
-        "t_tank_bottom": 13.3211,
-        "t_collector": 15.9916,
+        "t_tank_top": 14.1411,
+        "t_tank_bottom": 13.2237,
+        "t_collector": 15.8996,
         "t_greenhouse": 12.9349,
         "t_outdoor": 11.6069
       },
@@ -1504,9 +1504,9 @@
     {
       "time": 8160,
       "values": {
-        "t_tank_top": 14.2717,
-        "t_tank_bottom": 13.3539,
-        "t_collector": 16.0313,
+        "t_tank_top": 14.1755,
+        "t_tank_bottom": 13.2555,
+        "t_collector": 15.9383,
         "t_greenhouse": 12.9618,
         "t_outdoor": 11.6275
       },
@@ -1515,9 +1515,9 @@
     {
       "time": 8220,
       "values": {
-        "t_tank_top": 14.3071,
-        "t_tank_bottom": 13.3867,
-        "t_collector": 16.071,
+        "t_tank_top": 14.2099,
+        "t_tank_bottom": 13.2874,
+        "t_collector": 15.9772,
         "t_greenhouse": 12.9886,
         "t_outdoor": 11.6481
       },
@@ -1526,9 +1526,9 @@
     {
       "time": 8280,
       "values": {
-        "t_tank_top": 14.3425,
-        "t_tank_bottom": 13.4196,
-        "t_collector": 16.1107,
+        "t_tank_top": 14.2445,
+        "t_tank_bottom": 13.3194,
+        "t_collector": 16.016,
         "t_greenhouse": 13.0155,
         "t_outdoor": 11.6687
       },
@@ -1537,9 +1537,9 @@
     {
       "time": 8340,
       "values": {
-        "t_tank_top": 14.378,
-        "t_tank_bottom": 13.4526,
-        "t_collector": 16.1505,
+        "t_tank_top": 14.279,
+        "t_tank_bottom": 13.3515,
+        "t_collector": 16.0549,
         "t_greenhouse": 13.0424,
         "t_outdoor": 11.6892
       },
@@ -1548,9 +1548,9 @@
     {
       "time": 8400,
       "values": {
-        "t_tank_top": 14.4135,
-        "t_tank_bottom": 13.4856,
-        "t_collector": 16.1903,
+        "t_tank_top": 14.3137,
+        "t_tank_bottom": 13.3836,
+        "t_collector": 16.0938,
         "t_greenhouse": 13.0692,
         "t_outdoor": 11.7098
       },
@@ -1559,9 +1559,9 @@
     {
       "time": 8460,
       "values": {
-        "t_tank_top": 14.4491,
-        "t_tank_bottom": 13.5188,
-        "t_collector": 16.2301,
+        "t_tank_top": 14.3484,
+        "t_tank_bottom": 13.4159,
+        "t_collector": 16.1328,
         "t_greenhouse": 13.0961,
         "t_outdoor": 11.7302
       },
@@ -1570,9 +1570,9 @@
     {
       "time": 8520,
       "values": {
-        "t_tank_top": 14.4848,
-        "t_tank_bottom": 13.5521,
-        "t_collector": 16.27,
+        "t_tank_top": 14.3832,
+        "t_tank_bottom": 13.4482,
+        "t_collector": 16.1718,
         "t_greenhouse": 13.123,
         "t_outdoor": 11.7507
       },
@@ -1581,9 +1581,9 @@
     {
       "time": 8580,
       "values": {
-        "t_tank_top": 14.5206,
-        "t_tank_bottom": 13.5854,
-        "t_collector": 16.31,
+        "t_tank_top": 14.418,
+        "t_tank_bottom": 13.4806,
+        "t_collector": 16.2109,
         "t_greenhouse": 13.1498,
         "t_outdoor": 11.7711
       },
@@ -1592,9 +1592,9 @@
     {
       "time": 8640,
       "values": {
-        "t_tank_top": 14.5565,
-        "t_tank_bottom": 13.6188,
-        "t_collector": 16.35,
+        "t_tank_top": 14.4529,
+        "t_tank_bottom": 13.5131,
+        "t_collector": 16.25,
         "t_greenhouse": 13.1767,
         "t_outdoor": 11.7915
       },
@@ -1603,9 +1603,9 @@
     {
       "time": 8700,
       "values": {
-        "t_tank_top": 14.5924,
-        "t_tank_bottom": 13.6523,
-        "t_collector": 16.39,
+        "t_tank_top": 14.4879,
+        "t_tank_bottom": 13.5456,
+        "t_collector": 16.2891,
         "t_greenhouse": 13.2035,
         "t_outdoor": 11.8119
       },
@@ -1614,9 +1614,9 @@
     {
       "time": 8760,
       "values": {
-        "t_tank_top": 14.6283,
-        "t_tank_bottom": 13.6859,
-        "t_collector": 16.4301,
+        "t_tank_top": 14.5229,
+        "t_tank_bottom": 13.5782,
+        "t_collector": 16.3282,
         "t_greenhouse": 13.2304,
         "t_outdoor": 11.8322
       },
@@ -1625,9 +1625,9 @@
     {
       "time": 8820,
       "values": {
-        "t_tank_top": 14.6644,
-        "t_tank_bottom": 13.7196,
-        "t_collector": 16.4702,
+        "t_tank_top": 14.558,
+        "t_tank_bottom": 13.611,
+        "t_collector": 16.3674,
         "t_greenhouse": 13.2572,
         "t_outdoor": 11.8524
       },
@@ -1636,9 +1636,9 @@
     {
       "time": 8880,
       "values": {
-        "t_tank_top": 14.7005,
-        "t_tank_bottom": 13.7534,
-        "t_collector": 16.5104,
+        "t_tank_top": 14.5932,
+        "t_tank_bottom": 13.6437,
+        "t_collector": 16.4067,
         "t_greenhouse": 13.284,
         "t_outdoor": 11.8727
       },
@@ -1647,9 +1647,9 @@
     {
       "time": 8940,
       "values": {
-        "t_tank_top": 14.7367,
-        "t_tank_bottom": 13.7872,
-        "t_collector": 16.5505,
+        "t_tank_top": 14.6284,
+        "t_tank_bottom": 13.6766,
+        "t_collector": 16.4459,
         "t_greenhouse": 13.3108,
         "t_outdoor": 11.8929
       },
@@ -1658,9 +1658,9 @@
     {
       "time": 9000,
       "values": {
-        "t_tank_top": 14.7729,
-        "t_tank_bottom": 13.8211,
-        "t_collector": 16.5908,
+        "t_tank_top": 14.6637,
+        "t_tank_bottom": 13.7096,
+        "t_collector": 16.4852,
         "t_greenhouse": 13.3376,
         "t_outdoor": 11.9131
       },
@@ -1669,9 +1669,9 @@
     {
       "time": 9060,
       "values": {
-        "t_tank_top": 14.8092,
-        "t_tank_bottom": 13.8551,
-        "t_collector": 16.631,
+        "t_tank_top": 14.699,
+        "t_tank_bottom": 13.7426,
+        "t_collector": 16.5245,
         "t_greenhouse": 13.3644,
         "t_outdoor": 11.9332
       },
@@ -1680,9 +1680,9 @@
     {
       "time": 9120,
       "values": {
-        "t_tank_top": 14.8456,
-        "t_tank_bottom": 13.8892,
-        "t_collector": 16.6713,
+        "t_tank_top": 14.7344,
+        "t_tank_bottom": 13.7757,
+        "t_collector": 16.5639,
         "t_greenhouse": 13.3911,
         "t_outdoor": 11.9533
       },
@@ -1691,9 +1691,9 @@
     {
       "time": 9180,
       "values": {
-        "t_tank_top": 14.882,
-        "t_tank_bottom": 13.9234,
-        "t_collector": 16.7117,
+        "t_tank_top": 14.7699,
+        "t_tank_bottom": 13.8088,
+        "t_collector": 16.6033,
         "t_greenhouse": 13.4179,
         "t_outdoor": 11.9734
       },
@@ -1702,9 +1702,9 @@
     {
       "time": 9240,
       "values": {
-        "t_tank_top": 14.9185,
-        "t_tank_bottom": 13.9576,
-        "t_collector": 16.752,
+        "t_tank_top": 14.8054,
+        "t_tank_bottom": 13.8421,
+        "t_collector": 16.6427,
         "t_greenhouse": 13.4446,
         "t_outdoor": 11.9934
       },
@@ -1713,9 +1713,9 @@
     {
       "time": 9300,
       "values": {
-        "t_tank_top": 14.9551,
-        "t_tank_bottom": 13.992,
-        "t_collector": 16.7925,
+        "t_tank_top": 14.841,
+        "t_tank_bottom": 13.8754,
+        "t_collector": 16.6821,
         "t_greenhouse": 13.4713,
         "t_outdoor": 12.0134
       },
@@ -1724,9 +1724,9 @@
     {
       "time": 9360,
       "values": {
-        "t_tank_top": 14.9917,
-        "t_tank_bottom": 14.0264,
-        "t_collector": 16.8329,
+        "t_tank_top": 14.8766,
+        "t_tank_bottom": 13.9088,
+        "t_collector": 16.7216,
         "t_greenhouse": 13.498,
         "t_outdoor": 12.0334
       },
@@ -1735,9 +1735,9 @@
     {
       "time": 9420,
       "values": {
-        "t_tank_top": 15.0284,
-        "t_tank_bottom": 14.0608,
-        "t_collector": 16.8734,
+        "t_tank_top": 14.9123,
+        "t_tank_bottom": 13.9422,
+        "t_collector": 16.7611,
         "t_greenhouse": 13.5246,
         "t_outdoor": 12.0533
       },
@@ -1746,9 +1746,9 @@
     {
       "time": 9480,
       "values": {
-        "t_tank_top": 15.0652,
-        "t_tank_bottom": 14.0954,
-        "t_collector": 16.9139,
+        "t_tank_top": 14.948,
+        "t_tank_bottom": 13.9757,
+        "t_collector": 16.8006,
         "t_greenhouse": 13.5513,
         "t_outdoor": 12.0731
       },
@@ -1757,9 +1757,9 @@
     {
       "time": 9540,
       "values": {
-        "t_tank_top": 15.102,
-        "t_tank_bottom": 14.13,
-        "t_collector": 16.9544,
+        "t_tank_top": 14.9838,
+        "t_tank_bottom": 14.0093,
+        "t_collector": 16.8402,
         "t_greenhouse": 13.5779,
         "t_outdoor": 12.093
       },
@@ -1768,9 +1768,9 @@
     {
       "time": 9600,
       "values": {
-        "t_tank_top": 15.1389,
-        "t_tank_bottom": 14.1647,
-        "t_collector": 16.995,
+        "t_tank_top": 15.0197,
+        "t_tank_bottom": 14.043,
+        "t_collector": 16.8798,
         "t_greenhouse": 13.6044,
         "t_outdoor": 12.1128
       },
@@ -1779,9 +1779,9 @@
     {
       "time": 9660,
       "values": {
-        "t_tank_top": 15.1758,
-        "t_tank_bottom": 14.1995,
-        "t_collector": 17.0356,
+        "t_tank_top": 15.0556,
+        "t_tank_bottom": 14.0767,
+        "t_collector": 16.9194,
         "t_greenhouse": 13.631,
         "t_outdoor": 12.1325
       },
@@ -1790,9 +1790,9 @@
     {
       "time": 9720,
       "values": {
-        "t_tank_top": 15.2128,
-        "t_tank_bottom": 14.2344,
-        "t_collector": 17.0762,
+        "t_tank_top": 15.0915,
+        "t_tank_bottom": 14.1105,
+        "t_collector": 16.959,
         "t_greenhouse": 13.6575,
         "t_outdoor": 12.1522
       },
@@ -1801,9 +1801,9 @@
     {
       "time": 9780,
       "values": {
-        "t_tank_top": 15.2498,
-        "t_tank_bottom": 14.2693,
-        "t_collector": 17.1169,
+        "t_tank_top": 15.1275,
+        "t_tank_bottom": 14.1444,
+        "t_collector": 16.9987,
         "t_greenhouse": 13.684,
         "t_outdoor": 12.1719
       },
@@ -1812,9 +1812,9 @@
     {
       "time": 9840,
       "values": {
-        "t_tank_top": 15.2869,
-        "t_tank_bottom": 14.3043,
-        "t_collector": 17.1576,
+        "t_tank_top": 15.1636,
+        "t_tank_bottom": 14.1783,
+        "t_collector": 17.0383,
         "t_greenhouse": 13.7105,
         "t_outdoor": 12.1915
       },
@@ -1823,9 +1823,9 @@
     {
       "time": 9900,
       "values": {
-        "t_tank_top": 15.3241,
-        "t_tank_bottom": 14.3394,
-        "t_collector": 17.1983,
+        "t_tank_top": 15.1997,
+        "t_tank_bottom": 14.2124,
+        "t_collector": 17.078,
         "t_greenhouse": 13.7369,
         "t_outdoor": 12.2111
       },
@@ -1834,9 +1834,9 @@
     {
       "time": 9960,
       "values": {
-        "t_tank_top": 15.3613,
-        "t_tank_bottom": 14.3746,
-        "t_collector": 17.239,
+        "t_tank_top": 15.2359,
+        "t_tank_bottom": 14.2464,
+        "t_collector": 17.1177,
         "t_greenhouse": 13.7633,
         "t_outdoor": 12.2307
       },
@@ -1845,9 +1845,9 @@
     {
       "time": 10020,
       "values": {
-        "t_tank_top": 15.3986,
-        "t_tank_bottom": 14.4098,
-        "t_collector": 17.2798,
+        "t_tank_top": 15.2721,
+        "t_tank_bottom": 14.2806,
+        "t_collector": 17.1575,
         "t_greenhouse": 13.7896,
         "t_outdoor": 12.2502
       },
@@ -1856,9 +1856,9 @@
     {
       "time": 10080,
       "values": {
-        "t_tank_top": 15.4359,
-        "t_tank_bottom": 14.4451,
-        "t_collector": 17.3206,
+        "t_tank_top": 15.3083,
+        "t_tank_bottom": 14.3148,
+        "t_collector": 17.1972,
         "t_greenhouse": 13.8159,
         "t_outdoor": 12.2696
       },
@@ -1867,9 +1867,9 @@
     {
       "time": 10140,
       "values": {
-        "t_tank_top": 15.4733,
-        "t_tank_bottom": 14.4804,
-        "t_collector": 17.3614,
+        "t_tank_top": 15.3446,
+        "t_tank_bottom": 14.349,
+        "t_collector": 17.237,
         "t_greenhouse": 13.8422,
         "t_outdoor": 12.289
       },
@@ -1878,9 +1878,9 @@
     {
       "time": 10200,
       "values": {
-        "t_tank_top": 15.5108,
-        "t_tank_bottom": 14.5159,
-        "t_collector": 17.4023,
+        "t_tank_top": 15.381,
+        "t_tank_bottom": 14.3834,
+        "t_collector": 17.2768,
         "t_greenhouse": 13.8685,
         "t_outdoor": 12.3084
       },
@@ -1889,9 +1889,9 @@
     {
       "time": 10260,
       "values": {
-        "t_tank_top": 15.5483,
-        "t_tank_bottom": 14.5514,
-        "t_collector": 17.4432,
+        "t_tank_top": 15.4174,
+        "t_tank_bottom": 14.4177,
+        "t_collector": 17.3166,
         "t_greenhouse": 13.8947,
         "t_outdoor": 12.3278
       },
@@ -1900,9 +1900,9 @@
     {
       "time": 10320,
       "values": {
-        "t_tank_top": 15.5858,
-        "t_tank_bottom": 14.587,
-        "t_collector": 17.4841,
+        "t_tank_top": 15.4538,
+        "t_tank_bottom": 14.4522,
+        "t_collector": 17.3564,
         "t_greenhouse": 13.9208,
         "t_outdoor": 12.347
       },
@@ -1911,9 +1911,9 @@
     {
       "time": 10380,
       "values": {
-        "t_tank_top": 15.6234,
-        "t_tank_bottom": 14.6226,
-        "t_collector": 17.525,
+        "t_tank_top": 15.4903,
+        "t_tank_bottom": 14.4867,
+        "t_collector": 17.3963,
         "t_greenhouse": 13.9469,
         "t_outdoor": 12.3663
       },
@@ -1922,9 +1922,9 @@
     {
       "time": 10440,
       "values": {
-        "t_tank_top": 15.661,
-        "t_tank_bottom": 14.6583,
-        "t_collector": 17.5659,
+        "t_tank_top": 15.5268,
+        "t_tank_bottom": 14.5213,
+        "t_collector": 17.4362,
         "t_greenhouse": 13.973,
         "t_outdoor": 12.3855
       },
@@ -1933,9 +1933,9 @@
     {
       "time": 10500,
       "values": {
-        "t_tank_top": 15.6987,
-        "t_tank_bottom": 14.6941,
-        "t_collector": 17.6069,
+        "t_tank_top": 15.5634,
+        "t_tank_bottom": 14.5559,
+        "t_collector": 17.476,
         "t_greenhouse": 13.9991,
         "t_outdoor": 12.4046
       },
@@ -1944,9 +1944,9 @@
     {
       "time": 10560,
       "values": {
-        "t_tank_top": 15.7365,
-        "t_tank_bottom": 14.7299,
-        "t_collector": 17.6479,
+        "t_tank_top": 15.6,
+        "t_tank_bottom": 14.5906,
+        "t_collector": 17.5159,
         "t_greenhouse": 14.0251,
         "t_outdoor": 12.4237
       },
@@ -1955,9 +1955,9 @@
     {
       "time": 10620,
       "values": {
-        "t_tank_top": 15.7743,
-        "t_tank_bottom": 14.7658,
-        "t_collector": 17.6889,
+        "t_tank_top": 15.6367,
+        "t_tank_bottom": 14.6254,
+        "t_collector": 17.5558,
         "t_greenhouse": 14.051,
         "t_outdoor": 12.4428
       },
@@ -1966,9 +1966,9 @@
     {
       "time": 10680,
       "values": {
-        "t_tank_top": 15.8121,
-        "t_tank_bottom": 14.8018,
-        "t_collector": 17.7299,
+        "t_tank_top": 15.6734,
+        "t_tank_bottom": 14.6602,
+        "t_collector": 17.5957,
         "t_greenhouse": 14.0769,
         "t_outdoor": 12.4618
       },
@@ -1977,9 +1977,9 @@
     {
       "time": 10740,
       "values": {
-        "t_tank_top": 15.85,
-        "t_tank_bottom": 14.8379,
-        "t_collector": 17.7709,
+        "t_tank_top": 15.7102,
+        "t_tank_bottom": 14.6951,
+        "t_collector": 17.6357,
         "t_greenhouse": 14.1028,
         "t_outdoor": 12.4808
       },
@@ -1988,9 +1988,9 @@
     {
       "time": 10800,
       "values": {
-        "t_tank_top": 15.888,
-        "t_tank_bottom": 14.874,
-        "t_collector": 17.812,
+        "t_tank_top": 15.747,
+        "t_tank_bottom": 14.73,
+        "t_collector": 17.6756,
         "t_greenhouse": 14.1286,
         "t_outdoor": 12.4997
       },
@@ -1999,9 +1999,9 @@
     {
       "time": 10860,
       "values": {
-        "t_tank_top": 15.926,
-        "t_tank_bottom": 14.9101,
-        "t_collector": 17.8531,
+        "t_tank_top": 15.7838,
+        "t_tank_bottom": 14.765,
+        "t_collector": 17.7155,
         "t_greenhouse": 14.1543,
         "t_outdoor": 12.5186
       },
@@ -2010,9 +2010,9 @@
     {
       "time": 10920,
       "values": {
-        "t_tank_top": 15.964,
-        "t_tank_bottom": 14.9464,
-        "t_collector": 17.8941,
+        "t_tank_top": 15.8207,
+        "t_tank_bottom": 14.8,
+        "t_collector": 17.7555,
         "t_greenhouse": 14.18,
         "t_outdoor": 12.5374
       },
@@ -2021,9 +2021,9 @@
     {
       "time": 10980,
       "values": {
-        "t_tank_top": 16.0021,
-        "t_tank_bottom": 14.9827,
-        "t_collector": 17.9353,
+        "t_tank_top": 15.8576,
+        "t_tank_bottom": 14.8351,
+        "t_collector": 17.7955,
         "t_greenhouse": 14.2057,
         "t_outdoor": 12.5562
       },
@@ -2032,9 +2032,9 @@
     {
       "time": 11040,
       "values": {
-        "t_tank_top": 16.0402,
-        "t_tank_bottom": 15.019,
-        "t_collector": 17.9764,
+        "t_tank_top": 15.8945,
+        "t_tank_bottom": 14.8702,
+        "t_collector": 17.8354,
         "t_greenhouse": 14.2313,
         "t_outdoor": 12.5749
       },
@@ -2043,9 +2043,9 @@
     {
       "time": 11100,
       "values": {
-        "t_tank_top": 16.0784,
-        "t_tank_bottom": 15.0554,
-        "t_collector": 18.0175,
+        "t_tank_top": 15.9315,
+        "t_tank_bottom": 14.9054,
+        "t_collector": 17.8754,
         "t_greenhouse": 14.2569,
         "t_outdoor": 12.5936
       },
@@ -2054,9 +2054,9 @@
     {
       "time": 11160,
       "values": {
-        "t_tank_top": 16.1166,
-        "t_tank_bottom": 15.0919,
-        "t_collector": 18.0587,
+        "t_tank_top": 15.9685,
+        "t_tank_bottom": 14.9407,
+        "t_collector": 17.9154,
         "t_greenhouse": 14.2824,
         "t_outdoor": 12.6122
       },
@@ -2065,9 +2065,9 @@
     {
       "time": 11220,
       "values": {
-        "t_tank_top": 16.1549,
-        "t_tank_bottom": 15.1284,
-        "t_collector": 18.0998,
+        "t_tank_top": 16.0056,
+        "t_tank_bottom": 14.976,
+        "t_collector": 17.9554,
         "t_greenhouse": 14.3078,
         "t_outdoor": 12.6308
       },
@@ -2076,9 +2076,9 @@
     {
       "time": 11280,
       "values": {
-        "t_tank_top": 16.1932,
-        "t_tank_bottom": 15.165,
-        "t_collector": 18.141,
+        "t_tank_top": 16.0427,
+        "t_tank_bottom": 15.0114,
+        "t_collector": 17.9954,
         "t_greenhouse": 14.3332,
         "t_outdoor": 12.6493
       },
@@ -2087,9 +2087,9 @@
     {
       "time": 11340,
       "values": {
-        "t_tank_top": 16.2315,
-        "t_tank_bottom": 15.2017,
-        "t_collector": 18.1822,
+        "t_tank_top": 16.0798,
+        "t_tank_bottom": 15.0468,
+        "t_collector": 18.0354,
         "t_greenhouse": 14.3586,
         "t_outdoor": 12.6678
       },
@@ -2098,9 +2098,9 @@
     {
       "time": 11400,
       "values": {
-        "t_tank_top": 16.2699,
-        "t_tank_bottom": 15.2384,
-        "t_collector": 18.2234,
+        "t_tank_top": 16.1169,
+        "t_tank_bottom": 15.0822,
+        "t_collector": 18.0754,
         "t_greenhouse": 14.3839,
         "t_outdoor": 12.6862
       },
@@ -2109,9 +2109,9 @@
     {
       "time": 11460,
       "values": {
-        "t_tank_top": 16.3083,
-        "t_tank_bottom": 15.2752,
-        "t_collector": 18.2646,
+        "t_tank_top": 16.1541,
+        "t_tank_bottom": 15.1177,
+        "t_collector": 18.1154,
         "t_greenhouse": 14.4091,
         "t_outdoor": 12.7046
       },
@@ -2120,9 +2120,9 @@
     {
       "time": 11520,
       "values": {
-        "t_tank_top": 16.3468,
-        "t_tank_bottom": 15.312,
-        "t_collector": 18.3058,
+        "t_tank_top": 16.1913,
+        "t_tank_bottom": 15.1533,
+        "t_collector": 18.1555,
         "t_greenhouse": 14.4342,
         "t_outdoor": 12.7229
       },
@@ -2131,9 +2131,9 @@
     {
       "time": 11580,
       "values": {
-        "t_tank_top": 16.3853,
-        "t_tank_bottom": 15.3489,
-        "t_collector": 18.347,
+        "t_tank_top": 16.2286,
+        "t_tank_bottom": 15.1889,
+        "t_collector": 18.1955,
         "t_greenhouse": 14.4594,
         "t_outdoor": 12.7412
       },
@@ -2142,9 +2142,9 @@
     {
       "time": 11640,
       "values": {
-        "t_tank_top": 16.4238,
-        "t_tank_bottom": 15.3858,
-        "t_collector": 18.3883,
+        "t_tank_top": 16.2659,
+        "t_tank_bottom": 15.2246,
+        "t_collector": 18.2355,
         "t_greenhouse": 14.4844,
         "t_outdoor": 12.7594
       },
@@ -2153,9 +2153,9 @@
     {
       "time": 11700,
       "values": {
-        "t_tank_top": 16.4624,
-        "t_tank_bottom": 15.4228,
-        "t_collector": 18.4295,
+        "t_tank_top": 16.3032,
+        "t_tank_bottom": 15.2603,
+        "t_collector": 18.2755,
         "t_greenhouse": 14.5094,
         "t_outdoor": 12.7775
       },
@@ -2164,9 +2164,9 @@
     {
       "time": 11760,
       "values": {
-        "t_tank_top": 16.501,
-        "t_tank_bottom": 15.4598,
-        "t_collector": 18.4708,
+        "t_tank_top": 16.3406,
+        "t_tank_bottom": 15.296,
+        "t_collector": 18.3155,
         "t_greenhouse": 14.5343,
         "t_outdoor": 12.7957
       },
@@ -2175,9 +2175,9 @@
     {
       "time": 11820,
       "values": {
-        "t_tank_top": 16.5397,
-        "t_tank_bottom": 15.4969,
-        "t_collector": 18.512,
+        "t_tank_top": 16.3779,
+        "t_tank_bottom": 15.3318,
+        "t_collector": 18.3555,
         "t_greenhouse": 14.5592,
         "t_outdoor": 12.8137
       },
@@ -2186,9 +2186,9 @@
     {
       "time": 11880,
       "values": {
-        "t_tank_top": 16.5784,
-        "t_tank_bottom": 15.5341,
-        "t_collector": 18.5533,
+        "t_tank_top": 16.4153,
+        "t_tank_bottom": 15.3676,
+        "t_collector": 18.3956,
         "t_greenhouse": 14.584,
         "t_outdoor": 12.8317
       },
@@ -2197,9 +2197,9 @@
     {
       "time": 11940,
       "values": {
-        "t_tank_top": 16.6171,
-        "t_tank_bottom": 15.5713,
-        "t_collector": 18.5946,
+        "t_tank_top": 16.4528,
+        "t_tank_bottom": 15.4035,
+        "t_collector": 18.4356,
         "t_greenhouse": 14.6088,
         "t_outdoor": 12.8497
       },
@@ -2208,9 +2208,9 @@
     {
       "time": 12000,
       "values": {
-        "t_tank_top": 16.6558,
-        "t_tank_bottom": 15.6085,
-        "t_collector": 18.6358,
+        "t_tank_top": 16.4902,
+        "t_tank_bottom": 15.4395,
+        "t_collector": 18.4756,
         "t_greenhouse": 14.6334,
         "t_outdoor": 12.8676
       },
@@ -2219,9 +2219,9 @@
     {
       "time": 12060,
       "values": {
-        "t_tank_top": 16.6946,
-        "t_tank_bottom": 15.6459,
-        "t_collector": 18.6771,
+        "t_tank_top": 16.5277,
+        "t_tank_bottom": 15.4754,
+        "t_collector": 18.5156,
         "t_greenhouse": 14.6581,
         "t_outdoor": 12.8854
       },
@@ -2230,9 +2230,9 @@
     {
       "time": 12120,
       "values": {
-        "t_tank_top": 16.7335,
-        "t_tank_bottom": 15.6832,
-        "t_collector": 18.7184,
+        "t_tank_top": 16.5652,
+        "t_tank_bottom": 15.5114,
+        "t_collector": 18.5556,
         "t_greenhouse": 14.6826,
         "t_outdoor": 12.9032
       },
@@ -2241,9 +2241,9 @@
     {
       "time": 12180,
       "values": {
-        "t_tank_top": 16.7723,
-        "t_tank_bottom": 15.7206,
-        "t_collector": 18.7597,
+        "t_tank_top": 16.6028,
+        "t_tank_bottom": 15.5475,
+        "t_collector": 18.5956,
         "t_greenhouse": 14.7071,
         "t_outdoor": 12.921
       },
@@ -2252,9 +2252,9 @@
     {
       "time": 12240,
       "values": {
-        "t_tank_top": 16.8112,
-        "t_tank_bottom": 15.7581,
-        "t_collector": 18.801,
+        "t_tank_top": 16.6403,
+        "t_tank_bottom": 15.5836,
+        "t_collector": 18.6356,
         "t_greenhouse": 14.7315,
         "t_outdoor": 12.9386
       },
@@ -2263,9 +2263,9 @@
     {
       "time": 12300,
       "values": {
-        "t_tank_top": 16.8501,
-        "t_tank_bottom": 15.7956,
-        "t_collector": 18.8422,
+        "t_tank_top": 16.6779,
+        "t_tank_bottom": 15.6197,
+        "t_collector": 18.6756,
         "t_greenhouse": 14.7559,
         "t_outdoor": 12.9563
       },
@@ -2274,9 +2274,9 @@
     {
       "time": 12360,
       "values": {
-        "t_tank_top": 16.8891,
-        "t_tank_bottom": 15.8331,
-        "t_collector": 18.8835,
+        "t_tank_top": 16.7155,
+        "t_tank_bottom": 15.6559,
+        "t_collector": 18.7155,
         "t_greenhouse": 14.7802,
         "t_outdoor": 12.9738
       },
@@ -2285,9 +2285,9 @@
     {
       "time": 12420,
       "values": {
-        "t_tank_top": 16.9281,
-        "t_tank_bottom": 15.8707,
-        "t_collector": 18.9248,
+        "t_tank_top": 16.7531,
+        "t_tank_bottom": 15.6921,
+        "t_collector": 18.7555,
         "t_greenhouse": 14.8044,
         "t_outdoor": 12.9913
       },
@@ -2296,9 +2296,9 @@
     {
       "time": 12480,
       "values": {
-        "t_tank_top": 16.9671,
-        "t_tank_bottom": 15.9084,
-        "t_collector": 18.9661,
+        "t_tank_top": 16.7908,
+        "t_tank_bottom": 15.7284,
+        "t_collector": 18.7955,
         "t_greenhouse": 14.8285,
         "t_outdoor": 13.0088
       },
@@ -2307,9 +2307,9 @@
     {
       "time": 12540,
       "values": {
-        "t_tank_top": 17.0061,
-        "t_tank_bottom": 15.9461,
-        "t_collector": 19.0074,
+        "t_tank_top": 16.8285,
+        "t_tank_bottom": 15.7647,
+        "t_collector": 18.8354,
         "t_greenhouse": 14.8526,
         "t_outdoor": 13.0262
       },
@@ -2318,9 +2318,9 @@
     {
       "time": 12600,
       "values": {
-        "t_tank_top": 17.0452,
-        "t_tank_bottom": 15.9838,
-        "t_collector": 19.0487,
+        "t_tank_top": 16.8662,
+        "t_tank_bottom": 15.801,
+        "t_collector": 18.8753,
         "t_greenhouse": 14.8766,
         "t_outdoor": 13.0435
       },
@@ -2329,9 +2329,9 @@
     {
       "time": 12660,
       "values": {
-        "t_tank_top": 17.0843,
-        "t_tank_bottom": 16.0216,
-        "t_collector": 19.0899,
+        "t_tank_top": 16.9039,
+        "t_tank_bottom": 15.8374,
+        "t_collector": 18.9153,
         "t_greenhouse": 14.9006,
         "t_outdoor": 13.0608
       },
@@ -2340,9 +2340,9 @@
     {
       "time": 12720,
       "values": {
-        "t_tank_top": 17.1234,
-        "t_tank_bottom": 16.0594,
-        "t_collector": 19.1312,
+        "t_tank_top": 16.9416,
+        "t_tank_bottom": 15.8738,
+        "t_collector": 18.9552,
         "t_greenhouse": 14.9244,
         "t_outdoor": 13.078
       },
@@ -2351,9 +2351,9 @@
     {
       "time": 12780,
       "values": {
-        "t_tank_top": 17.1626,
-        "t_tank_bottom": 16.0973,
-        "t_collector": 19.1725,
+        "t_tank_top": 16.9793,
+        "t_tank_bottom": 15.9102,
+        "t_collector": 18.9951,
         "t_greenhouse": 14.9482,
         "t_outdoor": 13.0952
       },
@@ -2362,9 +2362,9 @@
     {
       "time": 12840,
       "values": {
-        "t_tank_top": 17.2018,
-        "t_tank_bottom": 16.1352,
-        "t_collector": 19.2137,
+        "t_tank_top": 17.0171,
+        "t_tank_bottom": 15.9467,
+        "t_collector": 19.035,
         "t_greenhouse": 14.9719,
         "t_outdoor": 13.1123
       },
@@ -2373,9 +2373,9 @@
     {
       "time": 12900,
       "values": {
-        "t_tank_top": 17.241,
-        "t_tank_bottom": 16.1731,
-        "t_collector": 19.255,
+        "t_tank_top": 17.0549,
+        "t_tank_bottom": 15.9832,
+        "t_collector": 19.0749,
         "t_greenhouse": 14.9956,
         "t_outdoor": 13.1293
       },
@@ -2384,9 +2384,9 @@
     {
       "time": 12960,
       "values": {
-        "t_tank_top": 17.2802,
-        "t_tank_bottom": 16.2111,
-        "t_collector": 19.2962,
+        "t_tank_top": 17.0927,
+        "t_tank_bottom": 16.0197,
+        "t_collector": 19.1147,
         "t_greenhouse": 15.0192,
         "t_outdoor": 13.1463
       },
@@ -2395,9 +2395,9 @@
     {
       "time": 13020,
       "values": {
-        "t_tank_top": 17.3195,
-        "t_tank_bottom": 16.2492,
-        "t_collector": 19.3375,
+        "t_tank_top": 17.1305,
+        "t_tank_bottom": 16.0563,
+        "t_collector": 19.1546,
         "t_greenhouse": 15.0426,
         "t_outdoor": 13.1632
       },
@@ -2406,9 +2406,9 @@
     {
       "time": 13080,
       "values": {
-        "t_tank_top": 17.3587,
-        "t_tank_bottom": 16.2873,
-        "t_collector": 19.3787,
+        "t_tank_top": 17.1683,
+        "t_tank_bottom": 16.0929,
+        "t_collector": 19.1944,
         "t_greenhouse": 15.0661,
         "t_outdoor": 13.1801
       },
@@ -2417,9 +2417,9 @@
     {
       "time": 13140,
       "values": {
-        "t_tank_top": 17.398,
-        "t_tank_bottom": 16.3254,
-        "t_collector": 19.4199,
+        "t_tank_top": 17.2062,
+        "t_tank_bottom": 16.1295,
+        "t_collector": 19.2342,
         "t_greenhouse": 15.0894,
         "t_outdoor": 13.1969
       },
@@ -2428,9 +2428,9 @@
     {
       "time": 13200,
       "values": {
-        "t_tank_top": 17.4374,
-        "t_tank_bottom": 16.3635,
-        "t_collector": 19.4612,
+        "t_tank_top": 17.244,
+        "t_tank_bottom": 16.1662,
+        "t_collector": 19.274,
         "t_greenhouse": 15.1127,
         "t_outdoor": 13.2137
       },
@@ -2439,9 +2439,9 @@
     {
       "time": 13260,
       "values": {
-        "t_tank_top": 17.4767,
-        "t_tank_bottom": 16.4017,
-        "t_collector": 19.5024,
+        "t_tank_top": 17.2819,
+        "t_tank_bottom": 16.2029,
+        "t_collector": 19.3138,
         "t_greenhouse": 15.1359,
         "t_outdoor": 13.2303
       },
@@ -2450,9 +2450,9 @@
     {
       "time": 13320,
       "values": {
-        "t_tank_top": 17.5161,
-        "t_tank_bottom": 16.44,
-        "t_collector": 19.5436,
+        "t_tank_top": 17.3198,
+        "t_tank_bottom": 16.2396,
+        "t_collector": 19.3535,
         "t_greenhouse": 15.159,
         "t_outdoor": 13.247
       },
@@ -2461,9 +2461,9 @@
     {
       "time": 13380,
       "values": {
-        "t_tank_top": 17.5554,
-        "t_tank_bottom": 16.4782,
-        "t_collector": 19.5847,
+        "t_tank_top": 17.3577,
+        "t_tank_bottom": 16.2764,
+        "t_collector": 19.3933,
         "t_greenhouse": 15.182,
         "t_outdoor": 13.2635
       },
@@ -2472,9 +2472,9 @@
     {
       "time": 13440,
       "values": {
-        "t_tank_top": 17.5948,
-        "t_tank_bottom": 16.5165,
-        "t_collector": 19.6259,
+        "t_tank_top": 17.3956,
+        "t_tank_bottom": 16.3132,
+        "t_collector": 19.433,
         "t_greenhouse": 15.205,
         "t_outdoor": 13.28
       },
@@ -2483,9 +2483,9 @@
     {
       "time": 13500,
       "values": {
-        "t_tank_top": 17.6343,
-        "t_tank_bottom": 16.5549,
-        "t_collector": 19.6671,
+        "t_tank_top": 17.4335,
+        "t_tank_bottom": 16.35,
+        "t_collector": 19.4727,
         "t_greenhouse": 15.2279,
         "t_outdoor": 13.2965
       },
@@ -2494,9 +2494,9 @@
     {
       "time": 13560,
       "values": {
-        "t_tank_top": 17.6737,
-        "t_tank_bottom": 16.5933,
-        "t_collector": 19.7082,
+        "t_tank_top": 17.4714,
+        "t_tank_bottom": 16.3868,
+        "t_collector": 19.5124,
         "t_greenhouse": 15.2507,
         "t_outdoor": 13.3128
       },
@@ -2505,9 +2505,9 @@
     {
       "time": 13620,
       "values": {
-        "t_tank_top": 17.7132,
-        "t_tank_bottom": 16.6317,
-        "t_collector": 19.7494,
+        "t_tank_top": 17.5094,
+        "t_tank_bottom": 16.4237,
+        "t_collector": 19.552,
         "t_greenhouse": 15.2734,
         "t_outdoor": 13.3291
       },
@@ -2516,9 +2516,9 @@
     {
       "time": 13680,
       "values": {
-        "t_tank_top": 17.7526,
-        "t_tank_bottom": 16.6701,
-        "t_collector": 19.7905,
+        "t_tank_top": 17.5473,
+        "t_tank_bottom": 16.4605,
+        "t_collector": 19.5917,
         "t_greenhouse": 15.296,
         "t_outdoor": 13.3454
       },
@@ -2527,9 +2527,9 @@
     {
       "time": 13740,
       "values": {
-        "t_tank_top": 17.7921,
-        "t_tank_bottom": 16.7086,
-        "t_collector": 19.8316,
+        "t_tank_top": 17.5852,
+        "t_tank_bottom": 16.4975,
+        "t_collector": 19.6313,
         "t_greenhouse": 15.3186,
         "t_outdoor": 13.3616
       },
@@ -2538,9 +2538,9 @@
     {
       "time": 13800,
       "values": {
-        "t_tank_top": 17.8316,
-        "t_tank_bottom": 16.7471,
-        "t_collector": 19.8727,
+        "t_tank_top": 17.6232,
+        "t_tank_bottom": 16.5344,
+        "t_collector": 19.6709,
         "t_greenhouse": 15.3411,
         "t_outdoor": 13.3777
       },
@@ -2549,9 +2549,9 @@
     {
       "time": 13860,
       "values": {
-        "t_tank_top": 17.8711,
-        "t_tank_bottom": 16.7857,
-        "t_collector": 19.9137,
+        "t_tank_top": 17.6612,
+        "t_tank_bottom": 16.5713,
+        "t_collector": 19.7104,
         "t_greenhouse": 15.3634,
         "t_outdoor": 13.3937
       },
@@ -2560,9 +2560,9 @@
     {
       "time": 13920,
       "values": {
-        "t_tank_top": 17.9107,
-        "t_tank_bottom": 16.8242,
-        "t_collector": 19.9548,
+        "t_tank_top": 17.6991,
+        "t_tank_bottom": 16.6083,
+        "t_collector": 19.7499,
         "t_greenhouse": 15.3858,
         "t_outdoor": 13.4097
       },
@@ -2571,9 +2571,9 @@
     {
       "time": 13980,
       "values": {
-        "t_tank_top": 17.9502,
-        "t_tank_bottom": 16.8628,
-        "t_collector": 19.9958,
+        "t_tank_top": 17.7371,
+        "t_tank_bottom": 16.6453,
+        "t_collector": 19.7895,
         "t_greenhouse": 15.408,
         "t_outdoor": 13.4257
       },
@@ -2582,9 +2582,9 @@
     {
       "time": 14040,
       "values": {
-        "t_tank_top": 17.9898,
-        "t_tank_bottom": 16.9015,
-        "t_collector": 20.0368,
+        "t_tank_top": 17.7751,
+        "t_tank_bottom": 16.6823,
+        "t_collector": 19.8289,
         "t_greenhouse": 15.4301,
         "t_outdoor": 13.4415
       },
@@ -2593,9 +2593,9 @@
     {
       "time": 14100,
       "values": {
-        "t_tank_top": 18.0293,
-        "t_tank_bottom": 16.9401,
-        "t_collector": 20.0778,
+        "t_tank_top": 17.813,
+        "t_tank_bottom": 16.7194,
+        "t_collector": 19.8684,
         "t_greenhouse": 15.4522,
         "t_outdoor": 13.4573
       },
@@ -2604,9 +2604,9 @@
     {
       "time": 14160,
       "values": {
-        "t_tank_top": 18.0689,
-        "t_tank_bottom": 16.9788,
-        "t_collector": 20.1188,
+        "t_tank_top": 17.851,
+        "t_tank_bottom": 16.7565,
+        "t_collector": 19.9078,
         "t_greenhouse": 15.4741,
         "t_outdoor": 13.473
       },
@@ -2615,9 +2615,9 @@
     {
       "time": 14220,
       "values": {
-        "t_tank_top": 18.1085,
-        "t_tank_bottom": 17.0176,
-        "t_collector": 20.1598,
+        "t_tank_top": 17.889,
+        "t_tank_bottom": 16.7935,
+        "t_collector": 19.9472,
         "t_greenhouse": 15.496,
         "t_outdoor": 13.4887
       },
@@ -2626,9 +2626,9 @@
     {
       "time": 14280,
       "values": {
-        "t_tank_top": 18.1481,
-        "t_tank_bottom": 17.0563,
-        "t_collector": 20.2007,
+        "t_tank_top": 17.927,
+        "t_tank_bottom": 16.8306,
+        "t_collector": 19.9866,
         "t_greenhouse": 15.5178,
         "t_outdoor": 13.5043
       },
@@ -2637,9 +2637,9 @@
     {
       "time": 14340,
       "values": {
-        "t_tank_top": 18.1877,
-        "t_tank_bottom": 17.0951,
-        "t_collector": 20.2416,
+        "t_tank_top": 17.965,
+        "t_tank_bottom": 16.8678,
+        "t_collector": 20.0259,
         "t_greenhouse": 15.5395,
         "t_outdoor": 13.5198
       },
@@ -2648,9 +2648,9 @@
     {
       "time": 14400,
       "values": {
-        "t_tank_top": 18.2273,
-        "t_tank_bottom": 17.1339,
-        "t_collector": 20.2825,
+        "t_tank_top": 18.0029,
+        "t_tank_bottom": 16.9049,
+        "t_collector": 20.0652,
         "t_greenhouse": 15.5612,
         "t_outdoor": 13.5353
       },
@@ -2659,9 +2659,9 @@
     {
       "time": 14460,
       "values": {
-        "t_tank_top": 18.2669,
-        "t_tank_bottom": 17.1727,
-        "t_collector": 20.3233,
+        "t_tank_top": 18.0409,
+        "t_tank_bottom": 16.942,
+        "t_collector": 20.1044,
         "t_greenhouse": 15.5827,
         "t_outdoor": 13.5507
       },
@@ -2670,9 +2670,9 @@
     {
       "time": 14520,
       "values": {
-        "t_tank_top": 18.3066,
-        "t_tank_bottom": 17.2116,
-        "t_collector": 20.3642,
+        "t_tank_top": 18.0789,
+        "t_tank_bottom": 16.9792,
+        "t_collector": 20.1437,
         "t_greenhouse": 15.6042,
         "t_outdoor": 13.566
       },
@@ -2681,9 +2681,9 @@
     {
       "time": 14580,
       "values": {
-        "t_tank_top": 18.3462,
-        "t_tank_bottom": 17.2505,
-        "t_collector": 20.405,
+        "t_tank_top": 18.1169,
+        "t_tank_bottom": 17.0164,
+        "t_collector": 20.1829,
         "t_greenhouse": 15.6255,
         "t_outdoor": 13.5813
       },
@@ -2692,9 +2692,9 @@
     {
       "time": 14640,
       "values": {
-        "t_tank_top": 18.3859,
-        "t_tank_bottom": 17.2894,
-        "t_collector": 20.4458,
+        "t_tank_top": 18.1549,
+        "t_tank_bottom": 17.0536,
+        "t_collector": 20.222,
         "t_greenhouse": 15.6468,
         "t_outdoor": 13.5964
       },
@@ -2703,9 +2703,9 @@
     {
       "time": 14700,
       "values": {
-        "t_tank_top": 18.4255,
-        "t_tank_bottom": 17.3283,
-        "t_collector": 20.4866,
+        "t_tank_top": 18.1928,
+        "t_tank_bottom": 17.0908,
+        "t_collector": 20.2612,
         "t_greenhouse": 15.668,
         "t_outdoor": 13.6116
       },
@@ -2714,9 +2714,9 @@
     {
       "time": 14760,
       "values": {
-        "t_tank_top": 18.4652,
-        "t_tank_bottom": 17.3672,
-        "t_collector": 20.5273,
+        "t_tank_top": 18.2308,
+        "t_tank_bottom": 17.128,
+        "t_collector": 20.3003,
         "t_greenhouse": 15.6891,
         "t_outdoor": 13.6266
       },
@@ -2725,9 +2725,9 @@
     {
       "time": 14820,
       "values": {
-        "t_tank_top": 18.5048,
-        "t_tank_bottom": 17.4062,
-        "t_collector": 20.568,
+        "t_tank_top": 18.2688,
+        "t_tank_bottom": 17.1653,
+        "t_collector": 20.3393,
         "t_greenhouse": 15.7101,
         "t_outdoor": 13.6416
       },
@@ -2736,9 +2736,9 @@
     {
       "time": 14880,
       "values": {
-        "t_tank_top": 18.5445,
-        "t_tank_bottom": 17.4452,
-        "t_collector": 20.6087,
+        "t_tank_top": 18.3067,
+        "t_tank_bottom": 17.2025,
+        "t_collector": 20.3784,
         "t_greenhouse": 15.731,
         "t_outdoor": 13.6565
       },
@@ -2747,9 +2747,9 @@
     {
       "time": 14940,
       "values": {
-        "t_tank_top": 18.5842,
-        "t_tank_bottom": 17.4842,
-        "t_collector": 20.6493,
+        "t_tank_top": 18.3447,
+        "t_tank_bottom": 17.2398,
+        "t_collector": 20.4173,
         "t_greenhouse": 15.7518,
         "t_outdoor": 13.6714
       },
@@ -2758,9 +2758,9 @@
     {
       "time": 15000,
       "values": {
-        "t_tank_top": 18.6238,
-        "t_tank_bottom": 17.5232,
-        "t_collector": 20.69,
+        "t_tank_top": 18.3826,
+        "t_tank_bottom": 17.277,
+        "t_collector": 20.4563,
         "t_greenhouse": 15.7725,
         "t_outdoor": 13.6861
       },
@@ -2769,9 +2769,9 @@
     {
       "time": 15060,
       "values": {
-        "t_tank_top": 18.6635,
-        "t_tank_bottom": 17.5623,
-        "t_collector": 20.7305,
+        "t_tank_top": 18.4205,
+        "t_tank_bottom": 17.3143,
+        "t_collector": 20.4952,
         "t_greenhouse": 15.7931,
         "t_outdoor": 13.7008
       },
@@ -2780,9 +2780,9 @@
     {
       "time": 15120,
       "values": {
-        "t_tank_top": 18.7032,
-        "t_tank_bottom": 17.6013,
-        "t_collector": 20.7711,
+        "t_tank_top": 18.4585,
+        "t_tank_bottom": 17.3516,
+        "t_collector": 20.5341,
         "t_greenhouse": 15.8137,
         "t_outdoor": 13.7155
       },
@@ -2791,9 +2791,9 @@
     {
       "time": 15180,
       "values": {
-        "t_tank_top": 18.7428,
-        "t_tank_bottom": 17.6404,
-        "t_collector": 20.8116,
+        "t_tank_top": 18.4964,
+        "t_tank_bottom": 17.3889,
+        "t_collector": 20.5729,
         "t_greenhouse": 15.8341,
         "t_outdoor": 13.73
       },
@@ -2802,9 +2802,9 @@
     {
       "time": 15240,
       "values": {
-        "t_tank_top": 18.7825,
-        "t_tank_bottom": 17.6795,
-        "t_collector": 20.8521,
+        "t_tank_top": 18.5343,
+        "t_tank_bottom": 17.4262,
+        "t_collector": 20.6117,
         "t_greenhouse": 15.8545,
         "t_outdoor": 13.7445
       },
@@ -2813,9 +2813,9 @@
     {
       "time": 15300,
       "values": {
-        "t_tank_top": 18.8222,
-        "t_tank_bottom": 17.7187,
-        "t_collector": 20.8926,
+        "t_tank_top": 18.5722,
+        "t_tank_bottom": 17.4635,
+        "t_collector": 20.6504,
         "t_greenhouse": 15.8747,
         "t_outdoor": 13.759
       },
@@ -2824,9 +2824,9 @@
     {
       "time": 15360,
       "values": {
-        "t_tank_top": 18.8618,
-        "t_tank_bottom": 17.7578,
-        "t_collector": 20.933,
+        "t_tank_top": 18.6101,
+        "t_tank_bottom": 17.5008,
+        "t_collector": 20.6891,
         "t_greenhouse": 15.8949,
         "t_outdoor": 13.7733
       },
@@ -2835,9 +2835,9 @@
     {
       "time": 15420,
       "values": {
-        "t_tank_top": 18.9015,
-        "t_tank_bottom": 17.7969,
-        "t_collector": 20.9734,
+        "t_tank_top": 18.6479,
+        "t_tank_bottom": 17.5382,
+        "t_collector": 20.7278,
         "t_greenhouse": 15.915,
         "t_outdoor": 13.7876
       },
@@ -2846,9 +2846,9 @@
     {
       "time": 15480,
       "values": {
-        "t_tank_top": 18.9412,
-        "t_tank_bottom": 17.8361,
-        "t_collector": 21.0138,
+        "t_tank_top": 18.6858,
+        "t_tank_bottom": 17.5755,
+        "t_collector": 20.7664,
         "t_greenhouse": 15.9349,
         "t_outdoor": 13.8018
       },
@@ -2857,9 +2857,9 @@
     {
       "time": 15540,
       "values": {
-        "t_tank_top": 18.9808,
-        "t_tank_bottom": 17.8753,
-        "t_collector": 21.0541,
+        "t_tank_top": 18.7236,
+        "t_tank_bottom": 17.6128,
+        "t_collector": 20.8049,
         "t_greenhouse": 15.9548,
         "t_outdoor": 13.8159
       },
@@ -2868,9 +2868,9 @@
     {
       "time": 15600,
       "values": {
-        "t_tank_top": 19.0205,
-        "t_tank_bottom": 17.9145,
-        "t_collector": 21.0944,
+        "t_tank_top": 18.7615,
+        "t_tank_bottom": 17.6502,
+        "t_collector": 20.8435,
         "t_greenhouse": 15.9746,
         "t_outdoor": 13.83
       },
@@ -2879,9 +2879,9 @@
     {
       "time": 15660,
       "values": {
-        "t_tank_top": 19.0601,
-        "t_tank_bottom": 17.9537,
-        "t_collector": 21.1347,
+        "t_tank_top": 18.7993,
+        "t_tank_bottom": 17.6875,
+        "t_collector": 20.8819,
         "t_greenhouse": 15.9943,
         "t_outdoor": 13.844
       },
@@ -2890,9 +2890,9 @@
     {
       "time": 15720,
       "values": {
-        "t_tank_top": 19.0998,
-        "t_tank_bottom": 17.9929,
-        "t_collector": 21.1749,
+        "t_tank_top": 18.8371,
+        "t_tank_bottom": 17.7248,
+        "t_collector": 20.9204,
         "t_greenhouse": 16.0139,
         "t_outdoor": 13.8579
       },
@@ -2901,9 +2901,9 @@
     {
       "time": 15780,
       "values": {
-        "t_tank_top": 19.1394,
-        "t_tank_bottom": 18.0321,
-        "t_collector": 21.2151,
+        "t_tank_top": 18.8749,
+        "t_tank_bottom": 17.7622,
+        "t_collector": 20.9587,
         "t_greenhouse": 16.0333,
         "t_outdoor": 13.8717
       },
@@ -2912,9 +2912,9 @@
     {
       "time": 15840,
       "values": {
-        "t_tank_top": 19.179,
-        "t_tank_bottom": 18.0714,
-        "t_collector": 21.2552,
+        "t_tank_top": 18.9126,
+        "t_tank_bottom": 17.7995,
+        "t_collector": 20.9971,
         "t_greenhouse": 16.0527,
         "t_outdoor": 13.8855
       },
@@ -2923,9 +2923,9 @@
     {
       "time": 15900,
       "values": {
-        "t_tank_top": 19.2187,
-        "t_tank_bottom": 18.1106,
-        "t_collector": 21.2953,
+        "t_tank_top": 18.9504,
+        "t_tank_bottom": 17.8369,
+        "t_collector": 21.0353,
         "t_greenhouse": 16.072,
         "t_outdoor": 13.8992
       },
@@ -2934,9 +2934,9 @@
     {
       "time": 15960,
       "values": {
-        "t_tank_top": 19.2583,
-        "t_tank_bottom": 18.1499,
-        "t_collector": 21.3354,
+        "t_tank_top": 18.9881,
+        "t_tank_bottom": 17.8742,
+        "t_collector": 21.0736,
         "t_greenhouse": 16.0912,
         "t_outdoor": 13.9128
       },
@@ -2945,9 +2945,9 @@
     {
       "time": 16020,
       "values": {
-        "t_tank_top": 19.2979,
-        "t_tank_bottom": 18.1892,
-        "t_collector": 21.3754,
+        "t_tank_top": 19.0258,
+        "t_tank_bottom": 17.9115,
+        "t_collector": 21.1118,
         "t_greenhouse": 16.1103,
         "t_outdoor": 13.9264
       },
@@ -2956,9 +2956,9 @@
     {
       "time": 16080,
       "values": {
-        "t_tank_top": 19.3375,
-        "t_tank_bottom": 18.2284,
-        "t_collector": 21.4154,
+        "t_tank_top": 19.0635,
+        "t_tank_bottom": 17.9489,
+        "t_collector": 21.1499,
         "t_greenhouse": 16.1293,
         "t_outdoor": 13.9398
       },
@@ -2967,9 +2967,9 @@
     {
       "time": 16140,
       "values": {
-        "t_tank_top": 19.3771,
-        "t_tank_bottom": 18.2677,
-        "t_collector": 21.4553,
+        "t_tank_top": 19.1012,
+        "t_tank_bottom": 17.9862,
+        "t_collector": 21.188,
         "t_greenhouse": 16.1482,
         "t_outdoor": 13.9532
       },
@@ -2978,9 +2978,9 @@
     {
       "time": 16200,
       "values": {
-        "t_tank_top": 19.4166,
-        "t_tank_bottom": 18.307,
-        "t_collector": 21.4952,
+        "t_tank_top": 19.1389,
+        "t_tank_bottom": 18.0236,
+        "t_collector": 21.226,
         "t_greenhouse": 16.167,
         "t_outdoor": 13.9665
       },
@@ -2989,9 +2989,9 @@
     {
       "time": 16260,
       "values": {
-        "t_tank_top": 19.4562,
-        "t_tank_bottom": 18.3463,
-        "t_collector": 21.535,
+        "t_tank_top": 19.1765,
+        "t_tank_bottom": 18.0609,
+        "t_collector": 21.264,
         "t_greenhouse": 16.1857,
         "t_outdoor": 13.9798
       },
@@ -3000,9 +3000,9 @@
     {
       "time": 16320,
       "values": {
-        "t_tank_top": 19.4957,
-        "t_tank_bottom": 18.3856,
-        "t_collector": 21.5748,
+        "t_tank_top": 19.2141,
+        "t_tank_bottom": 18.0982,
+        "t_collector": 21.3019,
         "t_greenhouse": 16.2043,
         "t_outdoor": 13.993
       },
@@ -3011,9 +3011,9 @@
     {
       "time": 16380,
       "values": {
-        "t_tank_top": 19.5353,
-        "t_tank_bottom": 18.4249,
-        "t_collector": 21.6146,
+        "t_tank_top": 19.2517,
+        "t_tank_bottom": 18.1355,
+        "t_collector": 21.3398,
         "t_greenhouse": 16.2228,
         "t_outdoor": 14.0061
       },
@@ -3022,9 +3022,9 @@
     {
       "time": 16440,
       "values": {
-        "t_tank_top": 19.5748,
-        "t_tank_bottom": 18.4642,
-        "t_collector": 21.6543,
+        "t_tank_top": 19.2893,
+        "t_tank_bottom": 18.1729,
+        "t_collector": 21.3776,
         "t_greenhouse": 16.2412,
         "t_outdoor": 14.0191
       },
@@ -3033,9 +3033,9 @@
     {
       "time": 16500,
       "values": {
-        "t_tank_top": 19.6143,
-        "t_tank_bottom": 18.5035,
-        "t_collector": 21.694,
+        "t_tank_top": 19.3268,
+        "t_tank_bottom": 18.2102,
+        "t_collector": 21.4153,
         "t_greenhouse": 16.2594,
         "t_outdoor": 14.032
       },
@@ -3044,9 +3044,9 @@
     {
       "time": 16560,
       "values": {
-        "t_tank_top": 19.6538,
-        "t_tank_bottom": 18.5428,
-        "t_collector": 21.7336,
+        "t_tank_top": 19.3643,
+        "t_tank_bottom": 18.2475,
+        "t_collector": 21.453,
         "t_greenhouse": 16.2776,
         "t_outdoor": 14.0449
       },
@@ -3055,9 +3055,9 @@
     {
       "time": 16620,
       "values": {
-        "t_tank_top": 19.6933,
-        "t_tank_bottom": 18.5822,
-        "t_collector": 21.7732,
+        "t_tank_top": 19.4018,
+        "t_tank_bottom": 18.2848,
+        "t_collector": 21.4907,
         "t_greenhouse": 16.2957,
         "t_outdoor": 14.0577
       },
@@ -3066,9 +3066,9 @@
     {
       "time": 16680,
       "values": {
-        "t_tank_top": 19.7327,
-        "t_tank_bottom": 18.6215,
-        "t_collector": 21.8127,
+        "t_tank_top": 19.4393,
+        "t_tank_bottom": 18.322,
+        "t_collector": 21.5283,
         "t_greenhouse": 16.3137,
         "t_outdoor": 14.0704
       },
@@ -3077,9 +3077,9 @@
     {
       "time": 16740,
       "values": {
-        "t_tank_top": 19.7722,
-        "t_tank_bottom": 18.6608,
-        "t_collector": 21.8522,
+        "t_tank_top": 19.4767,
+        "t_tank_bottom": 18.3593,
+        "t_collector": 21.5658,
         "t_greenhouse": 16.3315,
         "t_outdoor": 14.083
       },
@@ -3088,9 +3088,9 @@
     {
       "time": 16800,
       "values": {
-        "t_tank_top": 19.8116,
-        "t_tank_bottom": 18.7001,
-        "t_collector": 21.8916,
+        "t_tank_top": 19.5141,
+        "t_tank_bottom": 18.3966,
+        "t_collector": 21.6033,
         "t_greenhouse": 16.3493,
         "t_outdoor": 14.0956
       },
@@ -3099,9 +3099,9 @@
     {
       "time": 16860,
       "values": {
-        "t_tank_top": 19.851,
-        "t_tank_bottom": 18.7395,
-        "t_collector": 21.931,
+        "t_tank_top": 19.5515,
+        "t_tank_bottom": 18.4338,
+        "t_collector": 21.6407,
         "t_greenhouse": 16.367,
         "t_outdoor": 14.108
       },
@@ -3110,9 +3110,9 @@
     {
       "time": 16920,
       "values": {
-        "t_tank_top": 19.8904,
-        "t_tank_bottom": 18.7788,
-        "t_collector": 21.9703,
+        "t_tank_top": 19.5889,
+        "t_tank_bottom": 18.4711,
+        "t_collector": 21.678,
         "t_greenhouse": 16.3845,
         "t_outdoor": 14.1204
       },
@@ -3121,9 +3121,9 @@
     {
       "time": 16980,
       "values": {
-        "t_tank_top": 19.9298,
-        "t_tank_bottom": 18.8181,
-        "t_collector": 22.0096,
+        "t_tank_top": 19.6262,
+        "t_tank_bottom": 18.5083,
+        "t_collector": 21.7153,
         "t_greenhouse": 16.402,
         "t_outdoor": 14.1327
       },
@@ -3132,9 +3132,9 @@
     {
       "time": 17040,
       "values": {
-        "t_tank_top": 19.9691,
-        "t_tank_bottom": 18.8574,
-        "t_collector": 22.0488,
+        "t_tank_top": 19.6635,
+        "t_tank_bottom": 18.5455,
+        "t_collector": 21.7525,
         "t_greenhouse": 16.4193,
         "t_outdoor": 14.145
       },
@@ -3143,9 +3143,9 @@
     {
       "time": 17100,
       "values": {
-        "t_tank_top": 20.0085,
-        "t_tank_bottom": 18.8967,
-        "t_collector": 22.088,
+        "t_tank_top": 19.7007,
+        "t_tank_bottom": 18.5827,
+        "t_collector": 21.7897,
         "t_greenhouse": 16.4366,
         "t_outdoor": 14.1571
       },
@@ -3154,9 +3154,9 @@
     {
       "time": 17160,
       "values": {
-        "t_tank_top": 20.0478,
-        "t_tank_bottom": 18.936,
-        "t_collector": 22.1271,
+        "t_tank_top": 19.738,
+        "t_tank_bottom": 18.6199,
+        "t_collector": 21.8268,
         "t_greenhouse": 16.4537,
         "t_outdoor": 14.1692
       },
@@ -3165,9 +3165,9 @@
     {
       "time": 17220,
       "values": {
-        "t_tank_top": 20.0871,
-        "t_tank_bottom": 18.9753,
-        "t_collector": 22.1661,
+        "t_tank_top": 19.7752,
+        "t_tank_bottom": 18.6571,
+        "t_collector": 21.8638,
         "t_greenhouse": 16.4707,
         "t_outdoor": 14.1812
       },
@@ -3176,9 +3176,9 @@
     {
       "time": 17280,
       "values": {
-        "t_tank_top": 20.1263,
-        "t_tank_bottom": 19.0146,
-        "t_collector": 22.2052,
+        "t_tank_top": 19.8123,
+        "t_tank_bottom": 18.6943,
+        "t_collector": 21.9008,
         "t_greenhouse": 16.4876,
         "t_outdoor": 14.1932
       },
@@ -3187,9 +3187,9 @@
     {
       "time": 17340,
       "values": {
-        "t_tank_top": 20.1656,
-        "t_tank_bottom": 19.0539,
-        "t_collector": 22.2441,
+        "t_tank_top": 19.8495,
+        "t_tank_bottom": 18.7314,
+        "t_collector": 21.9377,
         "t_greenhouse": 16.5045,
         "t_outdoor": 14.205
       },
@@ -3198,9 +3198,9 @@
     {
       "time": 17400,
       "values": {
-        "t_tank_top": 20.2048,
-        "t_tank_bottom": 19.0932,
-        "t_collector": 22.283,
+        "t_tank_top": 19.8866,
+        "t_tank_bottom": 18.7686,
+        "t_collector": 21.9745,
         "t_greenhouse": 16.5212,
         "t_outdoor": 14.2168
       },
@@ -3209,9 +3209,9 @@
     {
       "time": 17460,
       "values": {
-        "t_tank_top": 20.244,
-        "t_tank_bottom": 19.1325,
-        "t_collector": 22.3218,
+        "t_tank_top": 19.9236,
+        "t_tank_bottom": 18.8057,
+        "t_collector": 22.0113,
         "t_greenhouse": 16.5378,
         "t_outdoor": 14.2284
       },
@@ -3220,9 +3220,9 @@
     {
       "time": 17520,
       "values": {
-        "t_tank_top": 20.2831,
-        "t_tank_bottom": 19.1718,
-        "t_collector": 22.3606,
+        "t_tank_top": 19.9607,
+        "t_tank_bottom": 18.8428,
+        "t_collector": 22.048,
         "t_greenhouse": 16.5542,
         "t_outdoor": 14.24
       },
@@ -3231,9 +3231,9 @@
     {
       "time": 17580,
       "values": {
-        "t_tank_top": 20.3223,
-        "t_tank_bottom": 19.211,
-        "t_collector": 22.3994,
+        "t_tank_top": 19.9977,
+        "t_tank_bottom": 18.8798,
+        "t_collector": 22.0846,
         "t_greenhouse": 16.5706,
         "t_outdoor": 14.2516
       },
@@ -3242,9 +3242,9 @@
     {
       "time": 17640,
       "values": {
-        "t_tank_top": 20.3614,
-        "t_tank_bottom": 19.2503,
-        "t_collector": 22.438,
+        "t_tank_top": 20.0346,
+        "t_tank_bottom": 18.9169,
+        "t_collector": 22.1212,
         "t_greenhouse": 16.5869,
         "t_outdoor": 14.263
       },
@@ -3253,9 +3253,9 @@
     {
       "time": 17700,
       "values": {
-        "t_tank_top": 20.4005,
-        "t_tank_bottom": 19.2895,
-        "t_collector": 22.4766,
+        "t_tank_top": 20.0715,
+        "t_tank_bottom": 18.9539,
+        "t_collector": 22.1577,
         "t_greenhouse": 16.6031,
         "t_outdoor": 14.2744
       },
@@ -3264,9 +3264,9 @@
     {
       "time": 17760,
       "values": {
-        "t_tank_top": 20.4395,
-        "t_tank_bottom": 19.3288,
-        "t_collector": 22.5152,
+        "t_tank_top": 20.1084,
+        "t_tank_bottom": 18.991,
+        "t_collector": 22.1941,
         "t_greenhouse": 16.6191,
         "t_outdoor": 14.2856
       },
@@ -3275,9 +3275,9 @@
     {
       "time": 17820,
       "values": {
-        "t_tank_top": 20.4786,
-        "t_tank_bottom": 19.368,
-        "t_collector": 22.5537,
+        "t_tank_top": 20.1453,
+        "t_tank_bottom": 19.028,
+        "t_collector": 22.2305,
         "t_greenhouse": 16.635,
         "t_outdoor": 14.2968
       },
@@ -3286,9 +3286,9 @@
     {
       "time": 17880,
       "values": {
-        "t_tank_top": 20.5176,
-        "t_tank_bottom": 19.4072,
-        "t_collector": 22.5921,
+        "t_tank_top": 20.1821,
+        "t_tank_bottom": 19.0649,
+        "t_collector": 22.2668,
         "t_greenhouse": 16.6509,
         "t_outdoor": 14.308
       },
@@ -3297,9 +3297,9 @@
     {
       "time": 17940,
       "values": {
-        "t_tank_top": 20.5565,
-        "t_tank_bottom": 19.4464,
-        "t_collector": 22.6305,
+        "t_tank_top": 20.2188,
+        "t_tank_bottom": 19.1019,
+        "t_collector": 22.303,
         "t_greenhouse": 16.6666,
         "t_outdoor": 14.319
       },
@@ -3308,9 +3308,9 @@
     {
       "time": 18000,
       "values": {
-        "t_tank_top": 20.5955,
-        "t_tank_bottom": 19.4856,
-        "t_collector": 22.6688,
+        "t_tank_top": 20.2555,
+        "t_tank_bottom": 19.1388,
+        "t_collector": 22.3392,
         "t_greenhouse": 16.6822,
         "t_outdoor": 14.3299
       },
@@ -3319,9 +3319,9 @@
     {
       "time": 18060,
       "values": {
-        "t_tank_top": 20.6344,
-        "t_tank_bottom": 19.5248,
-        "t_collector": 22.707,
+        "t_tank_top": 20.2922,
+        "t_tank_bottom": 19.1757,
+        "t_collector": 22.3752,
         "t_greenhouse": 16.6977,
         "t_outdoor": 14.3408
       },
@@ -3330,9 +3330,9 @@
     {
       "time": 18120,
       "values": {
-        "t_tank_top": 20.6732,
-        "t_tank_bottom": 19.564,
-        "t_collector": 22.7452,
+        "t_tank_top": 20.3289,
+        "t_tank_bottom": 19.2126,
+        "t_collector": 22.4112,
         "t_greenhouse": 16.7131,
         "t_outdoor": 14.3516
       },
@@ -3341,9 +3341,9 @@
     {
       "time": 18180,
       "values": {
-        "t_tank_top": 20.7121,
-        "t_tank_bottom": 19.6031,
-        "t_collector": 22.7833,
+        "t_tank_top": 20.3654,
+        "t_tank_bottom": 19.2495,
+        "t_collector": 22.4472,
         "t_greenhouse": 16.7283,
         "t_outdoor": 14.3623
       },
@@ -3352,9 +3352,9 @@
     {
       "time": 18240,
       "values": {
-        "t_tank_top": 20.7509,
-        "t_tank_bottom": 19.6422,
-        "t_collector": 22.8213,
+        "t_tank_top": 20.402,
+        "t_tank_bottom": 19.2863,
+        "t_collector": 22.483,
         "t_greenhouse": 16.7435,
         "t_outdoor": 14.3729
       },
@@ -3363,9 +3363,9 @@
     {
       "time": 18300,
       "values": {
-        "t_tank_top": 20.7897,
-        "t_tank_bottom": 19.6814,
-        "t_collector": 22.8593,
+        "t_tank_top": 20.4385,
+        "t_tank_bottom": 19.3231,
+        "t_collector": 22.5188,
         "t_greenhouse": 16.7586,
         "t_outdoor": 14.3835
       },
@@ -3374,9 +3374,9 @@
     {
       "time": 18360,
       "values": {
-        "t_tank_top": 20.8284,
-        "t_tank_bottom": 19.7205,
-        "t_collector": 22.8972,
+        "t_tank_top": 20.475,
+        "t_tank_bottom": 19.3599,
+        "t_collector": 22.5545,
         "t_greenhouse": 16.7735,
         "t_outdoor": 14.3939
       },
@@ -3385,9 +3385,9 @@
     {
       "time": 18420,
       "values": {
-        "t_tank_top": 20.8671,
-        "t_tank_bottom": 19.7595,
-        "t_collector": 22.9351,
+        "t_tank_top": 20.5114,
+        "t_tank_bottom": 19.3966,
+        "t_collector": 22.5901,
         "t_greenhouse": 16.7883,
         "t_outdoor": 14.4043
       },
@@ -3396,9 +3396,9 @@
     {
       "time": 18480,
       "values": {
-        "t_tank_top": 20.9058,
-        "t_tank_bottom": 19.7986,
-        "t_collector": 22.9729,
+        "t_tank_top": 20.5477,
+        "t_tank_bottom": 19.4333,
+        "t_collector": 22.6256,
         "t_greenhouse": 16.803,
         "t_outdoor": 14.4146
       },
@@ -3407,9 +3407,9 @@
     {
       "time": 18540,
       "values": {
-        "t_tank_top": 20.9444,
-        "t_tank_bottom": 19.8377,
-        "t_collector": 23.0106,
+        "t_tank_top": 20.5841,
+        "t_tank_bottom": 19.47,
+        "t_collector": 22.6611,
         "t_greenhouse": 16.8176,
         "t_outdoor": 14.4248
       },
@@ -3418,9 +3418,9 @@
     {
       "time": 18600,
       "values": {
-        "t_tank_top": 20.983,
-        "t_tank_bottom": 19.8767,
-        "t_collector": 23.0482,
+        "t_tank_top": 20.6203,
+        "t_tank_bottom": 19.5067,
+        "t_collector": 22.6965,
         "t_greenhouse": 16.8321,
         "t_outdoor": 14.4349
       },
@@ -3429,9 +3429,9 @@
     {
       "time": 18660,
       "values": {
-        "t_tank_top": 21.0216,
-        "t_tank_bottom": 19.9157,
-        "t_collector": 23.0858,
+        "t_tank_top": 20.6566,
+        "t_tank_bottom": 19.5433,
+        "t_collector": 22.7318,
         "t_greenhouse": 16.8464,
         "t_outdoor": 14.4449
       },
@@ -3440,9 +3440,9 @@
     {
       "time": 18720,
       "values": {
-        "t_tank_top": 21.0601,
-        "t_tank_bottom": 19.9547,
-        "t_collector": 23.1233,
+        "t_tank_top": 20.6928,
+        "t_tank_bottom": 19.5799,
+        "t_collector": 22.767,
         "t_greenhouse": 16.8607,
         "t_outdoor": 14.4549
       },
@@ -3451,9 +3451,9 @@
     {
       "time": 18780,
       "values": {
-        "t_tank_top": 21.0986,
-        "t_tank_bottom": 19.9936,
-        "t_collector": 23.1608,
+        "t_tank_top": 20.7289,
+        "t_tank_bottom": 19.6165,
+        "t_collector": 22.8022,
         "t_greenhouse": 16.8748,
         "t_outdoor": 14.4647
       },
@@ -3462,9 +3462,9 @@
     {
       "time": 18840,
       "values": {
-        "t_tank_top": 21.137,
-        "t_tank_bottom": 20.0326,
-        "t_collector": 23.1981,
+        "t_tank_top": 20.765,
+        "t_tank_bottom": 19.653,
+        "t_collector": 22.8372,
         "t_greenhouse": 16.8889,
         "t_outdoor": 14.4745
       },
@@ -3473,9 +3473,9 @@
     {
       "time": 18900,
       "values": {
-        "t_tank_top": 21.1755,
-        "t_tank_bottom": 20.0715,
-        "t_collector": 23.2354,
+        "t_tank_top": 20.801,
+        "t_tank_bottom": 19.6895,
+        "t_collector": 22.8722,
         "t_greenhouse": 16.9028,
         "t_outdoor": 14.4842
       },
@@ -3484,9 +3484,9 @@
     {
       "time": 18960,
       "values": {
-        "t_tank_top": 21.2138,
-        "t_tank_bottom": 20.1104,
-        "t_collector": 23.2726,
+        "t_tank_top": 20.837,
+        "t_tank_bottom": 19.726,
+        "t_collector": 22.9071,
         "t_greenhouse": 16.9165,
         "t_outdoor": 14.4938
       },
@@ -3495,9 +3495,9 @@
     {
       "time": 19020,
       "values": {
-        "t_tank_top": 21.2521,
-        "t_tank_bottom": 20.1493,
-        "t_collector": 23.3098,
+        "t_tank_top": 20.8729,
+        "t_tank_bottom": 19.7624,
+        "t_collector": 22.9419,
         "t_greenhouse": 16.9302,
         "t_outdoor": 14.5033
       },
@@ -3506,9 +3506,9 @@
     {
       "time": 19080,
       "values": {
-        "t_tank_top": 21.2904,
-        "t_tank_bottom": 20.1881,
-        "t_collector": 23.3469,
+        "t_tank_top": 20.9088,
+        "t_tank_bottom": 19.7988,
+        "t_collector": 22.9767,
         "t_greenhouse": 16.9438,
         "t_outdoor": 14.5128
       },
@@ -3517,9 +3517,9 @@
     {
       "time": 19140,
       "values": {
-        "t_tank_top": 21.3287,
-        "t_tank_bottom": 20.227,
-        "t_collector": 23.3839,
+        "t_tank_top": 20.9446,
+        "t_tank_bottom": 19.8352,
+        "t_collector": 23.0113,
         "t_greenhouse": 16.9572,
         "t_outdoor": 14.5221
       },
@@ -3528,9 +3528,9 @@
     {
       "time": 19200,
       "values": {
-        "t_tank_top": 21.3668,
-        "t_tank_bottom": 20.2658,
-        "t_collector": 23.4208,
+        "t_tank_top": 20.9804,
+        "t_tank_bottom": 19.8715,
+        "t_collector": 23.0459,
         "t_greenhouse": 16.9705,
         "t_outdoor": 14.5314
       },
@@ -3539,9 +3539,9 @@
     {
       "time": 19260,
       "values": {
-        "t_tank_top": 21.405,
-        "t_tank_bottom": 20.3045,
-        "t_collector": 23.4576,
+        "t_tank_top": 21.0161,
+        "t_tank_bottom": 19.9078,
+        "t_collector": 23.0804,
         "t_greenhouse": 16.9837,
         "t_outdoor": 14.5406
       },
@@ -3550,9 +3550,9 @@
     {
       "time": 19320,
       "values": {
-        "t_tank_top": 21.4431,
-        "t_tank_bottom": 20.3433,
-        "t_collector": 23.4944,
+        "t_tank_top": 21.0517,
+        "t_tank_bottom": 19.944,
+        "t_collector": 23.1147,
         "t_greenhouse": 16.9968,
         "t_outdoor": 14.5497
       },
@@ -3561,9 +3561,9 @@
     {
       "time": 19380,
       "values": {
-        "t_tank_top": 21.4812,
-        "t_tank_bottom": 20.382,
-        "t_collector": 23.5311,
+        "t_tank_top": 21.0873,
+        "t_tank_bottom": 19.9802,
+        "t_collector": 23.149,
         "t_greenhouse": 17.0098,
         "t_outdoor": 14.5587
       },
@@ -3572,9 +3572,9 @@
     {
       "time": 19440,
       "values": {
-        "t_tank_top": 21.5192,
-        "t_tank_bottom": 20.4207,
-        "t_collector": 23.5677,
+        "t_tank_top": 21.1229,
+        "t_tank_bottom": 20.0164,
+        "t_collector": 23.1833,
         "t_greenhouse": 17.0227,
         "t_outdoor": 14.5676
       },
@@ -3583,9 +3583,9 @@
     {
       "time": 19500,
       "values": {
-        "t_tank_top": 21.5571,
-        "t_tank_bottom": 20.4593,
-        "t_collector": 23.6043,
+        "t_tank_top": 21.1583,
+        "t_tank_bottom": 20.0525,
+        "t_collector": 23.2174,
         "t_greenhouse": 17.0354,
         "t_outdoor": 14.5764
       },
@@ -3594,9 +3594,9 @@
     {
       "time": 19560,
       "values": {
-        "t_tank_top": 21.5951,
-        "t_tank_bottom": 20.498,
-        "t_collector": 23.6407,
+        "t_tank_top": 21.1938,
+        "t_tank_bottom": 20.0886,
+        "t_collector": 23.2514,
         "t_greenhouse": 17.048,
         "t_outdoor": 14.5852
       },
@@ -3605,9 +3605,9 @@
     {
       "time": 19620,
       "values": {
-        "t_tank_top": 21.6329,
-        "t_tank_bottom": 20.5366,
-        "t_collector": 23.6771,
+        "t_tank_top": 21.2291,
+        "t_tank_bottom": 20.1247,
+        "t_collector": 23.2854,
         "t_greenhouse": 17.0605,
         "t_outdoor": 14.5938
       },
@@ -3616,9 +3616,9 @@
     {
       "time": 19680,
       "values": {
-        "t_tank_top": 21.6708,
-        "t_tank_bottom": 20.5751,
-        "t_collector": 23.7134,
+        "t_tank_top": 21.2645,
+        "t_tank_bottom": 20.1607,
+        "t_collector": 23.3192,
         "t_greenhouse": 17.0729,
         "t_outdoor": 14.6024
       },
@@ -3627,9 +3627,9 @@
     {
       "time": 19740,
       "values": {
-        "t_tank_top": 21.7085,
-        "t_tank_bottom": 20.6137,
-        "t_collector": 23.7496,
+        "t_tank_top": 21.2997,
+        "t_tank_bottom": 20.1966,
+        "t_collector": 23.353,
         "t_greenhouse": 17.0851,
         "t_outdoor": 14.6109
       },
@@ -3638,9 +3638,9 @@
     {
       "time": 19800,
       "values": {
-        "t_tank_top": 21.7463,
-        "t_tank_bottom": 20.6522,
-        "t_collector": 23.7858,
+        "t_tank_top": 21.3349,
+        "t_tank_bottom": 20.2326,
+        "t_collector": 23.3867,
         "t_greenhouse": 17.0973,
         "t_outdoor": 14.6193
       },
@@ -3649,9 +3649,9 @@
     {
       "time": 19860,
       "values": {
-        "t_tank_top": 21.7839,
-        "t_tank_bottom": 20.6907,
-        "t_collector": 23.8218,
+        "t_tank_top": 21.37,
+        "t_tank_bottom": 20.2685,
+        "t_collector": 23.4203,
         "t_greenhouse": 17.1093,
         "t_outdoor": 14.6276
       },
@@ -3660,9 +3660,9 @@
     {
       "time": 19920,
       "values": {
-        "t_tank_top": 21.8216,
-        "t_tank_bottom": 20.7291,
-        "t_collector": 23.8578,
+        "t_tank_top": 21.4051,
+        "t_tank_bottom": 20.3043,
+        "t_collector": 23.4538,
         "t_greenhouse": 17.1212,
         "t_outdoor": 14.6358
       },
@@ -3671,9 +3671,9 @@
     {
       "time": 19980,
       "values": {
-        "t_tank_top": 21.8591,
-        "t_tank_bottom": 20.7675,
-        "t_collector": 23.8937,
+        "t_tank_top": 21.4401,
+        "t_tank_bottom": 20.3401,
+        "t_collector": 23.4872,
         "t_greenhouse": 17.133,
         "t_outdoor": 14.6439
       },
@@ -3682,9 +3682,9 @@
     {
       "time": 20040,
       "values": {
-        "t_tank_top": 21.8967,
-        "t_tank_bottom": 20.8059,
-        "t_collector": 23.9295,
+        "t_tank_top": 21.475,
+        "t_tank_bottom": 20.3758,
+        "t_collector": 23.5205,
         "t_greenhouse": 17.1446,
         "t_outdoor": 14.652
       },
@@ -3693,9 +3693,9 @@
     {
       "time": 20100,
       "values": {
-        "t_tank_top": 21.9341,
-        "t_tank_bottom": 20.8442,
-        "t_collector": 23.9653,
+        "t_tank_top": 21.5099,
+        "t_tank_bottom": 20.4115,
+        "t_collector": 23.5537,
         "t_greenhouse": 17.1562,
         "t_outdoor": 14.6599
       },
@@ -3704,9 +3704,9 @@
     {
       "time": 20160,
       "values": {
-        "t_tank_top": 21.9715,
-        "t_tank_bottom": 20.8825,
-        "t_collector": 24.0009,
+        "t_tank_top": 21.5447,
+        "t_tank_bottom": 20.4472,
+        "t_collector": 23.5868,
         "t_greenhouse": 17.1676,
         "t_outdoor": 14.6678
       },
@@ -3715,9 +3715,9 @@
     {
       "time": 20220,
       "values": {
-        "t_tank_top": 22.0089,
-        "t_tank_bottom": 20.9208,
-        "t_collector": 24.0365,
+        "t_tank_top": 21.5795,
+        "t_tank_bottom": 20.4828,
+        "t_collector": 23.6198,
         "t_greenhouse": 17.1789,
         "t_outdoor": 14.6755
       },
@@ -3726,9 +3726,9 @@
     {
       "time": 20280,
       "values": {
-        "t_tank_top": 22.0462,
-        "t_tank_bottom": 20.959,
-        "t_collector": 24.0719,
+        "t_tank_top": 21.6142,
+        "t_tank_bottom": 20.5183,
+        "t_collector": 23.6527,
         "t_greenhouse": 17.1901,
         "t_outdoor": 14.6832
       },
@@ -3737,9 +3737,9 @@
     {
       "time": 20340,
       "values": {
-        "t_tank_top": 22.0835,
-        "t_tank_bottom": 20.9972,
-        "t_collector": 24.1073,
+        "t_tank_top": 21.6488,
+        "t_tank_bottom": 20.5538,
+        "t_collector": 23.6856,
         "t_greenhouse": 17.2011,
         "t_outdoor": 14.6908
       },
@@ -3748,9 +3748,9 @@
     {
       "time": 20400,
       "values": {
-        "t_tank_top": 22.1206,
-        "t_tank_bottom": 21.0353,
-        "t_collector": 24.1426,
+        "t_tank_top": 21.6833,
+        "t_tank_bottom": 20.5893,
+        "t_collector": 23.7183,
         "t_greenhouse": 17.212,
         "t_outdoor": 14.6983
       },
@@ -3759,9 +3759,9 @@
     {
       "time": 20460,
       "values": {
-        "t_tank_top": 22.1578,
-        "t_tank_bottom": 21.0735,
-        "t_collector": 24.1778,
+        "t_tank_top": 21.7178,
+        "t_tank_bottom": 20.6247,
+        "t_collector": 23.7509,
         "t_greenhouse": 17.2229,
         "t_outdoor": 14.7058
       },
@@ -3770,9 +3770,9 @@
     {
       "time": 20520,
       "values": {
-        "t_tank_top": 22.1949,
-        "t_tank_bottom": 21.1115,
-        "t_collector": 24.213,
+        "t_tank_top": 21.7523,
+        "t_tank_bottom": 20.6601,
+        "t_collector": 23.7835,
         "t_greenhouse": 17.2335,
         "t_outdoor": 14.7131
       },
@@ -3781,9 +3781,9 @@
     {
       "time": 20580,
       "values": {
-        "t_tank_top": 22.2319,
-        "t_tank_bottom": 21.1496,
-        "t_collector": 24.248,
+        "t_tank_top": 21.7866,
+        "t_tank_bottom": 20.6954,
+        "t_collector": 23.8159,
         "t_greenhouse": 17.2441,
         "t_outdoor": 14.7203
       },
@@ -3792,9 +3792,9 @@
     {
       "time": 20640,
       "values": {
-        "t_tank_top": 22.2689,
-        "t_tank_bottom": 21.1876,
-        "t_collector": 24.283,
+        "t_tank_top": 21.8209,
+        "t_tank_bottom": 20.7306,
+        "t_collector": 23.8482,
         "t_greenhouse": 17.2545,
         "t_outdoor": 14.7275
       },
@@ -3803,9 +3803,9 @@
     {
       "time": 20700,
       "values": {
-        "t_tank_top": 22.3058,
-        "t_tank_bottom": 21.2255,
-        "t_collector": 24.3178,
+        "t_tank_top": 21.8551,
+        "t_tank_bottom": 20.7658,
+        "t_collector": 23.8805,
         "t_greenhouse": 17.2649,
         "t_outdoor": 14.7345
       },
@@ -3814,9 +3814,9 @@
     {
       "time": 20760,
       "values": {
-        "t_tank_top": 22.3426,
-        "t_tank_bottom": 21.2634,
-        "t_collector": 24.3526,
+        "t_tank_top": 21.8892,
+        "t_tank_bottom": 20.801,
+        "t_collector": 23.9126,
         "t_greenhouse": 17.2751,
         "t_outdoor": 14.7415
       },
@@ -3825,9 +3825,9 @@
     {
       "time": 20820,
       "values": {
-        "t_tank_top": 22.3794,
-        "t_tank_bottom": 21.3013,
-        "t_collector": 24.3873,
+        "t_tank_top": 21.9233,
+        "t_tank_bottom": 20.8361,
+        "t_collector": 23.9446,
         "t_greenhouse": 17.2851,
         "t_outdoor": 14.7484
       },
@@ -3836,9 +3836,9 @@
     {
       "time": 20880,
       "values": {
-        "t_tank_top": 22.4161,
-        "t_tank_bottom": 21.3391,
-        "t_collector": 24.4218,
+        "t_tank_top": 21.9573,
+        "t_tank_bottom": 20.8711,
+        "t_collector": 23.9766,
         "t_greenhouse": 17.2951,
         "t_outdoor": 14.7552
       },
@@ -3847,9 +3847,9 @@
     {
       "time": 20940,
       "values": {
-        "t_tank_top": 22.4528,
-        "t_tank_bottom": 21.3769,
-        "t_collector": 24.4563,
+        "t_tank_top": 21.9912,
+        "t_tank_bottom": 20.9061,
+        "t_collector": 24.0084,
         "t_greenhouse": 17.3049,
         "t_outdoor": 14.7619
       },
@@ -3858,9 +3858,9 @@
     {
       "time": 21000,
       "values": {
-        "t_tank_top": 22.4894,
-        "t_tank_bottom": 21.4146,
-        "t_collector": 24.4907,
+        "t_tank_top": 22.0251,
+        "t_tank_bottom": 20.941,
+        "t_collector": 24.0401,
         "t_greenhouse": 17.3146,
         "t_outdoor": 14.7685
       },
@@ -3869,9 +3869,9 @@
     {
       "time": 21060,
       "values": {
-        "t_tank_top": 22.5259,
-        "t_tank_bottom": 21.4523,
-        "t_collector": 24.525,
+        "t_tank_top": 22.0589,
+        "t_tank_bottom": 20.9759,
+        "t_collector": 24.0717,
         "t_greenhouse": 17.3242,
         "t_outdoor": 14.775
       },
@@ -3880,9 +3880,9 @@
     {
       "time": 21120,
       "values": {
-        "t_tank_top": 22.5624,
-        "t_tank_bottom": 21.4899,
-        "t_collector": 24.5593,
+        "t_tank_top": 22.0926,
+        "t_tank_bottom": 21.0107,
+        "t_collector": 24.1032,
         "t_greenhouse": 17.3337,
         "t_outdoor": 14.7814
       },
@@ -3891,9 +3891,9 @@
     {
       "time": 21180,
       "values": {
-        "t_tank_top": 22.5988,
-        "t_tank_bottom": 21.5275,
-        "t_collector": 24.5934,
+        "t_tank_top": 22.1262,
+        "t_tank_bottom": 21.0455,
+        "t_collector": 24.1346,
         "t_greenhouse": 17.343,
         "t_outdoor": 14.7878
       },
@@ -3902,9 +3902,9 @@
     {
       "time": 21240,
       "values": {
-        "t_tank_top": 22.6352,
-        "t_tank_bottom": 21.5651,
-        "t_collector": 24.6274,
+        "t_tank_top": 22.1597,
+        "t_tank_bottom": 21.0802,
+        "t_collector": 24.166,
         "t_greenhouse": 17.3522,
         "t_outdoor": 14.794
       },
@@ -3913,9 +3913,9 @@
     {
       "time": 21300,
       "values": {
-        "t_tank_top": 22.6714,
-        "t_tank_bottom": 21.6026,
-        "t_collector": 24.6613,
+        "t_tank_top": 22.1932,
+        "t_tank_bottom": 21.1148,
+        "t_collector": 24.1972,
         "t_greenhouse": 17.3613,
         "t_outdoor": 14.8001
       },
@@ -3924,9 +3924,9 @@
     {
       "time": 21360,
       "values": {
-        "t_tank_top": 22.7077,
-        "t_tank_bottom": 21.64,
-        "t_collector": 24.6952,
+        "t_tank_top": 22.2266,
+        "t_tank_bottom": 21.1494,
+        "t_collector": 24.2282,
         "t_greenhouse": 17.3702,
         "t_outdoor": 14.8062
       },
@@ -3935,9 +3935,9 @@
     {
       "time": 21420,
       "values": {
-        "t_tank_top": 22.7438,
-        "t_tank_bottom": 21.6774,
-        "t_collector": 24.7289,
+        "t_tank_top": 22.2599,
+        "t_tank_bottom": 21.1839,
+        "t_collector": 24.2592,
         "t_greenhouse": 17.3791,
         "t_outdoor": 14.8122
       },
@@ -3946,9 +3946,9 @@
     {
       "time": 21480,
       "values": {
-        "t_tank_top": 22.7799,
-        "t_tank_bottom": 21.7148,
-        "t_collector": 24.7625,
+        "t_tank_top": 22.2932,
+        "t_tank_bottom": 21.2184,
+        "t_collector": 24.2901,
         "t_greenhouse": 17.3878,
         "t_outdoor": 14.8181
       },
@@ -3957,9 +3957,9 @@
     {
       "time": 21540,
       "values": {
-        "t_tank_top": 22.8159,
-        "t_tank_bottom": 21.7521,
-        "t_collector": 24.7961,
+        "t_tank_top": 22.3264,
+        "t_tank_bottom": 21.2528,
+        "t_collector": 24.3209,
         "t_greenhouse": 17.3963,
         "t_outdoor": 14.8238
       },
@@ -3968,9 +3968,9 @@
     {
       "time": 21600,
       "values": {
-        "t_tank_top": 22.8519,
-        "t_tank_bottom": 21.7893,
-        "t_collector": 24.8295,
+        "t_tank_top": 22.3594,
+        "t_tank_bottom": 21.2871,
+        "t_collector": 24.3515,
         "t_greenhouse": 17.4048,
         "t_outdoor": 14.8295
       },
@@ -3979,9 +3979,9 @@
     {
       "time": 21660,
       "values": {
-        "t_tank_top": 22.8877,
-        "t_tank_bottom": 21.8265,
-        "t_collector": 24.8629,
+        "t_tank_top": 22.3925,
+        "t_tank_bottom": 21.3214,
+        "t_collector": 24.3821,
         "t_greenhouse": 17.4131,
         "t_outdoor": 14.8351
       },
@@ -3990,9 +3990,9 @@
     {
       "time": 21720,
       "values": {
-        "t_tank_top": 22.9235,
-        "t_tank_bottom": 21.8637,
-        "t_collector": 24.8961,
+        "t_tank_top": 22.4254,
+        "t_tank_bottom": 21.3556,
+        "t_collector": 24.4125,
         "t_greenhouse": 17.4213,
         "t_outdoor": 14.8406
       },
@@ -4001,9 +4001,9 @@
     {
       "time": 21780,
       "values": {
-        "t_tank_top": 22.9593,
-        "t_tank_bottom": 21.9007,
-        "t_collector": 24.9292,
+        "t_tank_top": 22.4582,
+        "t_tank_bottom": 21.3898,
+        "t_collector": 24.4428,
         "t_greenhouse": 17.4294,
         "t_outdoor": 14.8461
       },
@@ -4012,9 +4012,9 @@
     {
       "time": 21840,
       "values": {
-        "t_tank_top": 22.995,
-        "t_tank_bottom": 21.9378,
-        "t_collector": 24.9623,
+        "t_tank_top": 22.491,
+        "t_tank_bottom": 21.4238,
+        "t_collector": 24.4731,
         "t_greenhouse": 17.4374,
         "t_outdoor": 14.8514
       },
@@ -4023,9 +4023,9 @@
     {
       "time": 21900,
       "values": {
-        "t_tank_top": 23.0306,
-        "t_tank_bottom": 21.9748,
-        "t_collector": 24.9952,
+        "t_tank_top": 22.5237,
+        "t_tank_bottom": 21.4579,
+        "t_collector": 24.5032,
         "t_greenhouse": 17.4452,
         "t_outdoor": 14.8566
       },
@@ -4034,9 +4034,9 @@
     {
       "time": 21960,
       "values": {
-        "t_tank_top": 23.0661,
-        "t_tank_bottom": 22.0117,
-        "t_collector": 25.0281,
+        "t_tank_top": 22.5563,
+        "t_tank_bottom": 21.4918,
+        "t_collector": 24.5332,
         "t_greenhouse": 17.4529,
         "t_outdoor": 14.8618
       },
@@ -4045,9 +4045,9 @@
     {
       "time": 22020,
       "values": {
-        "t_tank_top": 23.1015,
-        "t_tank_bottom": 22.0486,
-        "t_collector": 25.0608,
+        "t_tank_top": 22.5888,
+        "t_tank_bottom": 21.5257,
+        "t_collector": 24.563,
         "t_greenhouse": 17.4604,
         "t_outdoor": 14.8668
       },
@@ -4056,9 +4056,9 @@
     {
       "time": 22080,
       "values": {
-        "t_tank_top": 23.1369,
-        "t_tank_bottom": 22.0854,
-        "t_collector": 25.0934,
+        "t_tank_top": 22.6213,
+        "t_tank_bottom": 21.5595,
+        "t_collector": 24.5928,
         "t_greenhouse": 17.4679,
         "t_outdoor": 14.8718
       },
@@ -4067,9 +4067,9 @@
     {
       "time": 22140,
       "values": {
-        "t_tank_top": 23.1722,
-        "t_tank_bottom": 22.1222,
-        "t_collector": 25.126,
+        "t_tank_top": 22.6536,
+        "t_tank_bottom": 21.5933,
+        "t_collector": 24.6224,
         "t_greenhouse": 17.4752,
         "t_outdoor": 14.8766
       },
@@ -4078,9 +4078,9 @@
     {
       "time": 22200,
       "values": {
-        "t_tank_top": 23.2075,
-        "t_tank_bottom": 22.1589,
-        "t_collector": 25.1584,
+        "t_tank_top": 22.6859,
+        "t_tank_bottom": 21.6269,
+        "t_collector": 24.652,
         "t_greenhouse": 17.4824,
         "t_outdoor": 14.8814
       },
@@ -4089,9 +4089,9 @@
     {
       "time": 22260,
       "values": {
-        "t_tank_top": 23.2426,
-        "t_tank_bottom": 22.1955,
-        "t_collector": 25.1907,
+        "t_tank_top": 22.7181,
+        "t_tank_bottom": 21.6606,
+        "t_collector": 24.6814,
         "t_greenhouse": 17.4895,
         "t_outdoor": 14.8861
       },
@@ -4100,9 +4100,9 @@
     {
       "time": 22320,
       "values": {
-        "t_tank_top": 23.2777,
-        "t_tank_bottom": 22.2321,
-        "t_collector": 25.2229,
+        "t_tank_top": 22.7502,
+        "t_tank_bottom": 21.6941,
+        "t_collector": 24.7107,
         "t_greenhouse": 17.4964,
         "t_outdoor": 14.8907
       },
@@ -4111,9 +4111,9 @@
     {
       "time": 22380,
       "values": {
-        "t_tank_top": 23.3127,
-        "t_tank_bottom": 22.2686,
-        "t_collector": 25.255,
+        "t_tank_top": 22.7822,
+        "t_tank_bottom": 21.7276,
+        "t_collector": 24.7399,
         "t_greenhouse": 17.5032,
         "t_outdoor": 14.8952
       },
@@ -4122,9 +4122,9 @@
     {
       "time": 22440,
       "values": {
-        "t_tank_top": 23.3476,
-        "t_tank_bottom": 22.3051,
-        "t_collector": 25.287,
+        "t_tank_top": 22.8141,
+        "t_tank_bottom": 21.761,
+        "t_collector": 24.769,
         "t_greenhouse": 17.5099,
         "t_outdoor": 14.8996
       },
@@ -4133,9 +4133,9 @@
     {
       "time": 22500,
       "values": {
-        "t_tank_top": 23.3825,
-        "t_tank_bottom": 22.3415,
-        "t_collector": 25.3189,
+        "t_tank_top": 22.8459,
+        "t_tank_bottom": 21.7943,
+        "t_collector": 24.7979,
         "t_greenhouse": 17.5164,
         "t_outdoor": 14.9039
       },
@@ -4144,9 +4144,9 @@
     {
       "time": 22560,
       "values": {
-        "t_tank_top": 23.4173,
-        "t_tank_bottom": 22.3779,
-        "t_collector": 25.3507,
+        "t_tank_top": 22.8777,
+        "t_tank_bottom": 21.8276,
+        "t_collector": 24.8268,
         "t_greenhouse": 17.5229,
         "t_outdoor": 14.9081
       },
@@ -4155,9 +4155,9 @@
     {
       "time": 22620,
       "values": {
-        "t_tank_top": 23.452,
-        "t_tank_bottom": 22.4141,
-        "t_collector": 25.3824,
+        "t_tank_top": 22.9093,
+        "t_tank_bottom": 21.8608,
+        "t_collector": 24.8555,
         "t_greenhouse": 17.5291,
         "t_outdoor": 14.9122
       },
@@ -4166,9 +4166,9 @@
     {
       "time": 22680,
       "values": {
-        "t_tank_top": 23.4866,
-        "t_tank_bottom": 22.4504,
-        "t_collector": 25.414,
+        "t_tank_top": 22.9409,
+        "t_tank_bottom": 21.8939,
+        "t_collector": 24.8841,
         "t_greenhouse": 17.5353,
         "t_outdoor": 14.9162
       },
@@ -4177,9 +4177,9 @@
     {
       "time": 22740,
       "values": {
-        "t_tank_top": 23.5211,
-        "t_tank_bottom": 22.4865,
-        "t_collector": 25.4454,
+        "t_tank_top": 22.9724,
+        "t_tank_bottom": 21.9269,
+        "t_collector": 24.9126,
         "t_greenhouse": 17.5414,
         "t_outdoor": 14.9201
       },
@@ -4188,9 +4188,9 @@
     {
       "time": 22800,
       "values": {
-        "t_tank_top": 23.5556,
-        "t_tank_bottom": 22.5226,
-        "t_collector": 25.4768,
+        "t_tank_top": 23.0037,
+        "t_tank_bottom": 21.9599,
+        "t_collector": 24.9409,
         "t_greenhouse": 17.5473,
         "t_outdoor": 14.924
       },
@@ -4199,9 +4199,9 @@
     {
       "time": 22860,
       "values": {
-        "t_tank_top": 23.59,
-        "t_tank_bottom": 22.5587,
-        "t_collector": 25.508,
+        "t_tank_top": 23.035,
+        "t_tank_bottom": 21.9928,
+        "t_collector": 24.9692,
         "t_greenhouse": 17.553,
         "t_outdoor": 14.9277
       },
@@ -4210,9 +4210,9 @@
     {
       "time": 22920,
       "values": {
-        "t_tank_top": 23.6243,
-        "t_tank_bottom": 22.5946,
-        "t_collector": 25.5392,
+        "t_tank_top": 23.0662,
+        "t_tank_bottom": 22.0256,
+        "t_collector": 24.9973,
         "t_greenhouse": 17.5587,
         "t_outdoor": 14.9314
       },
@@ -4221,9 +4221,9 @@
     {
       "time": 22980,
       "values": {
-        "t_tank_top": 23.6585,
-        "t_tank_bottom": 22.6305,
-        "t_collector": 25.5702,
+        "t_tank_top": 23.0974,
+        "t_tank_bottom": 22.0583,
+        "t_collector": 25.0253,
         "t_greenhouse": 17.5642,
         "t_outdoor": 14.9349
       },
@@ -4232,9 +4232,9 @@
     {
       "time": 23040,
       "values": {
-        "t_tank_top": 23.6926,
-        "t_tank_bottom": 22.6664,
-        "t_collector": 25.6011,
+        "t_tank_top": 23.1284,
+        "t_tank_bottom": 22.091,
+        "t_collector": 25.0531,
         "t_greenhouse": 17.5696,
         "t_outdoor": 14.9384
       },
@@ -4243,9 +4243,9 @@
     {
       "time": 23100,
       "values": {
-        "t_tank_top": 23.7267,
-        "t_tank_bottom": 22.7022,
-        "t_collector": 25.6319,
+        "t_tank_top": 23.1593,
+        "t_tank_bottom": 22.1236,
+        "t_collector": 25.0809,
         "t_greenhouse": 17.5749,
         "t_outdoor": 14.9418
       },
@@ -4254,9 +4254,9 @@
     {
       "time": 23160,
       "values": {
-        "t_tank_top": 23.7607,
-        "t_tank_bottom": 22.7379,
-        "t_collector": 25.6626,
+        "t_tank_top": 23.1901,
+        "t_tank_bottom": 22.1561,
+        "t_collector": 25.1085,
         "t_greenhouse": 17.58,
         "t_outdoor": 14.945
       },
@@ -4265,9 +4265,9 @@
     {
       "time": 23220,
       "values": {
-        "t_tank_top": 23.7945,
-        "t_tank_bottom": 22.7735,
-        "t_collector": 25.6932,
+        "t_tank_top": 23.2209,
+        "t_tank_bottom": 22.1885,
+        "t_collector": 25.136,
         "t_greenhouse": 17.585,
         "t_outdoor": 14.9482
       },
@@ -4276,9 +4276,9 @@
     {
       "time": 23280,
       "values": {
-        "t_tank_top": 23.8283,
-        "t_tank_bottom": 22.8091,
-        "t_collector": 25.7236,
+        "t_tank_top": 23.2515,
+        "t_tank_bottom": 22.2209,
+        "t_collector": 25.1634,
         "t_greenhouse": 17.5899,
         "t_outdoor": 14.9513
       },
@@ -4287,9 +4287,9 @@
     {
       "time": 23340,
       "values": {
-        "t_tank_top": 23.8621,
-        "t_tank_bottom": 22.8446,
-        "t_collector": 25.754,
+        "t_tank_top": 23.282,
+        "t_tank_bottom": 22.2531,
+        "t_collector": 25.1907,
         "t_greenhouse": 17.5946,
         "t_outdoor": 14.9543
       },
@@ -4298,9 +4298,9 @@
     {
       "time": 23400,
       "values": {
-        "t_tank_top": 23.8957,
-        "t_tank_bottom": 22.88,
-        "t_collector": 25.7842,
+        "t_tank_top": 23.3125,
+        "t_tank_bottom": 22.2853,
+        "t_collector": 25.2178,
         "t_greenhouse": 17.5993,
         "t_outdoor": 14.9572
       },
@@ -4309,9 +4309,9 @@
     {
       "time": 23460,
       "values": {
-        "t_tank_top": 23.9292,
-        "t_tank_bottom": 22.9154,
-        "t_collector": 25.8143,
+        "t_tank_top": 23.3428,
+        "t_tank_bottom": 22.3174,
+        "t_collector": 25.2448,
         "t_greenhouse": 17.6037,
         "t_outdoor": 14.96
       },
@@ -4320,9 +4320,9 @@
     {
       "time": 23520,
       "values": {
-        "t_tank_top": 23.9627,
-        "t_tank_bottom": 22.9507,
-        "t_collector": 25.8443,
+        "t_tank_top": 23.3731,
+        "t_tank_bottom": 22.3495,
+        "t_collector": 25.2717,
         "t_greenhouse": 17.6081,
         "t_outdoor": 14.9627
       },
@@ -4331,9 +4331,9 @@
     {
       "time": 23580,
       "values": {
-        "t_tank_top": 23.9961,
-        "t_tank_bottom": 22.9859,
-        "t_collector": 25.8742,
+        "t_tank_top": 23.4032,
+        "t_tank_bottom": 22.3814,
+        "t_collector": 25.2984,
         "t_greenhouse": 17.6123,
         "t_outdoor": 14.9653
       },
@@ -4342,9 +4342,9 @@
     {
       "time": 23640,
       "values": {
-        "t_tank_top": 24.0293,
-        "t_tank_bottom": 23.021,
-        "t_collector": 25.904,
+        "t_tank_top": 23.4333,
+        "t_tank_bottom": 22.4133,
+        "t_collector": 25.325,
         "t_greenhouse": 17.6164,
         "t_outdoor": 14.9678
       },
@@ -4353,9 +4353,9 @@
     {
       "time": 23700,
       "values": {
-        "t_tank_top": 24.0625,
-        "t_tank_bottom": 23.0561,
-        "t_collector": 25.9336,
+        "t_tank_top": 23.4633,
+        "t_tank_bottom": 22.4451,
+        "t_collector": 25.3515,
         "t_greenhouse": 17.6204,
         "t_outdoor": 14.9702
       },
@@ -4364,9 +4364,9 @@
     {
       "time": 23760,
       "values": {
-        "t_tank_top": 24.0956,
-        "t_tank_bottom": 23.0911,
-        "t_collector": 25.9632,
+        "t_tank_top": 23.4931,
+        "t_tank_bottom": 22.4768,
+        "t_collector": 25.3779,
         "t_greenhouse": 17.6242,
         "t_outdoor": 14.9726
       },
@@ -4375,9 +4375,9 @@
     {
       "time": 23820,
       "values": {
-        "t_tank_top": 24.1287,
-        "t_tank_bottom": 23.1261,
-        "t_collector": 25.9926,
+        "t_tank_top": 23.5229,
+        "t_tank_bottom": 22.5084,
+        "t_collector": 25.4041,
         "t_greenhouse": 17.6279,
         "t_outdoor": 14.9748
       },
@@ -4386,9 +4386,9 @@
     {
       "time": 23880,
       "values": {
-        "t_tank_top": 24.1616,
-        "t_tank_bottom": 23.1609,
-        "t_collector": 26.0219,
+        "t_tank_top": 23.5525,
+        "t_tank_bottom": 22.5399,
+        "t_collector": 25.4303,
         "t_greenhouse": 17.6315,
         "t_outdoor": 14.9769
       },
@@ -4397,9 +4397,9 @@
     {
       "time": 23940,
       "values": {
-        "t_tank_top": 24.1944,
-        "t_tank_bottom": 23.1957,
-        "t_collector": 26.051,
+        "t_tank_top": 23.5821,
+        "t_tank_bottom": 22.5713,
+        "t_collector": 25.4562,
         "t_greenhouse": 17.635,
         "t_outdoor": 14.979
       },
@@ -4408,9 +4408,9 @@
     {
       "time": 24000,
       "values": {
-        "t_tank_top": 24.2272,
-        "t_tank_bottom": 23.2304,
-        "t_collector": 26.0801,
+        "t_tank_top": 23.6115,
+        "t_tank_bottom": 22.6027,
+        "t_collector": 25.4821,
         "t_greenhouse": 17.6383,
         "t_outdoor": 14.9809
       },
@@ -4419,9 +4419,9 @@
     {
       "time": 24060,
       "values": {
-        "t_tank_top": 24.2598,
-        "t_tank_bottom": 23.2651,
-        "t_collector": 26.109,
+        "t_tank_top": 23.6409,
+        "t_tank_bottom": 22.634,
+        "t_collector": 25.5078,
         "t_greenhouse": 17.6415,
         "t_outdoor": 14.9828
       },
@@ -4430,9 +4430,9 @@
     {
       "time": 24120,
       "values": {
-        "t_tank_top": 24.2924,
-        "t_tank_bottom": 23.2996,
-        "t_collector": 26.1379,
+        "t_tank_top": 23.6701,
+        "t_tank_bottom": 22.6652,
+        "t_collector": 25.5334,
         "t_greenhouse": 17.6445,
         "t_outdoor": 14.9846
       },
@@ -4441,9 +4441,9 @@
     {
       "time": 24180,
       "values": {
-        "t_tank_top": 24.3248,
-        "t_tank_bottom": 23.3341,
-        "t_collector": 26.1665,
+        "t_tank_top": 23.6993,
+        "t_tank_bottom": 22.6962,
+        "t_collector": 25.5588,
         "t_greenhouse": 17.6474,
         "t_outdoor": 14.9862
       },
@@ -4452,9 +4452,9 @@
     {
       "time": 24240,
       "values": {
-        "t_tank_top": 24.3572,
-        "t_tank_bottom": 23.3685,
-        "t_collector": 26.1951,
+        "t_tank_top": 23.7283,
+        "t_tank_bottom": 22.7273,
+        "t_collector": 25.5842,
         "t_greenhouse": 17.6502,
         "t_outdoor": 14.9878
       },
@@ -4463,9 +4463,9 @@
     {
       "time": 24300,
       "values": {
-        "t_tank_top": 24.3895,
-        "t_tank_bottom": 23.4028,
-        "t_collector": 26.2236,
+        "t_tank_top": 23.7572,
+        "t_tank_bottom": 22.7582,
+        "t_collector": 25.6094,
         "t_greenhouse": 17.6529,
         "t_outdoor": 14.9893
       },
@@ -4474,9 +4474,9 @@
     {
       "time": 24360,
       "values": {
-        "t_tank_top": 24.4217,
-        "t_tank_bottom": 23.4371,
-        "t_collector": 26.2519,
+        "t_tank_top": 23.7861,
+        "t_tank_bottom": 22.789,
+        "t_collector": 25.6344,
         "t_greenhouse": 17.6554,
         "t_outdoor": 14.9907
       },
@@ -4485,9 +4485,9 @@
     {
       "time": 24420,
       "values": {
-        "t_tank_top": 24.4538,
-        "t_tank_bottom": 23.4712,
-        "t_collector": 26.2801,
+        "t_tank_top": 23.8148,
+        "t_tank_bottom": 22.8197,
+        "t_collector": 25.6593,
         "t_greenhouse": 17.6578,
         "t_outdoor": 14.9919
       },
@@ -4496,9 +4496,9 @@
     {
       "time": 24480,
       "values": {
-        "t_tank_top": 24.4858,
-        "t_tank_bottom": 23.5053,
-        "t_collector": 26.3082,
+        "t_tank_top": 23.8434,
+        "t_tank_bottom": 22.8504,
+        "t_collector": 25.6841,
         "t_greenhouse": 17.6601,
         "t_outdoor": 14.9931
       },
@@ -4507,9 +4507,9 @@
     {
       "time": 24540,
       "values": {
-        "t_tank_top": 24.5177,
-        "t_tank_bottom": 23.5393,
-        "t_collector": 26.3361,
+        "t_tank_top": 23.8719,
+        "t_tank_bottom": 22.8809,
+        "t_collector": 25.7088,
         "t_greenhouse": 17.6622,
         "t_outdoor": 14.9942
       },
@@ -4518,9 +4518,9 @@
     {
       "time": 24600,
       "values": {
-        "t_tank_top": 24.5495,
-        "t_tank_bottom": 23.5732,
-        "t_collector": 26.364,
+        "t_tank_top": 23.9003,
+        "t_tank_bottom": 22.9114,
+        "t_collector": 25.7333,
         "t_greenhouse": 17.6642,
         "t_outdoor": 14.9952
       },
@@ -4529,9 +4529,9 @@
     {
       "time": 24660,
       "values": {
-        "t_tank_top": 24.5812,
-        "t_tank_bottom": 23.6071,
-        "t_collector": 26.3917,
+        "t_tank_top": 23.9286,
+        "t_tank_bottom": 22.9418,
+        "t_collector": 25.7577,
         "t_greenhouse": 17.6661,
         "t_outdoor": 14.9961
       },
@@ -4540,9 +4540,9 @@
     {
       "time": 24720,
       "values": {
-        "t_tank_top": 24.6128,
-        "t_tank_bottom": 23.6409,
-        "t_collector": 26.4192,
+        "t_tank_top": 23.9568,
+        "t_tank_bottom": 22.9721,
+        "t_collector": 25.7819,
         "t_greenhouse": 17.6678,
         "t_outdoor": 14.9969
       },
@@ -4551,9 +4551,9 @@
     {
       "time": 24780,
       "values": {
-        "t_tank_top": 24.6443,
-        "t_tank_bottom": 23.6745,
-        "t_collector": 26.4467,
+        "t_tank_top": 23.9849,
+        "t_tank_bottom": 23.0022,
+        "t_collector": 25.806,
         "t_greenhouse": 17.6694,
         "t_outdoor": 14.9977
       },
@@ -4562,9 +4562,9 @@
     {
       "time": 24840,
       "values": {
-        "t_tank_top": 24.6757,
-        "t_tank_bottom": 23.7081,
-        "t_collector": 26.474,
+        "t_tank_top": 24.0128,
+        "t_tank_bottom": 23.0323,
+        "t_collector": 25.83,
         "t_greenhouse": 17.6709,
         "t_outdoor": 14.9983
       },
@@ -4573,9 +4573,9 @@
     {
       "time": 24900,
       "values": {
-        "t_tank_top": 24.707,
-        "t_tank_bottom": 23.7416,
-        "t_collector": 26.5012,
+        "t_tank_top": 24.0407,
+        "t_tank_bottom": 23.0623,
+        "t_collector": 25.8538,
         "t_greenhouse": 17.6723,
         "t_outdoor": 14.9988
       },
@@ -4584,9 +4584,9 @@
     {
       "time": 24960,
       "values": {
-        "t_tank_top": 24.7382,
-        "t_tank_bottom": 23.7751,
-        "t_collector": 26.5283,
+        "t_tank_top": 24.0685,
+        "t_tank_bottom": 23.0922,
+        "t_collector": 25.8775,
         "t_greenhouse": 17.6735,
         "t_outdoor": 14.9992
       },
@@ -4595,9 +4595,9 @@
     {
       "time": 25020,
       "values": {
-        "t_tank_top": 24.7693,
-        "t_tank_bottom": 23.8084,
-        "t_collector": 26.5552,
+        "t_tank_top": 24.0961,
+        "t_tank_bottom": 23.122,
+        "t_collector": 25.9011,
         "t_greenhouse": 17.6746,
         "t_outdoor": 14.9996
       },
@@ -4606,9 +4606,9 @@
     {
       "time": 25080,
       "values": {
-        "t_tank_top": 24.8003,
-        "t_tank_bottom": 23.8417,
-        "t_collector": 26.5821,
+        "t_tank_top": 24.1236,
+        "t_tank_bottom": 23.1518,
+        "t_collector": 25.9245,
         "t_greenhouse": 17.6755,
         "t_outdoor": 14.9998
       },
@@ -4617,9 +4617,9 @@
     {
       "time": 25140,
       "values": {
-        "t_tank_top": 24.8312,
-        "t_tank_bottom": 23.8748,
-        "t_collector": 26.6087,
+        "t_tank_top": 24.151,
+        "t_tank_bottom": 23.1814,
+        "t_collector": 25.9478,
         "t_greenhouse": 17.6763,
         "t_outdoor": 15
       },
@@ -4628,9 +4628,9 @@
     {
       "time": 25200,
       "values": {
-        "t_tank_top": 24.862,
-        "t_tank_bottom": 23.9079,
-        "t_collector": 26.6353,
+        "t_tank_top": 24.1783,
+        "t_tank_bottom": 23.2109,
+        "t_collector": 25.9709,
         "t_greenhouse": 17.677,
         "t_outdoor": 15
       },
@@ -4639,9 +4639,9 @@
     {
       "time": 25260,
       "values": {
-        "t_tank_top": 24.8927,
-        "t_tank_bottom": 23.9409,
-        "t_collector": 26.6617,
+        "t_tank_top": 24.2055,
+        "t_tank_bottom": 23.2403,
+        "t_collector": 25.9939,
         "t_greenhouse": 17.6776,
         "t_outdoor": 15
       },
@@ -4650,9 +4650,9 @@
     {
       "time": 25320,
       "values": {
-        "t_tank_top": 24.9233,
-        "t_tank_bottom": 23.9738,
-        "t_collector": 26.688,
+        "t_tank_top": 24.2326,
+        "t_tank_bottom": 23.2696,
+        "t_collector": 26.0168,
         "t_greenhouse": 17.678,
         "t_outdoor": 14.9998
       },
@@ -4661,9 +4661,9 @@
     {
       "time": 25380,
       "values": {
-        "t_tank_top": 24.9538,
-        "t_tank_bottom": 24.0067,
-        "t_collector": 26.7142,
+        "t_tank_top": 24.2595,
+        "t_tank_bottom": 23.2989,
+        "t_collector": 26.0395,
         "t_greenhouse": 17.6783,
         "t_outdoor": 14.9996
       },
@@ -4672,9 +4672,9 @@
     {
       "time": 25440,
       "values": {
-        "t_tank_top": 24.9842,
-        "t_tank_bottom": 24.0394,
-        "t_collector": 26.7402,
+        "t_tank_top": 24.2864,
+        "t_tank_bottom": 23.328,
+        "t_collector": 26.0621,
         "t_greenhouse": 17.6785,
         "t_outdoor": 14.9992
       },
@@ -4683,9 +4683,9 @@
     {
       "time": 25500,
       "values": {
-        "t_tank_top": 25.0145,
-        "t_tank_bottom": 24.072,
-        "t_collector": 26.7661,
+        "t_tank_top": 24.3131,
+        "t_tank_bottom": 23.357,
+        "t_collector": 26.0845,
         "t_greenhouse": 17.6785,
         "t_outdoor": 14.9988
       },
@@ -4694,9 +4694,9 @@
     {
       "time": 25560,
       "values": {
-        "t_tank_top": 25.0447,
-        "t_tank_bottom": 24.1046,
-        "t_collector": 26.7919,
+        "t_tank_top": 24.3397,
+        "t_tank_bottom": 23.3859,
+        "t_collector": 26.1068,
         "t_greenhouse": 17.6784,
         "t_outdoor": 14.9983
       },
@@ -4705,9 +4705,9 @@
     {
       "time": 25620,
       "values": {
-        "t_tank_top": 25.0747,
-        "t_tank_bottom": 24.1371,
-        "t_collector": 26.8175,
+        "t_tank_top": 24.3662,
+        "t_tank_bottom": 23.4147,
+        "t_collector": 26.129,
         "t_greenhouse": 17.6781,
         "t_outdoor": 14.9977
       },
@@ -4716,9 +4716,9 @@
     {
       "time": 25680,
       "values": {
-        "t_tank_top": 25.1047,
-        "t_tank_bottom": 24.1694,
-        "t_collector": 26.843,
+        "t_tank_top": 24.3926,
+        "t_tank_bottom": 23.4435,
+        "t_collector": 26.151,
         "t_greenhouse": 17.6778,
         "t_outdoor": 14.997
       },
@@ -4727,9 +4727,9 @@
     {
       "time": 25740,
       "values": {
-        "t_tank_top": 25.1346,
-        "t_tank_bottom": 24.2017,
-        "t_collector": 26.8684,
+        "t_tank_top": 24.4189,
+        "t_tank_bottom": 23.4721,
+        "t_collector": 26.1728,
         "t_greenhouse": 17.6773,
         "t_outdoor": 14.9962
       },
@@ -4738,9 +4738,9 @@
     {
       "time": 25800,
       "values": {
-        "t_tank_top": 25.1643,
-        "t_tank_bottom": 24.2339,
-        "t_collector": 26.8936,
+        "t_tank_top": 24.445,
+        "t_tank_bottom": 23.5006,
+        "t_collector": 26.1945,
         "t_greenhouse": 17.6766,
         "t_outdoor": 14.9953
       },
@@ -4749,9 +4749,9 @@
     {
       "time": 25860,
       "values": {
-        "t_tank_top": 25.194,
-        "t_tank_bottom": 24.266,
-        "t_collector": 26.9187,
+        "t_tank_top": 24.471,
+        "t_tank_bottom": 23.529,
+        "t_collector": 26.2161,
         "t_greenhouse": 17.6759,
         "t_outdoor": 14.9943
       },
@@ -4760,9 +4760,9 @@
     {
       "time": 25920,
       "values": {
-        "t_tank_top": 25.2235,
-        "t_tank_bottom": 24.298,
-        "t_collector": 26.9437,
+        "t_tank_top": 24.4969,
+        "t_tank_bottom": 23.5573,
+        "t_collector": 26.2375,
         "t_greenhouse": 17.675,
         "t_outdoor": 14.9932
       },
@@ -4771,9 +4771,9 @@
     {
       "time": 25980,
       "values": {
-        "t_tank_top": 25.2529,
-        "t_tank_bottom": 24.3299,
-        "t_collector": 26.9685,
+        "t_tank_top": 24.5227,
+        "t_tank_bottom": 23.5855,
+        "t_collector": 26.2588,
         "t_greenhouse": 17.674,
         "t_outdoor": 14.992
       },
@@ -4782,9 +4782,9 @@
     {
       "time": 26040,
       "values": {
-        "t_tank_top": 25.2823,
-        "t_tank_bottom": 24.3617,
-        "t_collector": 26.9932,
+        "t_tank_top": 24.5484,
+        "t_tank_bottom": 23.6136,
+        "t_collector": 26.28,
         "t_greenhouse": 17.6728,
         "t_outdoor": 14.9907
       },
@@ -4793,9 +4793,9 @@
     {
       "time": 26100,
       "values": {
-        "t_tank_top": 25.3115,
-        "t_tank_bottom": 24.3935,
-        "t_collector": 27.0178,
+        "t_tank_top": 24.574,
+        "t_tank_bottom": 23.6416,
+        "t_collector": 26.301,
         "t_greenhouse": 17.6715,
         "t_outdoor": 14.9893
       },
@@ -4804,9 +4804,9 @@
     {
       "time": 26160,
       "values": {
-        "t_tank_top": 25.3406,
-        "t_tank_bottom": 24.4251,
-        "t_collector": 27.0422,
+        "t_tank_top": 24.5994,
+        "t_tank_bottom": 23.6695,
+        "t_collector": 26.3218,
         "t_greenhouse": 17.6701,
         "t_outdoor": 14.9878
       },
@@ -4815,9 +4815,9 @@
     {
       "time": 26220,
       "values": {
-        "t_tank_top": 25.3696,
-        "t_tank_bottom": 24.4566,
-        "t_collector": 27.0665,
+        "t_tank_top": 24.6247,
+        "t_tank_bottom": 23.6973,
+        "t_collector": 26.3425,
         "t_greenhouse": 17.6685,
         "t_outdoor": 14.9863
       },
@@ -4826,9 +4826,9 @@
     {
       "time": 26280,
       "values": {
-        "t_tank_top": 25.3984,
-        "t_tank_bottom": 24.488,
-        "t_collector": 27.0907,
+        "t_tank_top": 24.6499,
+        "t_tank_bottom": 23.7249,
+        "t_collector": 26.363,
         "t_greenhouse": 17.6669,
         "t_outdoor": 14.9846
       },
@@ -4837,9 +4837,9 @@
     {
       "time": 26340,
       "values": {
-        "t_tank_top": 25.4272,
-        "t_tank_bottom": 24.5194,
-        "t_collector": 27.1147,
+        "t_tank_top": 24.6749,
+        "t_tank_bottom": 23.7525,
+        "t_collector": 26.3834,
         "t_greenhouse": 17.665,
         "t_outdoor": 14.9829
       },
@@ -4848,9 +4848,9 @@
     {
       "time": 26400,
       "values": {
-        "t_tank_top": 25.4559,
-        "t_tank_bottom": 24.5506,
-        "t_collector": 27.1385,
+        "t_tank_top": 24.6999,
+        "t_tank_bottom": 23.78,
+        "t_collector": 26.4037,
         "t_greenhouse": 17.6631,
         "t_outdoor": 14.981
       },
@@ -4859,9 +4859,9 @@
     {
       "time": 26460,
       "values": {
-        "t_tank_top": 25.4844,
-        "t_tank_bottom": 24.5818,
-        "t_collector": 27.1623,
+        "t_tank_top": 24.7247,
+        "t_tank_bottom": 23.8073,
+        "t_collector": 26.4238,
         "t_greenhouse": 17.661,
         "t_outdoor": 14.9791
       },
@@ -4870,9 +4870,9 @@
     {
       "time": 26520,
       "values": {
-        "t_tank_top": 25.5128,
-        "t_tank_bottom": 24.6128,
-        "t_collector": 27.1859,
+        "t_tank_top": 24.7494,
+        "t_tank_bottom": 23.8346,
+        "t_collector": 26.4437,
         "t_greenhouse": 17.6588,
         "t_outdoor": 14.977
       },
@@ -4881,9 +4881,9 @@
     {
       "time": 26580,
       "values": {
-        "t_tank_top": 25.5411,
-        "t_tank_bottom": 24.6438,
-        "t_collector": 27.2093,
+        "t_tank_top": 24.774,
+        "t_tank_bottom": 23.8617,
+        "t_collector": 26.4636,
         "t_greenhouse": 17.6564,
         "t_outdoor": 14.9749
       },
@@ -4892,9 +4892,9 @@
     {
       "time": 26640,
       "values": {
-        "t_tank_top": 25.5693,
-        "t_tank_bottom": 24.6746,
-        "t_collector": 27.2326,
+        "t_tank_top": 24.7984,
+        "t_tank_bottom": 23.8887,
+        "t_collector": 26.4832,
         "t_greenhouse": 17.654,
         "t_outdoor": 14.9726
       },
@@ -4903,9 +4903,9 @@
     {
       "time": 26700,
       "values": {
-        "t_tank_top": 25.5974,
-        "t_tank_bottom": 24.7053,
-        "t_collector": 27.2558,
+        "t_tank_top": 24.8227,
+        "t_tank_bottom": 23.9156,
+        "t_collector": 26.5027,
         "t_greenhouse": 17.6514,
         "t_outdoor": 14.9703
       },
@@ -4914,9 +4914,9 @@
     {
       "time": 26760,
       "values": {
-        "t_tank_top": 25.6254,
-        "t_tank_bottom": 24.736,
-        "t_collector": 27.2788,
+        "t_tank_top": 24.8469,
+        "t_tank_bottom": 23.9424,
+        "t_collector": 26.5221,
         "t_greenhouse": 17.6486,
         "t_outdoor": 14.9679
       },
@@ -4925,9 +4925,9 @@
     {
       "time": 26820,
       "values": {
-        "t_tank_top": 25.6533,
-        "t_tank_bottom": 24.7665,
-        "t_collector": 27.3017,
+        "t_tank_top": 24.871,
+        "t_tank_bottom": 23.9691,
+        "t_collector": 26.5413,
         "t_greenhouse": 17.6457,
         "t_outdoor": 14.9654
       },
@@ -4936,9 +4936,9 @@
     {
       "time": 26880,
       "values": {
-        "t_tank_top": 25.681,
-        "t_tank_bottom": 24.797,
-        "t_collector": 27.3245,
+        "t_tank_top": 24.895,
+        "t_tank_bottom": 23.9957,
+        "t_collector": 26.5603,
         "t_greenhouse": 17.6427,
         "t_outdoor": 14.9628
       },
@@ -4947,9 +4947,9 @@
     {
       "time": 26940,
       "values": {
-        "t_tank_top": 25.7086,
-        "t_tank_bottom": 24.8273,
-        "t_collector": 27.3471,
+        "t_tank_top": 24.9188,
+        "t_tank_bottom": 24.0222,
+        "t_collector": 26.5792,
         "t_greenhouse": 17.6396,
         "t_outdoor": 14.9601
       },
@@ -4958,9 +4958,9 @@
     {
       "time": 27000,
       "values": {
-        "t_tank_top": 25.7361,
-        "t_tank_bottom": 24.8575,
-        "t_collector": 27.3695,
+        "t_tank_top": 24.9425,
+        "t_tank_bottom": 24.0485,
+        "t_collector": 26.598,
         "t_greenhouse": 17.6363,
         "t_outdoor": 14.9573
       },
@@ -4969,9 +4969,9 @@
     {
       "time": 27060,
       "values": {
-        "t_tank_top": 25.7635,
-        "t_tank_bottom": 24.8877,
-        "t_collector": 27.3919,
+        "t_tank_top": 24.966,
+        "t_tank_bottom": 24.0748,
+        "t_collector": 26.6165,
         "t_greenhouse": 17.6329,
         "t_outdoor": 14.9544
       },
@@ -4980,9 +4980,9 @@
     {
       "time": 27120,
       "values": {
-        "t_tank_top": 25.7908,
-        "t_tank_bottom": 24.9177,
-        "t_collector": 27.414,
+        "t_tank_top": 24.9895,
+        "t_tank_bottom": 24.1009,
+        "t_collector": 26.635,
         "t_greenhouse": 17.6294,
         "t_outdoor": 14.9514
       },
@@ -4991,9 +4991,9 @@
     {
       "time": 27180,
       "values": {
-        "t_tank_top": 25.8179,
-        "t_tank_bottom": 24.9476,
-        "t_collector": 27.4361,
+        "t_tank_top": 25.0128,
+        "t_tank_bottom": 24.1269,
+        "t_collector": 26.6533,
         "t_greenhouse": 17.6257,
         "t_outdoor": 14.9483
       },
@@ -5002,9 +5002,9 @@
     {
       "time": 27240,
       "values": {
-        "t_tank_top": 25.845,
-        "t_tank_bottom": 24.9774,
-        "t_collector": 27.458,
+        "t_tank_top": 25.0359,
+        "t_tank_bottom": 24.1528,
+        "t_collector": 26.6714,
         "t_greenhouse": 17.622,
         "t_outdoor": 14.9451
       },
@@ -5013,9 +5013,9 @@
     {
       "time": 27300,
       "values": {
-        "t_tank_top": 25.8719,
-        "t_tank_bottom": 25.0072,
-        "t_collector": 27.4797,
+        "t_tank_top": 25.059,
+        "t_tank_bottom": 24.1786,
+        "t_collector": 26.6894,
         "t_greenhouse": 17.618,
         "t_outdoor": 14.9419
       },
@@ -5024,9 +5024,9 @@
     {
       "time": 27360,
       "values": {
-        "t_tank_top": 25.8987,
-        "t_tank_bottom": 25.0368,
-        "t_collector": 27.5013,
+        "t_tank_top": 25.0819,
+        "t_tank_bottom": 24.2042,
+        "t_collector": 26.7072,
         "t_greenhouse": 17.614,
         "t_outdoor": 14.9385
       },
@@ -5035,9 +5035,9 @@
     {
       "time": 27420,
       "values": {
-        "t_tank_top": 25.9253,
-        "t_tank_bottom": 25.0663,
-        "t_collector": 27.5228,
+        "t_tank_top": 25.1047,
+        "t_tank_bottom": 24.2298,
+        "t_collector": 26.7249,
         "t_greenhouse": 17.6098,
         "t_outdoor": 14.935
       },
@@ -5046,9 +5046,9 @@
     {
       "time": 27480,
       "values": {
-        "t_tank_top": 25.9519,
-        "t_tank_bottom": 25.0957,
-        "t_collector": 27.5441,
+        "t_tank_top": 25.1274,
+        "t_tank_bottom": 24.2552,
+        "t_collector": 26.7424,
         "t_greenhouse": 17.6055,
         "t_outdoor": 14.9315
       },
@@ -5057,9 +5057,9 @@
     {
       "time": 27540,
       "values": {
-        "t_tank_top": 25.9783,
-        "t_tank_bottom": 25.125,
-        "t_collector": 27.5653,
+        "t_tank_top": 25.1499,
+        "t_tank_bottom": 24.2805,
+        "t_collector": 26.7597,
         "t_greenhouse": 17.601,
         "t_outdoor": 14.9278
       },
@@ -5068,9 +5068,9 @@
     {
       "time": 27600,
       "values": {
-        "t_tank_top": 26.0046,
-        "t_tank_bottom": 25.1541,
-        "t_collector": 27.5863,
+        "t_tank_top": 25.1723,
+        "t_tank_bottom": 24.3057,
+        "t_collector": 26.7769,
         "t_greenhouse": 17.5964,
         "t_outdoor": 14.9241
       },
@@ -5079,9 +5079,9 @@
     {
       "time": 27660,
       "values": {
-        "t_tank_top": 26.0308,
-        "t_tank_bottom": 25.1832,
-        "t_collector": 27.6071,
+        "t_tank_top": 25.1945,
+        "t_tank_bottom": 24.3308,
+        "t_collector": 26.794,
         "t_greenhouse": 17.5917,
         "t_outdoor": 14.9203
       },
@@ -5090,9 +5090,9 @@
     {
       "time": 27720,
       "values": {
-        "t_tank_top": 26.0569,
-        "t_tank_bottom": 25.2122,
-        "t_collector": 27.6279,
+        "t_tank_top": 25.2167,
+        "t_tank_bottom": 24.3558,
+        "t_collector": 26.8109,
         "t_greenhouse": 17.5869,
         "t_outdoor": 14.9163
       },
@@ -5101,9 +5101,9 @@
     {
       "time": 27780,
       "values": {
-        "t_tank_top": 26.0828,
-        "t_tank_bottom": 25.241,
-        "t_collector": 27.6484,
+        "t_tank_top": 25.2387,
+        "t_tank_bottom": 24.3806,
+        "t_collector": 26.8276,
         "t_greenhouse": 17.5819,
         "t_outdoor": 14.9123
       },
@@ -5112,9 +5112,9 @@
     {
       "time": 27840,
       "values": {
-        "t_tank_top": 26.1086,
-        "t_tank_bottom": 25.2698,
-        "t_collector": 27.6689,
+        "t_tank_top": 25.2605,
+        "t_tank_bottom": 24.4053,
+        "t_collector": 26.8442,
         "t_greenhouse": 17.5768,
         "t_outdoor": 14.9082
       },
@@ -5123,9 +5123,9 @@
     {
       "time": 27900,
       "values": {
-        "t_tank_top": 26.1343,
-        "t_tank_bottom": 25.2984,
-        "t_collector": 27.6891,
+        "t_tank_top": 25.2823,
+        "t_tank_bottom": 24.4299,
+        "t_collector": 26.8606,
         "t_greenhouse": 17.5716,
         "t_outdoor": 14.904
       },
@@ -5134,9 +5134,9 @@
     {
       "time": 27960,
       "values": {
-        "t_tank_top": 26.1599,
-        "t_tank_bottom": 25.3269,
-        "t_collector": 27.7093,
+        "t_tank_top": 25.3039,
+        "t_tank_bottom": 24.4544,
+        "t_collector": 26.8768,
         "t_greenhouse": 17.5662,
         "t_outdoor": 14.8997
       },
@@ -5145,9 +5145,9 @@
     {
       "time": 28020,
       "values": {
-        "t_tank_top": 26.1853,
-        "t_tank_bottom": 25.3553,
-        "t_collector": 27.7293,
+        "t_tank_top": 25.3253,
+        "t_tank_bottom": 24.4787,
+        "t_collector": 26.8929,
         "t_greenhouse": 17.5607,
         "t_outdoor": 14.8953
       },
@@ -5156,9 +5156,9 @@
     {
       "time": 28080,
       "values": {
-        "t_tank_top": 26.2106,
-        "t_tank_bottom": 25.3836,
-        "t_collector": 27.7491,
+        "t_tank_top": 25.3466,
+        "t_tank_bottom": 24.503,
+        "t_collector": 26.9089,
         "t_greenhouse": 17.5551,
         "t_outdoor": 14.8908
       },
@@ -5167,9 +5167,9 @@
     {
       "time": 28140,
       "values": {
-        "t_tank_top": 26.2358,
-        "t_tank_bottom": 25.4118,
-        "t_collector": 27.7688,
+        "t_tank_top": 25.3678,
+        "t_tank_bottom": 24.5271,
+        "t_collector": 26.9246,
         "t_greenhouse": 17.5493,
         "t_outdoor": 14.8862
       },
@@ -5178,9 +5178,9 @@
     {
       "time": 28200,
       "values": {
-        "t_tank_top": 26.2609,
-        "t_tank_bottom": 25.4399,
-        "t_collector": 27.7883,
+        "t_tank_top": 25.3889,
+        "t_tank_bottom": 24.5511,
+        "t_collector": 26.9403,
         "t_greenhouse": 17.5434,
         "t_outdoor": 14.8816
       },
@@ -5189,9 +5189,9 @@
     {
       "time": 28260,
       "values": {
-        "t_tank_top": 26.2858,
-        "t_tank_bottom": 25.4679,
-        "t_collector": 27.8077,
+        "t_tank_top": 25.4098,
+        "t_tank_bottom": 24.575,
+        "t_collector": 26.9557,
         "t_greenhouse": 17.5374,
         "t_outdoor": 14.8768
       },
@@ -5200,9 +5200,9 @@
     {
       "time": 28320,
       "values": {
-        "t_tank_top": 26.3107,
-        "t_tank_bottom": 25.4957,
-        "t_collector": 27.8269,
+        "t_tank_top": 25.4306,
+        "t_tank_bottom": 24.5987,
+        "t_collector": 26.971,
         "t_greenhouse": 17.5312,
         "t_outdoor": 14.8719
       },
@@ -5211,9 +5211,9 @@
     {
       "time": 28380,
       "values": {
-        "t_tank_top": 26.3353,
-        "t_tank_bottom": 25.5234,
-        "t_collector": 27.846,
+        "t_tank_top": 25.4512,
+        "t_tank_bottom": 24.6223,
+        "t_collector": 26.9861,
         "t_greenhouse": 17.525,
         "t_outdoor": 14.867
       },
@@ -5222,9 +5222,9 @@
     {
       "time": 28440,
       "values": {
-        "t_tank_top": 26.3599,
-        "t_tank_bottom": 25.5511,
-        "t_collector": 27.8649,
+        "t_tank_top": 25.4717,
+        "t_tank_bottom": 24.6458,
+        "t_collector": 27.0011,
         "t_greenhouse": 17.5186,
         "t_outdoor": 14.8619
       },
@@ -5233,9 +5233,9 @@
     {
       "time": 28500,
       "values": {
-        "t_tank_top": 26.3843,
-        "t_tank_bottom": 25.5786,
-        "t_collector": 27.8837,
+        "t_tank_top": 25.4921,
+        "t_tank_bottom": 24.6692,
+        "t_collector": 27.0159,
         "t_greenhouse": 17.512,
         "t_outdoor": 14.8568
       },
@@ -5244,9 +5244,9 @@
     {
       "time": 28560,
       "values": {
-        "t_tank_top": 26.4086,
-        "t_tank_bottom": 25.606,
-        "t_collector": 27.9023,
+        "t_tank_top": 25.5123,
+        "t_tank_bottom": 24.6924,
+        "t_collector": 27.0306,
         "t_greenhouse": 17.5053,
         "t_outdoor": 14.8516
       },
@@ -5255,9 +5255,9 @@
     {
       "time": 28620,
       "values": {
-        "t_tank_top": 26.4328,
-        "t_tank_bottom": 25.6332,
-        "t_collector": 27.9208,
+        "t_tank_top": 25.5324,
+        "t_tank_bottom": 24.7156,
+        "t_collector": 27.0451,
         "t_greenhouse": 17.4985,
         "t_outdoor": 14.8462
       },
@@ -5266,9 +5266,9 @@
     {
       "time": 28680,
       "values": {
-        "t_tank_top": 26.4568,
-        "t_tank_bottom": 25.6604,
-        "t_collector": 27.9391,
+        "t_tank_top": 25.5524,
+        "t_tank_bottom": 24.7385,
+        "t_collector": 27.0594,
         "t_greenhouse": 17.4916,
         "t_outdoor": 14.8408
       },
@@ -5277,9 +5277,9 @@
     {
       "time": 28740,
       "values": {
-        "t_tank_top": 26.4807,
-        "t_tank_bottom": 25.6874,
-        "t_collector": 27.9573,
+        "t_tank_top": 25.5722,
+        "t_tank_bottom": 24.7614,
+        "t_collector": 27.0736,
         "t_greenhouse": 17.4846,
         "t_outdoor": 14.8353
       },
@@ -5288,9 +5288,9 @@
     {
       "time": 28800,
       "values": {
-        "t_tank_top": 26.5045,
-        "t_tank_bottom": 25.7143,
-        "t_collector": 27.9753,
+        "t_tank_top": 25.5918,
+        "t_tank_bottom": 24.7842,
+        "t_collector": 27.0876,
         "t_greenhouse": 17.4774,
         "t_outdoor": 14.8297
       },
@@ -5299,9 +5299,9 @@
     {
       "time": 28860,
       "values": {
-        "t_tank_top": 26.5282,
-        "t_tank_bottom": 25.7411,
-        "t_collector": 27.9931,
+        "t_tank_top": 25.6114,
+        "t_tank_bottom": 24.8068,
+        "t_collector": 27.1014,
         "t_greenhouse": 17.4701,
         "t_outdoor": 14.824
       },
@@ -5310,9 +5310,9 @@
     {
       "time": 28920,
       "values": {
-        "t_tank_top": 26.5517,
-        "t_tank_bottom": 25.7678,
-        "t_collector": 28.0108,
+        "t_tank_top": 25.6308,
+        "t_tank_bottom": 24.8293,
+        "t_collector": 27.1151,
         "t_greenhouse": 17.4626,
         "t_outdoor": 14.8182
       },
@@ -5321,9 +5321,9 @@
     {
       "time": 28980,
       "values": {
-        "t_tank_top": 26.5751,
-        "t_tank_bottom": 25.7944,
-        "t_collector": 28.0284,
+        "t_tank_top": 25.65,
+        "t_tank_bottom": 24.8516,
+        "t_collector": 27.1286,
         "t_greenhouse": 17.455,
         "t_outdoor": 14.8124
       },
@@ -5332,9 +5332,9 @@
     {
       "time": 29040,
       "values": {
-        "t_tank_top": 26.5983,
-        "t_tank_bottom": 25.8208,
-        "t_collector": 28.0458,
+        "t_tank_top": 25.6691,
+        "t_tank_bottom": 24.8738,
+        "t_collector": 27.1419,
         "t_greenhouse": 17.4473,
         "t_outdoor": 14.8064
       },
@@ -5343,9 +5343,9 @@
     {
       "time": 29100,
       "values": {
-        "t_tank_top": 26.6214,
-        "t_tank_bottom": 25.8472,
-        "t_collector": 28.063,
+        "t_tank_top": 25.6881,
+        "t_tank_bottom": 24.8959,
+        "t_collector": 27.1551,
         "t_greenhouse": 17.4395,
         "t_outdoor": 14.8004
       },
@@ -5354,9 +5354,9 @@
     {
       "time": 29160,
       "values": {
-        "t_tank_top": 26.6444,
-        "t_tank_bottom": 25.8734,
-        "t_collector": 28.0801,
+        "t_tank_top": 25.7069,
+        "t_tank_bottom": 24.9179,
+        "t_collector": 27.1681,
         "t_greenhouse": 17.4315,
         "t_outdoor": 14.7942
       },
@@ -5365,9 +5365,9 @@
     {
       "time": 29220,
       "values": {
-        "t_tank_top": 26.6673,
-        "t_tank_bottom": 25.8995,
-        "t_collector": 28.097,
+        "t_tank_top": 25.7256,
+        "t_tank_bottom": 24.9397,
+        "t_collector": 27.181,
         "t_greenhouse": 17.4234,
         "t_outdoor": 14.788
       },
@@ -5376,9 +5376,9 @@
     {
       "time": 29280,
       "values": {
-        "t_tank_top": 26.69,
-        "t_tank_bottom": 25.9254,
-        "t_collector": 28.1138,
+        "t_tank_top": 25.7441,
+        "t_tank_bottom": 24.9615,
+        "t_collector": 27.1937,
         "t_greenhouse": 17.4152,
         "t_outdoor": 14.7816
       },
@@ -5387,9 +5387,9 @@
     {
       "time": 29340,
       "values": {
-        "t_tank_top": 26.7126,
-        "t_tank_bottom": 25.9513,
-        "t_collector": 28.1304,
+        "t_tank_top": 25.7625,
+        "t_tank_bottom": 24.983,
+        "t_collector": 27.2062,
         "t_greenhouse": 17.4069,
         "t_outdoor": 14.7752
       },
@@ -5398,9 +5398,9 @@
     {
       "time": 29400,
       "values": {
-        "t_tank_top": 26.735,
-        "t_tank_bottom": 25.977,
-        "t_collector": 28.1469,
+        "t_tank_top": 25.7808,
+        "t_tank_bottom": 25.0045,
+        "t_collector": 27.2186,
         "t_greenhouse": 17.3984,
         "t_outdoor": 14.7687
       },
@@ -5409,9 +5409,9 @@
     {
       "time": 29460,
       "values": {
-        "t_tank_top": 26.7573,
-        "t_tank_bottom": 26.0026,
-        "t_collector": 28.1632,
+        "t_tank_top": 25.7989,
+        "t_tank_bottom": 25.0258,
+        "t_collector": 27.2308,
         "t_greenhouse": 17.3898,
         "t_outdoor": 14.7621
       },
@@ -5420,9 +5420,9 @@
     {
       "time": 29520,
       "values": {
-        "t_tank_top": 26.7795,
-        "t_tank_bottom": 26.0281,
-        "t_collector": 28.1793,
+        "t_tank_top": 25.8168,
+        "t_tank_bottom": 25.047,
+        "t_collector": 27.2428,
         "t_greenhouse": 17.3811,
         "t_outdoor": 14.7554
       },
@@ -5431,9 +5431,9 @@
     {
       "time": 29580,
       "values": {
-        "t_tank_top": 26.8015,
-        "t_tank_bottom": 26.0534,
-        "t_collector": 28.1953,
+        "t_tank_top": 25.8346,
+        "t_tank_bottom": 25.068,
+        "t_collector": 27.2546,
         "t_greenhouse": 17.3722,
         "t_outdoor": 14.7486
       },
@@ -5442,9 +5442,9 @@
     {
       "time": 29640,
       "values": {
-        "t_tank_top": 26.8234,
-        "t_tank_bottom": 26.0786,
-        "t_collector": 28.2111,
+        "t_tank_top": 25.8523,
+        "t_tank_bottom": 25.0889,
+        "t_collector": 27.2663,
         "t_greenhouse": 17.3632,
         "t_outdoor": 14.7417
       },
@@ -5453,9 +5453,9 @@
     {
       "time": 29700,
       "values": {
-        "t_tank_top": 26.8452,
-        "t_tank_bottom": 26.1037,
-        "t_collector": 28.2268,
+        "t_tank_top": 25.8698,
+        "t_tank_bottom": 25.1097,
+        "t_collector": 27.2778,
         "t_greenhouse": 17.3541,
         "t_outdoor": 14.7348
       },
@@ -5464,9 +5464,9 @@
     {
       "time": 29760,
       "values": {
-        "t_tank_top": 26.8668,
-        "t_tank_bottom": 26.1287,
-        "t_collector": 28.2423,
+        "t_tank_top": 25.8872,
+        "t_tank_bottom": 25.1304,
+        "t_collector": 27.2892,
         "t_greenhouse": 17.3449,
         "t_outdoor": 14.7277
       },
@@ -5475,9 +5475,9 @@
     {
       "time": 29820,
       "values": {
-        "t_tank_top": 26.8883,
-        "t_tank_bottom": 26.1536,
-        "t_collector": 28.2576,
+        "t_tank_top": 25.9045,
+        "t_tank_bottom": 25.1509,
+        "t_collector": 27.3004,
         "t_greenhouse": 17.3355,
         "t_outdoor": 14.7206
       },
@@ -5486,9 +5486,9 @@
     {
       "time": 29880,
       "values": {
-        "t_tank_top": 26.9097,
-        "t_tank_bottom": 26.1783,
-        "t_collector": 28.2728,
+        "t_tank_top": 25.9215,
+        "t_tank_bottom": 25.1713,
+        "t_collector": 27.3114,
         "t_greenhouse": 17.326,
         "t_outdoor": 14.7133
       },
@@ -5497,9 +5497,9 @@
     {
       "time": 29940,
       "values": {
-        "t_tank_top": 26.9309,
-        "t_tank_bottom": 26.2029,
-        "t_collector": 28.2878,
+        "t_tank_top": 25.9385,
+        "t_tank_bottom": 25.1915,
+        "t_collector": 27.3223,
         "t_greenhouse": 17.3164,
         "t_outdoor": 14.706
       },
@@ -5508,9 +5508,9 @@
     {
       "time": 30000,
       "values": {
-        "t_tank_top": 26.952,
-        "t_tank_bottom": 26.2274,
-        "t_collector": 28.3027,
+        "t_tank_top": 25.9553,
+        "t_tank_bottom": 25.2116,
+        "t_collector": 27.3329,
         "t_greenhouse": 17.3066,
         "t_outdoor": 14.6986
       },
@@ -5519,9 +5519,9 @@
     {
       "time": 30060,
       "values": {
-        "t_tank_top": 26.9729,
-        "t_tank_bottom": 26.2517,
-        "t_collector": 28.3174,
+        "t_tank_top": 25.9719,
+        "t_tank_bottom": 25.2316,
+        "t_collector": 27.3434,
         "t_greenhouse": 17.2967,
         "t_outdoor": 14.6911
       },
@@ -5530,9 +5530,9 @@
     {
       "time": 30120,
       "values": {
-        "t_tank_top": 26.9937,
-        "t_tank_bottom": 26.276,
-        "t_collector": 28.332,
+        "t_tank_top": 25.9884,
+        "t_tank_bottom": 25.2514,
+        "t_collector": 27.3538,
         "t_greenhouse": 17.2867,
         "t_outdoor": 14.6835
       },
@@ -5541,9 +5541,9 @@
     {
       "time": 30180,
       "values": {
-        "t_tank_top": 27.0144,
-        "t_tank_bottom": 26.3,
-        "t_collector": 28.3463,
+        "t_tank_top": 26.0047,
+        "t_tank_bottom": 25.2711,
+        "t_collector": 27.364,
         "t_greenhouse": 17.2766,
         "t_outdoor": 14.6758
       },
@@ -5552,9 +5552,9 @@
     {
       "time": 30240,
       "values": {
-        "t_tank_top": 27.0349,
-        "t_tank_bottom": 26.324,
-        "t_collector": 28.3606,
+        "t_tank_top": 26.0209,
+        "t_tank_bottom": 25.2907,
+        "t_collector": 27.374,
         "t_greenhouse": 17.2663,
         "t_outdoor": 14.668
       },
@@ -5563,9 +5563,9 @@
     {
       "time": 30300,
       "values": {
-        "t_tank_top": 27.0553,
-        "t_tank_bottom": 26.3478,
-        "t_collector": 28.3746,
+        "t_tank_top": 26.037,
+        "t_tank_bottom": 25.3101,
+        "t_collector": 27.3838,
         "t_greenhouse": 17.256,
         "t_outdoor": 14.6602
       },
@@ -5574,9 +5574,9 @@
     {
       "time": 30360,
       "values": {
-        "t_tank_top": 27.0755,
-        "t_tank_bottom": 26.3716,
-        "t_collector": 28.3885,
+        "t_tank_top": 26.0529,
+        "t_tank_bottom": 25.3294,
+        "t_collector": 27.3935,
         "t_greenhouse": 17.2454,
         "t_outdoor": 14.6522
       },
@@ -5585,9 +5585,9 @@
     {
       "time": 30420,
       "values": {
-        "t_tank_top": 27.0956,
-        "t_tank_bottom": 26.3951,
-        "t_collector": 28.4023,
+        "t_tank_top": 26.0686,
+        "t_tank_bottom": 25.3486,
+        "t_collector": 27.4029,
         "t_greenhouse": 17.2348,
         "t_outdoor": 14.6442
       },
@@ -5596,9 +5596,9 @@
     {
       "time": 30480,
       "values": {
-        "t_tank_top": 27.1156,
-        "t_tank_bottom": 26.4186,
-        "t_collector": 28.4158,
+        "t_tank_top": 26.0842,
+        "t_tank_bottom": 25.3676,
+        "t_collector": 27.4123,
         "t_greenhouse": 17.2241,
         "t_outdoor": 14.6361
       },
@@ -5607,9 +5607,9 @@
     {
       "time": 30540,
       "values": {
-        "t_tank_top": 27.1354,
-        "t_tank_bottom": 26.4419,
-        "t_collector": 28.4293,
+        "t_tank_top": 26.0997,
+        "t_tank_bottom": 25.3864,
+        "t_collector": 27.4214,
         "t_greenhouse": 17.2132,
         "t_outdoor": 14.6278
       },
@@ -5618,9 +5618,9 @@
     {
       "time": 30600,
       "values": {
-        "t_tank_top": 27.1551,
-        "t_tank_bottom": 26.4651,
-        "t_collector": 28.4425,
+        "t_tank_top": 26.115,
+        "t_tank_bottom": 25.4052,
+        "t_collector": 27.4304,
         "t_greenhouse": 17.2022,
         "t_outdoor": 14.6195
       },
@@ -5629,9 +5629,9 @@
     {
       "time": 30660,
       "values": {
-        "t_tank_top": 27.1746,
-        "t_tank_bottom": 26.4881,
-        "t_collector": 28.4556,
+        "t_tank_top": 26.1301,
+        "t_tank_bottom": 25.4238,
+        "t_collector": 27.4392,
         "t_greenhouse": 17.191,
         "t_outdoor": 14.6111
       },
@@ -5640,9 +5640,9 @@
     {
       "time": 30720,
       "values": {
-        "t_tank_top": 27.194,
-        "t_tank_bottom": 26.5111,
-        "t_collector": 28.4685,
+        "t_tank_top": 26.1451,
+        "t_tank_bottom": 25.4422,
+        "t_collector": 27.4478,
         "t_greenhouse": 17.1798,
         "t_outdoor": 14.6027
       },
@@ -5651,9 +5651,9 @@
     {
       "time": 30780,
       "values": {
-        "t_tank_top": 27.2132,
-        "t_tank_bottom": 26.5339,
-        "t_collector": 28.4813,
+        "t_tank_top": 26.16,
+        "t_tank_bottom": 25.4605,
+        "t_collector": 27.4563,
         "t_greenhouse": 17.1684,
         "t_outdoor": 14.5941
       },
@@ -5662,9 +5662,9 @@
     {
       "time": 30840,
       "values": {
-        "t_tank_top": 27.2323,
-        "t_tank_bottom": 26.5565,
-        "t_collector": 28.4939,
+        "t_tank_top": 26.1746,
+        "t_tank_bottom": 25.4787,
+        "t_collector": 27.4646,
         "t_greenhouse": 17.1569,
         "t_outdoor": 14.5854
       },
@@ -5673,9 +5673,9 @@
     {
       "time": 30900,
       "values": {
-        "t_tank_top": 27.2513,
-        "t_tank_bottom": 26.579,
-        "t_collector": 28.5063,
+        "t_tank_top": 26.1892,
+        "t_tank_bottom": 25.4967,
+        "t_collector": 27.4727,
         "t_greenhouse": 17.1452,
         "t_outdoor": 14.5767
       },
@@ -5684,9 +5684,9 @@
     {
       "time": 30960,
       "values": {
-        "t_tank_top": 27.2701,
-        "t_tank_bottom": 26.6014,
-        "t_collector": 28.5186,
+        "t_tank_top": 26.2036,
+        "t_tank_bottom": 25.5146,
+        "t_collector": 27.4807,
         "t_greenhouse": 17.1335,
         "t_outdoor": 14.5679
       },
@@ -5695,9 +5695,9 @@
     {
       "time": 31020,
       "values": {
-        "t_tank_top": 27.2888,
-        "t_tank_bottom": 26.6237,
-        "t_collector": 28.5307,
+        "t_tank_top": 26.2178,
+        "t_tank_bottom": 25.5324,
+        "t_collector": 27.4884,
         "t_greenhouse": 17.1216,
         "t_outdoor": 14.559
       },
@@ -5706,9 +5706,9 @@
     {
       "time": 31080,
       "values": {
-        "t_tank_top": 27.3073,
-        "t_tank_bottom": 26.6458,
-        "t_collector": 28.5426,
+        "t_tank_top": 26.2319,
+        "t_tank_bottom": 25.55,
+        "t_collector": 27.496,
         "t_greenhouse": 17.1096,
         "t_outdoor": 14.55
       },
@@ -5717,9 +5717,9 @@
     {
       "time": 31140,
       "values": {
-        "t_tank_top": 27.3257,
-        "t_tank_bottom": 26.6678,
-        "t_collector": 28.5544,
+        "t_tank_top": 26.2458,
+        "t_tank_bottom": 25.5674,
+        "t_collector": 27.5035,
         "t_greenhouse": 17.0975,
         "t_outdoor": 14.5409
       },
@@ -5728,9 +5728,9 @@
     {
       "time": 31200,
       "values": {
-        "t_tank_top": 27.3439,
-        "t_tank_bottom": 26.6897,
-        "t_collector": 28.566,
+        "t_tank_top": 26.2596,
+        "t_tank_bottom": 25.5847,
+        "t_collector": 27.5107,
         "t_greenhouse": 17.0852,
         "t_outdoor": 14.5317
       },
@@ -5739,9 +5739,9 @@
     {
       "time": 31260,
       "values": {
-        "t_tank_top": 27.362,
-        "t_tank_bottom": 26.7114,
-        "t_collector": 28.5774,
+        "t_tank_top": 26.2732,
+        "t_tank_bottom": 25.6019,
+        "t_collector": 27.5178,
         "t_greenhouse": 17.0728,
         "t_outdoor": 14.5224
       },
@@ -5750,9 +5750,9 @@
     {
       "time": 31320,
       "values": {
-        "t_tank_top": 27.3799,
-        "t_tank_bottom": 26.733,
-        "t_collector": 28.5887,
+        "t_tank_top": 26.2866,
+        "t_tank_bottom": 25.619,
+        "t_collector": 27.5247,
         "t_greenhouse": 17.0603,
         "t_outdoor": 14.5131
       },
@@ -5761,9 +5761,9 @@
     {
       "time": 31380,
       "values": {
-        "t_tank_top": 27.3977,
-        "t_tank_bottom": 26.7544,
-        "t_collector": 28.5998,
+        "t_tank_top": 26.2999,
+        "t_tank_bottom": 25.6358,
+        "t_collector": 27.5314,
         "t_greenhouse": 17.0477,
         "t_outdoor": 14.5036
       },
@@ -5772,9 +5772,9 @@
     {
       "time": 31440,
       "values": {
-        "t_tank_top": 27.4153,
-        "t_tank_bottom": 26.7757,
-        "t_collector": 28.6108,
+        "t_tank_top": 26.3131,
+        "t_tank_bottom": 25.6526,
+        "t_collector": 27.538,
         "t_greenhouse": 17.035,
         "t_outdoor": 14.4941
       },
@@ -5783,9 +5783,9 @@
     {
       "time": 31500,
       "values": {
-        "t_tank_top": 27.4328,
-        "t_tank_bottom": 26.7969,
-        "t_collector": 28.6216,
+        "t_tank_top": 26.3261,
+        "t_tank_bottom": 25.6692,
+        "t_collector": 27.5444,
         "t_greenhouse": 17.0221,
         "t_outdoor": 14.4845
       },
@@ -5794,9 +5794,9 @@
     {
       "time": 31560,
       "values": {
-        "t_tank_top": 27.4502,
-        "t_tank_bottom": 26.818,
-        "t_collector": 28.6322,
+        "t_tank_top": 26.3389,
+        "t_tank_bottom": 25.6856,
+        "t_collector": 27.5506,
         "t_greenhouse": 17.0091,
         "t_outdoor": 14.4748
       },
@@ -5805,9 +5805,9 @@
     {
       "time": 31620,
       "values": {
-        "t_tank_top": 27.4674,
-        "t_tank_bottom": 26.8389,
-        "t_collector": 28.6426,
+        "t_tank_top": 26.3516,
+        "t_tank_bottom": 25.7019,
+        "t_collector": 27.5566,
         "t_greenhouse": 16.996,
         "t_outdoor": 14.4651
       },
@@ -5816,9 +5816,9 @@
     {
       "time": 31680,
       "values": {
-        "t_tank_top": 27.4844,
-        "t_tank_bottom": 26.8596,
-        "t_collector": 28.6529,
+        "t_tank_top": 26.3641,
+        "t_tank_bottom": 25.7181,
+        "t_collector": 27.5625,
         "t_greenhouse": 16.9828,
         "t_outdoor": 14.4552
       },
@@ -5827,9 +5827,9 @@
     {
       "time": 31740,
       "values": {
-        "t_tank_top": 27.5013,
-        "t_tank_bottom": 26.8802,
-        "t_collector": 28.663,
+        "t_tank_top": 26.3765,
+        "t_tank_bottom": 25.7341,
+        "t_collector": 27.5681,
         "t_greenhouse": 16.9694,
         "t_outdoor": 14.4453
       },
@@ -5838,9 +5838,9 @@
     {
       "time": 31800,
       "values": {
-        "t_tank_top": 27.5181,
-        "t_tank_bottom": 26.9007,
-        "t_collector": 28.6729,
+        "t_tank_top": 26.3887,
+        "t_tank_bottom": 25.75,
+        "t_collector": 27.5736,
         "t_greenhouse": 16.9559,
         "t_outdoor": 14.4352
       },
@@ -5849,9 +5849,9 @@
     {
       "time": 31860,
       "values": {
-        "t_tank_top": 27.5347,
-        "t_tank_bottom": 26.9211,
-        "t_collector": 28.6827,
+        "t_tank_top": 26.4007,
+        "t_tank_bottom": 25.7657,
+        "t_collector": 27.579,
         "t_greenhouse": 16.9423,
         "t_outdoor": 14.4251
       },
@@ -5860,9 +5860,9 @@
     {
       "time": 31920,
       "values": {
-        "t_tank_top": 27.5511,
-        "t_tank_bottom": 26.9413,
-        "t_collector": 28.6923,
+        "t_tank_top": 26.4126,
+        "t_tank_bottom": 25.7813,
+        "t_collector": 27.5841,
         "t_greenhouse": 16.9286,
         "t_outdoor": 14.4149
       },
@@ -5871,9 +5871,9 @@
     {
       "time": 31980,
       "values": {
-        "t_tank_top": 27.5674,
-        "t_tank_bottom": 26.9614,
-        "t_collector": 28.7017,
+        "t_tank_top": 26.4244,
+        "t_tank_bottom": 25.7967,
+        "t_collector": 27.5891,
         "t_greenhouse": 16.9148,
         "t_outdoor": 14.4046
       },
@@ -5882,9 +5882,9 @@
     {
       "time": 32040,
       "values": {
-        "t_tank_top": 27.5836,
-        "t_tank_bottom": 26.9813,
-        "t_collector": 28.711,
+        "t_tank_top": 26.436,
+        "t_tank_bottom": 25.812,
+        "t_collector": 27.5939,
         "t_greenhouse": 16.9008,
         "t_outdoor": 14.3943
       },
@@ -5893,9 +5893,9 @@
     {
       "time": 32100,
       "values": {
-        "t_tank_top": 27.5996,
-        "t_tank_bottom": 27.0011,
-        "t_collector": 28.7201,
+        "t_tank_top": 26.4474,
+        "t_tank_bottom": 25.8271,
+        "t_collector": 27.5985,
         "t_greenhouse": 16.8867,
         "t_outdoor": 14.3838
       },
@@ -5904,9 +5904,9 @@
     {
       "time": 32160,
       "values": {
-        "t_tank_top": 27.6154,
-        "t_tank_bottom": 27.0207,
-        "t_collector": 28.729,
+        "t_tank_top": 26.4586,
+        "t_tank_bottom": 25.8421,
+        "t_collector": 27.603,
         "t_greenhouse": 16.8725,
         "t_outdoor": 14.3733
       },
@@ -5915,9 +5915,9 @@
     {
       "time": 32220,
       "values": {
-        "t_tank_top": 27.6311,
-        "t_tank_bottom": 27.0402,
-        "t_collector": 28.7378,
+        "t_tank_top": 26.4697,
+        "t_tank_bottom": 25.8569,
+        "t_collector": 27.6072,
         "t_greenhouse": 16.8582,
         "t_outdoor": 14.3627
       },
@@ -5926,9 +5926,9 @@
     {
       "time": 32280,
       "values": {
-        "t_tank_top": 27.6466,
-        "t_tank_bottom": 27.0596,
-        "t_collector": 28.7464,
+        "t_tank_top": 26.4807,
+        "t_tank_bottom": 25.8716,
+        "t_collector": 27.6113,
         "t_greenhouse": 16.8438,
         "t_outdoor": 14.352
       },
@@ -5937,9 +5937,9 @@
     {
       "time": 32340,
       "values": {
-        "t_tank_top": 27.662,
-        "t_tank_bottom": 27.0788,
-        "t_collector": 28.7548,
+        "t_tank_top": 26.4915,
+        "t_tank_bottom": 25.8861,
+        "t_collector": 27.6153,
         "t_greenhouse": 16.8292,
         "t_outdoor": 14.3412
       },
@@ -5948,9 +5948,9 @@
     {
       "time": 32400,
       "values": {
-        "t_tank_top": 27.6773,
-        "t_tank_bottom": 27.0979,
-        "t_collector": 28.7631,
+        "t_tank_top": 26.5021,
+        "t_tank_bottom": 25.9005,
+        "t_collector": 27.619,
         "t_greenhouse": 16.8146,
         "t_outdoor": 14.3303
       },
@@ -5959,9 +5959,9 @@
     {
       "time": 32460,
       "values": {
-        "t_tank_top": 27.6924,
-        "t_tank_bottom": 27.1168,
-        "t_collector": 28.7711,
+        "t_tank_top": 26.5126,
+        "t_tank_bottom": 25.9147,
+        "t_collector": 27.6226,
         "t_greenhouse": 16.7998,
         "t_outdoor": 14.3194
       },
@@ -5970,9 +5970,9 @@
     {
       "time": 32520,
       "values": {
-        "t_tank_top": 27.7073,
-        "t_tank_bottom": 27.1356,
-        "t_collector": 28.779,
+        "t_tank_top": 26.5229,
+        "t_tank_bottom": 25.9288,
+        "t_collector": 27.6259,
         "t_greenhouse": 16.7849,
         "t_outdoor": 14.3083
       },
@@ -5981,9 +5981,9 @@
     {
       "time": 32580,
       "values": {
-        "t_tank_top": 27.7221,
-        "t_tank_bottom": 27.1543,
-        "t_collector": 28.7868,
+        "t_tank_top": 26.533,
+        "t_tank_bottom": 25.9428,
+        "t_collector": 27.6292,
         "t_greenhouse": 16.7698,
         "t_outdoor": 14.2972
       },
@@ -5992,9 +5992,9 @@
     {
       "time": 32640,
       "values": {
-        "t_tank_top": 27.7367,
-        "t_tank_bottom": 27.1728,
-        "t_collector": 28.7943,
+        "t_tank_top": 26.543,
+        "t_tank_bottom": 25.9565,
+        "t_collector": 27.6322,
         "t_greenhouse": 16.7547,
         "t_outdoor": 14.286
       },
@@ -6003,9 +6003,9 @@
     {
       "time": 32700,
       "values": {
-        "t_tank_top": 27.7512,
-        "t_tank_bottom": 27.1912,
-        "t_collector": 28.8017,
+        "t_tank_top": 26.5528,
+        "t_tank_bottom": 25.9702,
+        "t_collector": 27.635,
         "t_greenhouse": 16.7394,
         "t_outdoor": 14.2747
       },
@@ -6014,9 +6014,9 @@
     {
       "time": 32760,
       "values": {
-        "t_tank_top": 27.7655,
-        "t_tank_bottom": 27.2094,
-        "t_collector": 28.809,
+        "t_tank_top": 26.5625,
+        "t_tank_bottom": 25.9836,
+        "t_collector": 27.6377,
         "t_greenhouse": 16.724,
         "t_outdoor": 14.2634
       },
@@ -6025,9 +6025,9 @@
     {
       "time": 32820,
       "values": {
-        "t_tank_top": 27.7797,
-        "t_tank_bottom": 27.2275,
-        "t_collector": 28.816,
+        "t_tank_top": 26.572,
+        "t_tank_bottom": 25.997,
+        "t_collector": 27.6402,
         "t_greenhouse": 16.7085,
         "t_outdoor": 14.252
       },
@@ -6036,9 +6036,9 @@
     {
       "time": 32880,
       "values": {
-        "t_tank_top": 27.7937,
-        "t_tank_bottom": 27.2454,
-        "t_collector": 28.8229,
+        "t_tank_top": 26.5813,
+        "t_tank_bottom": 26.0101,
+        "t_collector": 27.6425,
         "t_greenhouse": 16.6929,
         "t_outdoor": 14.2404
       },
@@ -6047,9 +6047,9 @@
     {
       "time": 32940,
       "values": {
-        "t_tank_top": 27.8075,
-        "t_tank_bottom": 27.2632,
-        "t_collector": 28.8296,
+        "t_tank_top": 26.5905,
+        "t_tank_bottom": 26.0232,
+        "t_collector": 27.6447,
         "t_greenhouse": 16.6772,
         "t_outdoor": 14.2288
       },
@@ -6058,9 +6058,9 @@
     {
       "time": 33000,
       "values": {
-        "t_tank_top": 27.8212,
-        "t_tank_bottom": 27.2808,
-        "t_collector": 28.8362,
+        "t_tank_top": 26.5995,
+        "t_tank_bottom": 26.036,
+        "t_collector": 27.6466,
         "t_greenhouse": 16.6613,
         "t_outdoor": 14.2172
       },
@@ -6069,9 +6069,9 @@
     {
       "time": 33060,
       "values": {
-        "t_tank_top": 27.8348,
-        "t_tank_bottom": 27.2983,
-        "t_collector": 28.8425,
+        "t_tank_top": 26.6083,
+        "t_tank_bottom": 26.0488,
+        "t_collector": 27.6484,
         "t_greenhouse": 16.6454,
         "t_outdoor": 14.2054
       },
@@ -6080,9 +6080,9 @@
     {
       "time": 33120,
       "values": {
-        "t_tank_top": 27.8482,
-        "t_tank_bottom": 27.3157,
-        "t_collector": 28.8487,
+        "t_tank_top": 26.617,
+        "t_tank_bottom": 26.0613,
+        "t_collector": 27.65,
         "t_greenhouse": 16.6293,
         "t_outdoor": 14.1936
       },
@@ -6091,9 +6091,9 @@
     {
       "time": 33180,
       "values": {
-        "t_tank_top": 27.8614,
-        "t_tank_bottom": 27.3329,
-        "t_collector": 28.8548,
+        "t_tank_top": 26.6255,
+        "t_tank_bottom": 26.0737,
+        "t_collector": 27.6514,
         "t_greenhouse": 16.6131,
         "t_outdoor": 14.1816
       },
@@ -6102,9 +6102,9 @@
     {
       "time": 33240,
       "values": {
-        "t_tank_top": 27.8745,
-        "t_tank_bottom": 27.3499,
-        "t_collector": 28.8606,
+        "t_tank_top": 26.6339,
+        "t_tank_bottom": 26.086,
+        "t_collector": 27.6527,
         "t_greenhouse": 16.5968,
         "t_outdoor": 14.1696
       },
@@ -6113,9 +6113,9 @@
     {
       "time": 33300,
       "values": {
-        "t_tank_top": 27.8874,
-        "t_tank_bottom": 27.3668,
-        "t_collector": 28.8663,
+        "t_tank_top": 26.6421,
+        "t_tank_bottom": 26.0981,
+        "t_collector": 27.6537,
         "t_greenhouse": 16.5803,
         "t_outdoor": 14.1576
       },
@@ -6124,9 +6124,9 @@
     {
       "time": 33360,
       "values": {
-        "t_tank_top": 27.9002,
-        "t_tank_bottom": 27.3836,
-        "t_collector": 28.8718,
+        "t_tank_top": 26.6501,
+        "t_tank_bottom": 26.11,
+        "t_collector": 27.6546,
         "t_greenhouse": 16.5638,
         "t_outdoor": 14.1454
       },
@@ -6135,9 +6135,9 @@
     {
       "time": 33420,
       "values": {
-        "t_tank_top": 27.9128,
-        "t_tank_bottom": 27.4002,
-        "t_collector": 28.8771,
+        "t_tank_top": 26.658,
+        "t_tank_bottom": 26.1218,
+        "t_collector": 27.6553,
         "t_greenhouse": 16.5471,
         "t_outdoor": 14.1332
       },
@@ -6146,9 +6146,9 @@
     {
       "time": 33480,
       "values": {
-        "t_tank_top": 27.9252,
-        "t_tank_bottom": 27.4166,
-        "t_collector": 28.8823,
+        "t_tank_top": 26.6657,
+        "t_tank_bottom": 26.1334,
+        "t_collector": 27.6558,
         "t_greenhouse": 16.5304,
         "t_outdoor": 14.1208
       },
@@ -6157,9 +6157,9 @@
     {
       "time": 33540,
       "values": {
-        "t_tank_top": 27.9375,
-        "t_tank_bottom": 27.433,
-        "t_collector": 28.8873,
+        "t_tank_top": 26.6733,
+        "t_tank_bottom": 26.1449,
+        "t_collector": 27.6562,
         "t_greenhouse": 16.5135,
         "t_outdoor": 14.1084
       },
@@ -6168,9 +6168,9 @@
     {
       "time": 33600,
       "values": {
-        "t_tank_top": 27.9496,
-        "t_tank_bottom": 27.4491,
-        "t_collector": 28.8921,
+        "t_tank_top": 26.6806,
+        "t_tank_bottom": 26.1562,
+        "t_collector": 27.6564,
         "t_greenhouse": 16.4965,
         "t_outdoor": 14.096
       },
@@ -6179,9 +6179,9 @@
     {
       "time": 33660,
       "values": {
-        "t_tank_top": 27.9616,
-        "t_tank_bottom": 27.4651,
-        "t_collector": 28.8967,
+        "t_tank_top": 26.6878,
+        "t_tank_bottom": 26.1674,
+        "t_collector": 27.6563,
         "t_greenhouse": 16.4794,
         "t_outdoor": 14.0834
       },
@@ -6190,9 +6190,9 @@
     {
       "time": 33720,
       "values": {
-        "t_tank_top": 27.9734,
-        "t_tank_bottom": 27.481,
-        "t_collector": 28.9012,
+        "t_tank_top": 26.6949,
+        "t_tank_bottom": 26.1784,
+        "t_collector": 27.6561,
         "t_greenhouse": 16.4621,
         "t_outdoor": 14.0708
       },
@@ -6201,9 +6201,9 @@
     {
       "time": 33780,
       "values": {
-        "t_tank_top": 27.9851,
-        "t_tank_bottom": 27.4967,
-        "t_collector": 28.9055,
+        "t_tank_top": 26.7018,
+        "t_tank_bottom": 26.1893,
+        "t_collector": 27.6558,
         "t_greenhouse": 16.4448,
         "t_outdoor": 14.0581
       },
@@ -6212,9 +6212,9 @@
     {
       "time": 33840,
       "values": {
-        "t_tank_top": 27.9966,
-        "t_tank_bottom": 27.5123,
-        "t_collector": 28.9096,
+        "t_tank_top": 26.7085,
+        "t_tank_bottom": 26.2,
+        "t_collector": 27.6552,
         "t_greenhouse": 16.4273,
         "t_outdoor": 14.0453
       },
@@ -6223,9 +6223,9 @@
     {
       "time": 33900,
       "values": {
-        "t_tank_top": 28.0079,
-        "t_tank_bottom": 27.5277,
-        "t_collector": 28.9135,
+        "t_tank_top": 26.715,
+        "t_tank_bottom": 26.2105,
+        "t_collector": 27.6545,
         "t_greenhouse": 16.4098,
         "t_outdoor": 14.0324
       },
@@ -6234,9 +6234,9 @@
     {
       "time": 33960,
       "values": {
-        "t_tank_top": 28.0191,
-        "t_tank_bottom": 27.543,
-        "t_collector": 28.9173,
+        "t_tank_top": 26.7214,
+        "t_tank_bottom": 26.2209,
+        "t_collector": 27.6536,
         "t_greenhouse": 16.3921,
         "t_outdoor": 14.0195
       },
@@ -6245,9 +6245,9 @@
     {
       "time": 34020,
       "values": {
-        "t_tank_top": 28.0301,
-        "t_tank_bottom": 27.5581,
-        "t_collector": 28.9209,
+        "t_tank_top": 26.7276,
+        "t_tank_bottom": 26.2311,
+        "t_collector": 27.6525,
         "t_greenhouse": 16.3743,
         "t_outdoor": 14.0065
       },
@@ -6256,9 +6256,9 @@
     {
       "time": 34080,
       "values": {
-        "t_tank_top": 28.041,
-        "t_tank_bottom": 27.573,
-        "t_collector": 28.9243,
+        "t_tank_top": 26.7337,
+        "t_tank_bottom": 26.2412,
+        "t_collector": 27.6512,
         "t_greenhouse": 16.3564,
         "t_outdoor": 13.9934
       },
@@ -6267,9 +6267,9 @@
     {
       "time": 34140,
       "values": {
-        "t_tank_top": 28.0517,
-        "t_tank_bottom": 27.5878,
-        "t_collector": 28.9276,
+        "t_tank_top": 26.7396,
+        "t_tank_bottom": 26.2511,
+        "t_collector": 27.6497,
         "t_greenhouse": 16.3384,
         "t_outdoor": 13.9802
       },
@@ -6278,9 +6278,9 @@
     {
       "time": 34200,
       "values": {
-        "t_tank_top": 28.0623,
-        "t_tank_bottom": 27.6025,
-        "t_collector": 28.9307,
+        "t_tank_top": 26.7453,
+        "t_tank_bottom": 26.2609,
+        "t_collector": 27.6481,
         "t_greenhouse": 16.3203,
         "t_outdoor": 13.967
       },
@@ -6289,9 +6289,9 @@
     {
       "time": 34260,
       "values": {
-        "t_tank_top": 28.0726,
-        "t_tank_bottom": 27.617,
-        "t_collector": 28.9336,
+        "t_tank_top": 26.7509,
+        "t_tank_bottom": 26.2705,
+        "t_collector": 27.6463,
         "t_greenhouse": 16.302,
         "t_outdoor": 13.9537
       },
@@ -6300,9 +6300,9 @@
     {
       "time": 34320,
       "values": {
-        "t_tank_top": 28.0829,
-        "t_tank_bottom": 27.6314,
-        "t_collector": 28.9363,
+        "t_tank_top": 26.7563,
+        "t_tank_bottom": 26.2799,
+        "t_collector": 27.6443,
         "t_greenhouse": 16.2837,
         "t_outdoor": 13.9403
       },
@@ -6311,9 +6311,9 @@
     {
       "time": 34380,
       "values": {
-        "t_tank_top": 28.0929,
-        "t_tank_bottom": 27.6456,
-        "t_collector": 28.9388,
+        "t_tank_top": 26.7615,
+        "t_tank_bottom": 26.2892,
+        "t_collector": 27.6421,
         "t_greenhouse": 16.2653,
         "t_outdoor": 13.9268
       },
@@ -6322,9 +6322,9 @@
     {
       "time": 34440,
       "values": {
-        "t_tank_top": 28.1028,
-        "t_tank_bottom": 27.6596,
-        "t_collector": 28.9412,
+        "t_tank_top": 26.7665,
+        "t_tank_bottom": 26.2983,
+        "t_collector": 27.6397,
         "t_greenhouse": 16.2467,
         "t_outdoor": 13.9133
       },
@@ -6333,9 +6333,9 @@
     {
       "time": 34500,
       "values": {
-        "t_tank_top": 28.1126,
-        "t_tank_bottom": 27.6735,
-        "t_collector": 28.9434,
+        "t_tank_top": 26.7714,
+        "t_tank_bottom": 26.3072,
+        "t_collector": 27.6372,
         "t_greenhouse": 16.228,
         "t_outdoor": 13.8996
       },
@@ -6344,9 +6344,9 @@
     {
       "time": 34560,
       "values": {
-        "t_tank_top": 28.1221,
-        "t_tank_bottom": 27.6872,
-        "t_collector": 28.9454,
+        "t_tank_top": 26.7761,
+        "t_tank_bottom": 26.316,
+        "t_collector": 27.6344,
         "t_greenhouse": 16.2092,
         "t_outdoor": 13.886
       },
@@ -6355,9 +6355,9 @@
     {
       "time": 34620,
       "values": {
-        "t_tank_top": 28.1315,
-        "t_tank_bottom": 27.7008,
-        "t_collector": 28.9473,
+        "t_tank_top": 26.7807,
+        "t_tank_bottom": 26.3247,
+        "t_collector": 27.6315,
         "t_greenhouse": 16.1904,
         "t_outdoor": 13.8722
       },
@@ -6366,9 +6366,9 @@
     {
       "time": 34680,
       "values": {
-        "t_tank_top": 28.1408,
-        "t_tank_bottom": 27.7143,
-        "t_collector": 28.9489,
+        "t_tank_top": 26.7851,
+        "t_tank_bottom": 26.3332,
+        "t_collector": 27.6284,
         "t_greenhouse": 16.1714,
         "t_outdoor": 13.8584
       },
@@ -6377,9 +6377,9 @@
     {
       "time": 34740,
       "values": {
-        "t_tank_top": 28.1499,
-        "t_tank_bottom": 27.7275,
-        "t_collector": 28.9504,
+        "t_tank_top": 26.7893,
+        "t_tank_bottom": 26.3415,
+        "t_collector": 27.6252,
         "t_greenhouse": 16.1522,
         "t_outdoor": 13.8444
       },
@@ -6388,9 +6388,9 @@
     {
       "time": 34800,
       "values": {
-        "t_tank_top": 28.1588,
-        "t_tank_bottom": 27.7407,
-        "t_collector": 28.9517,
+        "t_tank_top": 26.7933,
+        "t_tank_bottom": 26.3496,
+        "t_collector": 27.6217,
         "t_greenhouse": 16.133,
         "t_outdoor": 13.8305
       },
@@ -6399,9 +6399,9 @@
     {
       "time": 34860,
       "values": {
-        "t_tank_top": 28.1676,
-        "t_tank_bottom": 27.7536,
-        "t_collector": 28.9529,
+        "t_tank_top": 26.7972,
+        "t_tank_bottom": 26.3576,
+        "t_collector": 27.6181,
         "t_greenhouse": 16.1137,
         "t_outdoor": 13.8164
       },
@@ -6410,9 +6410,9 @@
     {
       "time": 34920,
       "values": {
-        "t_tank_top": 28.1762,
-        "t_tank_bottom": 27.7664,
-        "t_collector": 28.9539,
+        "t_tank_top": 26.8009,
+        "t_tank_bottom": 26.3655,
+        "t_collector": 27.6143,
         "t_greenhouse": 16.0943,
         "t_outdoor": 13.8023
       },
@@ -6421,9 +6421,9 @@
     {
       "time": 34980,
       "values": {
-        "t_tank_top": 28.1846,
-        "t_tank_bottom": 27.7791,
-        "t_collector": 28.9547,
+        "t_tank_top": 26.8045,
+        "t_tank_bottom": 26.3731,
+        "t_collector": 27.6103,
         "t_greenhouse": 16.0748,
         "t_outdoor": 13.7881
       },
@@ -6432,9 +6432,9 @@
     {
       "time": 35040,
       "values": {
-        "t_tank_top": 28.1929,
-        "t_tank_bottom": 27.7916,
-        "t_collector": 28.9553,
+        "t_tank_top": 26.8078,
+        "t_tank_bottom": 26.3807,
+        "t_collector": 27.6061,
         "t_greenhouse": 16.0551,
         "t_outdoor": 13.7738
       },
@@ -6443,9 +6443,9 @@
     {
       "time": 35100,
       "values": {
-        "t_tank_top": 28.201,
-        "t_tank_bottom": 27.804,
-        "t_collector": 28.9557,
+        "t_tank_top": 26.811,
+        "t_tank_bottom": 26.388,
+        "t_collector": 27.6017,
         "t_greenhouse": 16.0354,
         "t_outdoor": 13.7594
       },
@@ -6454,9 +6454,9 @@
     {
       "time": 35160,
       "values": {
-        "t_tank_top": 28.209,
-        "t_tank_bottom": 27.8161,
-        "t_collector": 28.956,
+        "t_tank_top": 26.8141,
+        "t_tank_bottom": 26.3952,
+        "t_collector": 27.5972,
         "t_greenhouse": 16.0155,
         "t_outdoor": 13.745
       },
@@ -6465,9 +6465,9 @@
     {
       "time": 35220,
       "values": {
-        "t_tank_top": 28.2167,
-        "t_tank_bottom": 27.8282,
-        "t_collector": 28.9561,
+        "t_tank_top": 26.8169,
+        "t_tank_bottom": 26.4022,
+        "t_collector": 27.5925,
         "t_greenhouse": 15.9956,
         "t_outdoor": 13.7305
       },
@@ -6476,9 +6476,9 @@
     {
       "time": 35280,
       "values": {
-        "t_tank_top": 28.2244,
-        "t_tank_bottom": 27.8401,
-        "t_collector": 28.956,
+        "t_tank_top": 26.8196,
+        "t_tank_bottom": 26.4091,
+        "t_collector": 27.5876,
         "t_greenhouse": 15.9755,
         "t_outdoor": 13.716
       },
@@ -6487,9 +6487,9 @@
     {
       "time": 35340,
       "values": {
-        "t_tank_top": 28.2318,
-        "t_tank_bottom": 27.8518,
-        "t_collector": 28.9557,
+        "t_tank_top": 26.8221,
+        "t_tank_bottom": 26.4158,
+        "t_collector": 27.5825,
         "t_greenhouse": 15.9553,
         "t_outdoor": 13.7013
       },
@@ -6498,9 +6498,9 @@
     {
       "time": 35400,
       "values": {
-        "t_tank_top": 28.2391,
-        "t_tank_bottom": 27.8633,
-        "t_collector": 28.9553,
+        "t_tank_top": 26.8245,
+        "t_tank_bottom": 26.4223,
+        "t_collector": 27.5772,
         "t_greenhouse": 15.9351,
         "t_outdoor": 13.6866
       },
@@ -6509,9 +6509,9 @@
     {
       "time": 35460,
       "values": {
-        "t_tank_top": 28.2462,
-        "t_tank_bottom": 27.8747,
-        "t_collector": 28.9546,
+        "t_tank_top": 26.8267,
+        "t_tank_bottom": 26.4287,
+        "t_collector": 27.5718,
         "t_greenhouse": 15.9147,
         "t_outdoor": 13.6719
       },
@@ -6520,9 +6520,9 @@
     {
       "time": 35520,
       "values": {
-        "t_tank_top": 28.2532,
-        "t_tank_bottom": 27.886,
-        "t_collector": 28.9538,
+        "t_tank_top": 26.8287,
+        "t_tank_bottom": 26.4349,
+        "t_collector": 27.5661,
         "t_greenhouse": 15.8942,
         "t_outdoor": 13.657
       },
@@ -6531,9 +6531,9 @@
     {
       "time": 35580,
       "values": {
-        "t_tank_top": 28.26,
-        "t_tank_bottom": 27.8971,
-        "t_collector": 28.9529,
+        "t_tank_top": 26.8306,
+        "t_tank_bottom": 26.441,
+        "t_collector": 27.5603,
         "t_greenhouse": 15.8736,
         "t_outdoor": 13.6421
       },
@@ -6542,9 +6542,9 @@
     {
       "time": 35640,
       "values": {
-        "t_tank_top": 28.2666,
-        "t_tank_bottom": 27.908,
-        "t_collector": 28.9517,
+        "t_tank_top": 26.8322,
+        "t_tank_bottom": 26.4469,
+        "t_collector": 27.5543,
         "t_greenhouse": 15.8529,
         "t_outdoor": 13.6271
       },
@@ -6553,9 +6553,9 @@
     {
       "time": 35700,
       "values": {
-        "t_tank_top": 28.2731,
-        "t_tank_bottom": 27.9188,
-        "t_collector": 28.9504,
+        "t_tank_top": 26.8337,
+        "t_tank_bottom": 26.4526,
+        "t_collector": 27.5481,
         "t_greenhouse": 15.8321,
         "t_outdoor": 13.6121
       },
@@ -6564,9 +6564,9 @@
     {
       "time": 35760,
       "values": {
-        "t_tank_top": 28.2794,
-        "t_tank_bottom": 27.9294,
-        "t_collector": 28.9489,
+        "t_tank_top": 26.8351,
+        "t_tank_bottom": 26.4581,
+        "t_collector": 27.5418,
         "t_greenhouse": 15.8113,
         "t_outdoor": 13.597
       },
@@ -6575,9 +6575,9 @@
     {
       "time": 35820,
       "values": {
-        "t_tank_top": 28.2855,
-        "t_tank_bottom": 27.9399,
-        "t_collector": 28.9472,
+        "t_tank_top": 26.8362,
+        "t_tank_bottom": 26.4635,
+        "t_collector": 27.5352,
         "t_greenhouse": 15.7903,
         "t_outdoor": 13.5818
       },
@@ -6586,9 +6586,9 @@
     {
       "time": 35880,
       "values": {
-        "t_tank_top": 28.2915,
-        "t_tank_bottom": 27.9501,
-        "t_collector": 28.9453,
+        "t_tank_top": 26.8372,
+        "t_tank_bottom": 26.4688,
+        "t_collector": 27.5285,
         "t_greenhouse": 15.7692,
         "t_outdoor": 13.5665
       },
@@ -6597,9 +6597,9 @@
     {
       "time": 35940,
       "values": {
-        "t_tank_top": 28.2973,
-        "t_tank_bottom": 27.9603,
-        "t_collector": 28.9433,
+        "t_tank_top": 26.8381,
+        "t_tank_bottom": 26.4738,
+        "t_collector": 27.5216,
         "t_greenhouse": 15.748,
         "t_outdoor": 13.5512
       },
@@ -6608,9 +6608,9 @@
     {
       "time": 36000,
       "values": {
-        "t_tank_top": 28.303,
-        "t_tank_bottom": 27.9703,
-        "t_collector": 28.9411,
+        "t_tank_top": 26.8387,
+        "t_tank_bottom": 26.4787,
+        "t_collector": 27.5145,
         "t_greenhouse": 15.7267,
         "t_outdoor": 13.5358
       },
@@ -6619,9 +6619,9 @@
     {
       "time": 36060,
       "values": {
-        "t_tank_top": 28.3084,
-        "t_tank_bottom": 27.9801,
-        "t_collector": 28.9387,
+        "t_tank_top": 26.8392,
+        "t_tank_bottom": 26.4835,
+        "t_collector": 27.5072,
         "t_greenhouse": 15.7053,
         "t_outdoor": 13.5203
       },
@@ -6630,9 +6630,9 @@
     {
       "time": 36120,
       "values": {
-        "t_tank_top": 28.3137,
-        "t_tank_bottom": 27.9897,
-        "t_collector": 28.9361,
+        "t_tank_top": 26.8395,
+        "t_tank_bottom": 26.4881,
+        "t_collector": 27.4998,
         "t_greenhouse": 15.6838,
         "t_outdoor": 13.5048
       },
@@ -6641,9 +6641,9 @@
     {
       "time": 36180,
       "values": {
-        "t_tank_top": 28.3189,
-        "t_tank_bottom": 27.9992,
-        "t_collector": 28.9334,
+        "t_tank_top": 26.8396,
+        "t_tank_bottom": 26.4925,
+        "t_collector": 27.4921,
         "t_greenhouse": 15.6622,
         "t_outdoor": 13.4892
       },
@@ -6652,9 +6652,9 @@
     {
       "time": 36240,
       "values": {
-        "t_tank_top": 28.3239,
-        "t_tank_bottom": 28.0086,
-        "t_collector": 28.9305,
+        "t_tank_top": 26.8396,
+        "t_tank_bottom": 26.4967,
+        "t_collector": 27.4843,
         "t_greenhouse": 15.6405,
         "t_outdoor": 13.4736
       },
@@ -6663,9 +6663,9 @@
     {
       "time": 36300,
       "values": {
-        "t_tank_top": 28.3287,
-        "t_tank_bottom": 28.0177,
-        "t_collector": 28.9274,
+        "t_tank_top": 26.8394,
+        "t_tank_bottom": 26.5008,
+        "t_collector": 27.4763,
         "t_greenhouse": 15.6187,
         "t_outdoor": 13.4578
       },
@@ -6674,9 +6674,9 @@
     {
       "time": 36360,
       "values": {
-        "t_tank_top": 28.3333,
-        "t_tank_bottom": 28.0268,
-        "t_collector": 28.9241,
+        "t_tank_top": 26.839,
+        "t_tank_bottom": 26.5047,
+        "t_collector": 27.4681,
         "t_greenhouse": 15.5968,
         "t_outdoor": 13.442
       },
@@ -6685,9 +6685,9 @@
     {
       "time": 36420,
       "values": {
-        "t_tank_top": 28.3378,
-        "t_tank_bottom": 28.0356,
-        "t_collector": 28.9206,
+        "t_tank_top": 26.8385,
+        "t_tank_bottom": 26.5085,
+        "t_collector": 27.4598,
         "t_greenhouse": 15.5748,
         "t_outdoor": 13.4262
       },
@@ -6696,9 +6696,9 @@
     {
       "time": 36480,
       "values": {
-        "t_tank_top": 28.3421,
-        "t_tank_bottom": 28.0443,
-        "t_collector": 28.917,
+        "t_tank_top": 26.8378,
+        "t_tank_bottom": 26.512,
+        "t_collector": 27.4512,
         "t_greenhouse": 15.5527,
         "t_outdoor": 13.4103
       },
@@ -6707,9 +6707,9 @@
     {
       "time": 36540,
       "values": {
-        "t_tank_top": 28.3462,
-        "t_tank_bottom": 28.0528,
-        "t_collector": 28.9132,
+        "t_tank_top": 26.8369,
+        "t_tank_bottom": 26.5155,
+        "t_collector": 27.4425,
         "t_greenhouse": 15.5305,
         "t_outdoor": 13.3943
       },
@@ -6718,9 +6718,9 @@
     {
       "time": 36600,
       "values": {
-        "t_tank_top": 28.3502,
-        "t_tank_bottom": 28.0612,
-        "t_collector": 28.9092,
+        "t_tank_top": 26.8358,
+        "t_tank_bottom": 26.5187,
+        "t_collector": 27.4336,
         "t_greenhouse": 15.5082,
         "t_outdoor": 13.3782
       },
@@ -6729,9 +6729,9 @@
     {
       "time": 36660,
       "values": {
-        "t_tank_top": 28.354,
-        "t_tank_bottom": 28.0694,
-        "t_collector": 28.905,
+        "t_tank_top": 26.8346,
+        "t_tank_bottom": 26.5218,
+        "t_collector": 27.4245,
         "t_greenhouse": 15.4859,
         "t_outdoor": 13.3621
       },
@@ -6740,9 +6740,9 @@
     {
       "time": 36720,
       "values": {
-        "t_tank_top": 28.3576,
-        "t_tank_bottom": 28.0775,
-        "t_collector": 28.9007,
+        "t_tank_top": 26.8332,
+        "t_tank_bottom": 26.5247,
+        "t_collector": 27.4152,
         "t_greenhouse": 15.4634,
         "t_outdoor": 13.3459
       },
@@ -6751,9 +6751,9 @@
     {
       "time": 36780,
       "values": {
-        "t_tank_top": 28.3611,
-        "t_tank_bottom": 28.0854,
-        "t_collector": 28.8962,
+        "t_tank_top": 26.8316,
+        "t_tank_bottom": 26.5275,
+        "t_collector": 27.4058,
         "t_greenhouse": 15.4408,
         "t_outdoor": 13.3297
       },
@@ -6762,9 +6762,9 @@
     {
       "time": 36840,
       "values": {
-        "t_tank_top": 28.3644,
-        "t_tank_bottom": 28.0931,
-        "t_collector": 28.8915,
+        "t_tank_top": 26.8298,
+        "t_tank_bottom": 26.53,
+        "t_collector": 27.3961,
         "t_greenhouse": 15.4181,
         "t_outdoor": 13.3134
       },
@@ -6773,9 +6773,9 @@
     {
       "time": 36900,
       "values": {
-        "t_tank_top": 28.3675,
-        "t_tank_bottom": 28.1006,
-        "t_collector": 28.8866,
+        "t_tank_top": 26.8279,
+        "t_tank_bottom": 26.5325,
+        "t_collector": 27.3863,
         "t_greenhouse": 15.3954,
         "t_outdoor": 13.297
       },
@@ -6784,9 +6784,9 @@
     {
       "time": 36960,
       "values": {
-        "t_tank_top": 28.3705,
-        "t_tank_bottom": 28.108,
-        "t_collector": 28.8816,
+        "t_tank_top": 26.8258,
+        "t_tank_bottom": 26.5347,
+        "t_collector": 27.3763,
         "t_greenhouse": 15.3725,
         "t_outdoor": 13.2806
       },
@@ -6795,9 +6795,9 @@
     {
       "time": 37020,
       "values": {
-        "t_tank_top": 28.3733,
-        "t_tank_bottom": 28.1153,
-        "t_collector": 28.8763,
+        "t_tank_top": 26.8236,
+        "t_tank_bottom": 26.5368,
+        "t_collector": 27.3661,
         "t_greenhouse": 15.3496,
         "t_outdoor": 13.2641
       },
@@ -6806,9 +6806,9 @@
     {
       "time": 37080,
       "values": {
-        "t_tank_top": 28.3759,
-        "t_tank_bottom": 28.1223,
-        "t_collector": 28.8709,
+        "t_tank_top": 26.8211,
+        "t_tank_bottom": 26.5387,
+        "t_collector": 27.3558,
         "t_greenhouse": 15.3265,
         "t_outdoor": 13.2475
       },
@@ -6817,9 +6817,9 @@
     {
       "time": 37140,
       "values": {
-        "t_tank_top": 28.3784,
-        "t_tank_bottom": 28.1292,
-        "t_collector": 28.8653,
+        "t_tank_top": 26.8185,
+        "t_tank_bottom": 26.5405,
+        "t_collector": 27.3452,
         "t_greenhouse": 15.3034,
         "t_outdoor": 13.2309
       },
@@ -6828,9 +6828,9 @@
     {
       "time": 37200,
       "values": {
-        "t_tank_top": 28.3807,
-        "t_tank_bottom": 28.136,
-        "t_collector": 28.8596,
+        "t_tank_top": 26.8157,
+        "t_tank_bottom": 26.5421,
+        "t_collector": 27.3345,
         "t_greenhouse": 15.2801,
         "t_outdoor": 13.2142
       },
@@ -6839,97 +6839,97 @@
     {
       "time": 37260,
       "values": {
-        "t_tank_top": 28.3828,
-        "t_tank_bottom": 28.1426,
-        "t_collector": 28.8536,
+        "t_tank_top": 26.8123,
+        "t_tank_bottom": 26.5435,
+        "t_collector": 27.3358,
         "t_greenhouse": 15.2568,
         "t_outdoor": 13.1975
       },
-      "mode": "solar_charging"
+      "mode": "idle"
     },
     {
       "time": 37320,
       "values": {
-        "t_tank_top": 28.3847,
-        "t_tank_bottom": 28.149,
-        "t_collector": 28.8475,
+        "t_tank_top": 26.7946,
+        "t_tank_bottom": 26.5444,
+        "t_collector": 27.6848,
         "t_greenhouse": 15.2334,
         "t_outdoor": 13.1807
       },
-      "mode": "solar_charging"
+      "mode": "idle"
     },
     {
       "time": 37380,
       "values": {
-        "t_tank_top": 28.3865,
-        "t_tank_bottom": 28.1552,
-        "t_collector": 28.8412,
+        "t_tank_top": 26.7775,
+        "t_tank_bottom": 26.5448,
+        "t_collector": 28.0214,
         "t_greenhouse": 15.2099,
         "t_outdoor": 13.1638
       },
-      "mode": "solar_charging"
+      "mode": "idle"
     },
     {
       "time": 37440,
       "values": {
-        "t_tank_top": 28.3881,
-        "t_tank_bottom": 28.1613,
-        "t_collector": 28.8348,
+        "t_tank_top": 26.761,
+        "t_tank_bottom": 26.5445,
+        "t_collector": 28.346,
         "t_greenhouse": 15.1862,
         "t_outdoor": 13.1469
       },
-      "mode": "solar_charging"
+      "mode": "idle"
     },
     {
       "time": 37500,
       "values": {
-        "t_tank_top": 28.3896,
-        "t_tank_bottom": 28.1672,
-        "t_collector": 28.8281,
+        "t_tank_top": 26.7451,
+        "t_tank_bottom": 26.5436,
+        "t_collector": 28.6586,
         "t_greenhouse": 15.1626,
         "t_outdoor": 13.1299
       },
-      "mode": "solar_charging"
+      "mode": "idle"
     },
     {
       "time": 37560,
       "values": {
-        "t_tank_top": 28.3909,
-        "t_tank_bottom": 28.173,
-        "t_collector": 28.8213,
+        "t_tank_top": 26.7297,
+        "t_tank_bottom": 26.5422,
+        "t_collector": 28.9595,
         "t_greenhouse": 15.1388,
         "t_outdoor": 13.1129
       },
-      "mode": "solar_charging"
+      "mode": "idle"
     },
     {
       "time": 37620,
       "values": {
-        "t_tank_top": 28.392,
-        "t_tank_bottom": 28.1786,
-        "t_collector": 28.8143,
+        "t_tank_top": 26.7148,
+        "t_tank_bottom": 26.5403,
+        "t_collector": 29.2489,
         "t_greenhouse": 15.1149,
         "t_outdoor": 13.0958
       },
-      "mode": "solar_charging"
+      "mode": "idle"
     },
     {
       "time": 37680,
       "values": {
-        "t_tank_top": 28.3929,
-        "t_tank_bottom": 28.184,
-        "t_collector": 28.8071,
+        "t_tank_top": 26.7003,
+        "t_tank_bottom": 26.538,
+        "t_collector": 29.5269,
         "t_greenhouse": 15.0909,
         "t_outdoor": 13.0786
       },
-      "mode": "solar_charging"
+      "mode": "idle"
     },
     {
       "time": 37740,
       "values": {
-        "t_tank_top": 28.3937,
-        "t_tank_bottom": 28.1893,
-        "t_collector": 28.7997,
+        "t_tank_top": 26.768,
+        "t_tank_bottom": 26.5367,
+        "t_collector": 28.6697,
         "t_greenhouse": 15.0669,
         "t_outdoor": 13.0614
       },
@@ -6938,9 +6938,9 @@
     {
       "time": 37800,
       "values": {
-        "t_tank_top": 28.3943,
-        "t_tank_bottom": 28.1944,
-        "t_collector": 28.7922,
+        "t_tank_top": 26.8075,
+        "t_tank_bottom": 26.5374,
+        "t_collector": 28.0954,
         "t_greenhouse": 15.0427,
         "t_outdoor": 13.0441
       },
@@ -6949,9 +6949,9 @@
     {
       "time": 37860,
       "values": {
-        "t_tank_top": 28.3947,
-        "t_tank_bottom": 28.1993,
-        "t_collector": 28.7845,
+        "t_tank_top": 26.8268,
+        "t_tank_bottom": 26.539,
+        "t_collector": 27.739,
         "t_greenhouse": 15.0185,
         "t_outdoor": 13.0268
       },
@@ -6960,9 +6960,9 @@
     {
       "time": 37920,
       "values": {
-        "t_tank_top": 28.3949,
-        "t_tank_bottom": 28.2041,
-        "t_collector": 28.7766,
+        "t_tank_top": 26.8338,
+        "t_tank_bottom": 26.541,
+        "t_collector": 27.5162,
         "t_greenhouse": 14.9941,
         "t_outdoor": 13.0094
       },
@@ -6971,9 +6971,9 @@
     {
       "time": 37980,
       "values": {
-        "t_tank_top": 28.395,
-        "t_tank_bottom": 28.2087,
-        "t_collector": 28.7685,
+        "t_tank_top": 26.8336,
+        "t_tank_bottom": 26.543,
+        "t_collector": 27.3755,
         "t_greenhouse": 14.9697,
         "t_outdoor": 12.9919
       },
@@ -6982,9 +6982,9 @@
     {
       "time": 38040,
       "values": {
-        "t_tank_top": 28.3949,
-        "t_tank_bottom": 28.2131,
-        "t_collector": 28.7603,
+        "t_tank_top": 26.829,
+        "t_tank_bottom": 26.5449,
+        "t_collector": 27.2849,
         "t_greenhouse": 14.9452,
         "t_outdoor": 12.9744
       },
@@ -6993,9 +6993,9 @@
     {
       "time": 38100,
       "values": {
-        "t_tank_top": 28.3947,
-        "t_tank_bottom": 28.2174,
-        "t_collector": 28.7519,
+        "t_tank_top": 26.8221,
+        "t_tank_bottom": 26.5465,
+        "t_collector": 27.2251,
         "t_greenhouse": 14.9206,
         "t_outdoor": 12.9568
       },
@@ -7004,9 +7004,9 @@
     {
       "time": 38160,
       "values": {
-        "t_tank_top": 28.3943,
-        "t_tank_bottom": 28.2215,
-        "t_collector": 28.7433,
+        "t_tank_top": 26.8138,
+        "t_tank_bottom": 26.5477,
+        "t_collector": 27.1839,
         "t_greenhouse": 14.896,
         "t_outdoor": 12.9392
       },
@@ -7015,9 +7015,9 @@
     {
       "time": 38220,
       "values": {
-        "t_tank_top": 28.3937,
-        "t_tank_bottom": 28.2254,
-        "t_collector": 28.7345,
+        "t_tank_top": 26.8047,
+        "t_tank_bottom": 26.5486,
+        "t_collector": 27.1541,
         "t_greenhouse": 14.8712,
         "t_outdoor": 12.9215
       },
@@ -7026,152 +7026,152 @@
     {
       "time": 38280,
       "values": {
-        "t_tank_top": 28.3929,
-        "t_tank_bottom": 28.2292,
-        "t_collector": 28.7255,
+        "t_tank_top": 26.7939,
+        "t_tank_bottom": 26.5491,
+        "t_collector": 27.1812,
         "t_greenhouse": 14.8464,
         "t_outdoor": 12.9038
       },
-      "mode": "solar_charging"
+      "mode": "idle"
     },
     {
       "time": 38340,
       "values": {
-        "t_tank_top": 28.392,
-        "t_tank_bottom": 28.2328,
-        "t_collector": 28.7164,
+        "t_tank_top": 26.7769,
+        "t_tank_bottom": 26.549,
+        "t_collector": 27.4277,
         "t_greenhouse": 14.8214,
         "t_outdoor": 12.886
       },
-      "mode": "solar_charging"
+      "mode": "idle"
     },
     {
       "time": 38400,
       "values": {
-        "t_tank_top": 28.3909,
-        "t_tank_bottom": 28.2363,
-        "t_collector": 28.7071,
+        "t_tank_top": 26.7604,
+        "t_tank_bottom": 26.5484,
+        "t_collector": 27.6634,
         "t_greenhouse": 14.7964,
         "t_outdoor": 12.8682
       },
-      "mode": "solar_charging"
+      "mode": "idle"
     },
     {
       "time": 38460,
       "values": {
-        "t_tank_top": 28.3896,
-        "t_tank_bottom": 28.2395,
-        "t_collector": 28.6976,
+        "t_tank_top": 26.7444,
+        "t_tank_bottom": 26.5472,
+        "t_collector": 27.8887,
         "t_greenhouse": 14.7713,
         "t_outdoor": 12.8503
       },
-      "mode": "solar_charging"
+      "mode": "idle"
     },
     {
       "time": 38520,
       "values": {
-        "t_tank_top": 28.3882,
-        "t_tank_bottom": 28.2426,
-        "t_collector": 28.6879,
+        "t_tank_top": 26.729,
+        "t_tank_bottom": 26.5455,
+        "t_collector": 28.1037,
         "t_greenhouse": 14.7461,
         "t_outdoor": 12.8323
       },
-      "mode": "solar_charging"
+      "mode": "idle"
     },
     {
       "time": 38580,
       "values": {
-        "t_tank_top": 28.3865,
-        "t_tank_bottom": 28.2456,
-        "t_collector": 28.6781,
+        "t_tank_top": 26.7141,
+        "t_tank_bottom": 26.5433,
+        "t_collector": 28.3086,
         "t_greenhouse": 14.7208,
         "t_outdoor": 12.8143
       },
-      "mode": "solar_charging"
+      "mode": "idle"
     },
     {
       "time": 38640,
       "values": {
-        "t_tank_top": 28.3848,
-        "t_tank_bottom": 28.2484,
-        "t_collector": 28.6681,
+        "t_tank_top": 26.6995,
+        "t_tank_bottom": 26.5406,
+        "t_collector": 28.5035,
         "t_greenhouse": 14.6955,
         "t_outdoor": 12.7963
       },
-      "mode": "solar_charging"
+      "mode": "idle"
     },
     {
       "time": 38700,
       "values": {
-        "t_tank_top": 28.3828,
-        "t_tank_bottom": 28.251,
-        "t_collector": 28.6579,
+        "t_tank_top": 26.6854,
+        "t_tank_bottom": 26.5375,
+        "t_collector": 28.6887,
         "t_greenhouse": 14.67,
         "t_outdoor": 12.7782
       },
-      "mode": "solar_charging"
+      "mode": "idle"
     },
     {
       "time": 38760,
       "values": {
-        "t_tank_top": 28.3807,
-        "t_tank_bottom": 28.2534,
-        "t_collector": 28.6475,
+        "t_tank_top": 26.6717,
+        "t_tank_bottom": 26.5341,
+        "t_collector": 28.8642,
         "t_greenhouse": 14.6445,
         "t_outdoor": 12.76
       },
-      "mode": "solar_charging"
+      "mode": "idle"
     },
     {
       "time": 38820,
       "values": {
-        "t_tank_top": 28.3784,
-        "t_tank_bottom": 28.2557,
-        "t_collector": 28.637,
+        "t_tank_top": 26.6583,
+        "t_tank_bottom": 26.5303,
+        "t_collector": 29.0303,
         "t_greenhouse": 14.6189,
         "t_outdoor": 12.7418
       },
-      "mode": "solar_charging"
+      "mode": "idle"
     },
     {
       "time": 38880,
       "values": {
-        "t_tank_top": 28.3759,
-        "t_tank_bottom": 28.2578,
-        "t_collector": 28.6263,
+        "t_tank_top": 26.6452,
+        "t_tank_bottom": 26.5261,
+        "t_collector": 29.1871,
         "t_greenhouse": 14.5932,
         "t_outdoor": 12.7235
       },
-      "mode": "solar_charging"
+      "mode": "idle"
     },
     {
       "time": 38940,
       "values": {
-        "t_tank_top": 28.3733,
-        "t_tank_bottom": 28.2597,
-        "t_collector": 28.6154,
+        "t_tank_top": 26.6325,
+        "t_tank_bottom": 26.5216,
+        "t_collector": 29.3348,
         "t_greenhouse": 14.5675,
         "t_outdoor": 12.7052
       },
-      "mode": "solar_charging"
+      "mode": "idle"
     },
     {
       "time": 39000,
       "values": {
-        "t_tank_top": 28.3705,
-        "t_tank_bottom": 28.2615,
-        "t_collector": 28.6043,
+        "t_tank_top": 26.62,
+        "t_tank_bottom": 26.5169,
+        "t_collector": 29.4735,
         "t_greenhouse": 14.5416,
         "t_outdoor": 12.6868
       },
-      "mode": "solar_charging"
+      "mode": "idle"
     },
     {
       "time": 39060,
       "values": {
-        "t_tank_top": 28.3675,
-        "t_tank_bottom": 28.2631,
-        "t_collector": 28.593,
+        "t_tank_top": 26.6706,
+        "t_tank_bottom": 26.5127,
+        "t_collector": 28.7689,
         "t_greenhouse": 14.5157,
         "t_outdoor": 12.6684
       },
@@ -7180,86 +7180,86 @@
     {
       "time": 39120,
       "values": {
-        "t_tank_top": 28.3628,
-        "t_tank_bottom": 28.2645,
-        "t_collector": 28.6666,
+        "t_tank_top": 26.7166,
+        "t_tank_bottom": 26.5107,
+        "t_collector": 28.0361,
         "t_greenhouse": 14.4897,
         "t_outdoor": 12.6499
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 39180,
       "values": {
-        "t_tank_top": 28.3572,
-        "t_tank_bottom": 28.2657,
-        "t_collector": 28.7981,
+        "t_tank_top": 26.7369,
+        "t_tank_bottom": 26.5099,
+        "t_collector": 27.5813,
         "t_greenhouse": 14.4636,
         "t_outdoor": 12.6314
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 39240,
       "values": {
-        "t_tank_top": 28.3517,
-        "t_tank_bottom": 28.2666,
-        "t_collector": 28.9209,
+        "t_tank_top": 26.7419,
+        "t_tank_bottom": 26.5095,
+        "t_collector": 27.2973,
         "t_greenhouse": 14.4374,
         "t_outdoor": 12.6128
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 39300,
       "values": {
-        "t_tank_top": 28.3465,
-        "t_tank_bottom": 28.2673,
-        "t_collector": 29.0351,
+        "t_tank_top": 26.7377,
+        "t_tank_bottom": 26.5091,
+        "t_collector": 27.118,
         "t_greenhouse": 14.4112,
         "t_outdoor": 12.5942
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 39360,
       "values": {
-        "t_tank_top": 28.3415,
-        "t_tank_bottom": 28.2678,
-        "t_collector": 29.141,
+        "t_tank_top": 26.7284,
+        "t_tank_bottom": 26.5085,
+        "t_collector": 27.0027,
         "t_greenhouse": 14.3849,
         "t_outdoor": 12.5755
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 39420,
       "values": {
-        "t_tank_top": 28.3367,
-        "t_tank_bottom": 28.2681,
-        "t_collector": 29.2385,
+        "t_tank_top": 26.716,
+        "t_tank_bottom": 26.5075,
+        "t_collector": 26.9267,
         "t_greenhouse": 14.3585,
         "t_outdoor": 12.5568
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 39480,
       "values": {
-        "t_tank_top": 28.3321,
-        "t_tank_bottom": 28.2683,
-        "t_collector": 29.3279,
+        "t_tank_top": 26.7021,
+        "t_tank_bottom": 26.506,
+        "t_collector": 26.8745,
         "t_greenhouse": 14.332,
         "t_outdoor": 12.538
       },
-      "mode": "idle"
+      "mode": "solar_charging"
     },
     {
       "time": 39540,
       "values": {
-        "t_tank_top": 28.3276,
-        "t_tank_bottom": 28.2682,
-        "t_collector": 29.4093,
+        "t_tank_top": 26.6874,
+        "t_tank_bottom": 26.5041,
+        "t_collector": 26.8498,
         "t_greenhouse": 14.3054,
         "t_outdoor": 12.5192
       },
@@ -7268,9 +7268,9 @@
     {
       "time": 39600,
       "values": {
-        "t_tank_top": 28.3233,
-        "t_tank_bottom": 28.268,
-        "t_collector": 29.4829,
+        "t_tank_top": 26.6723,
+        "t_tank_bottom": 26.5017,
+        "t_collector": 26.9689,
         "t_greenhouse": 14.2788,
         "t_outdoor": 12.5003
       },
@@ -7279,9 +7279,9 @@
     {
       "time": 39660,
       "values": {
-        "t_tank_top": 28.3191,
-        "t_tank_bottom": 28.2677,
-        "t_collector": 29.5487,
+        "t_tank_top": 26.6576,
+        "t_tank_bottom": 26.4989,
+        "t_collector": 27.0795,
         "t_greenhouse": 14.2521,
         "t_outdoor": 12.4814
       },
@@ -7290,9 +7290,9 @@
     {
       "time": 39720,
       "values": {
-        "t_tank_top": 28.315,
-        "t_tank_bottom": 28.2672,
-        "t_collector": 29.607,
+        "t_tank_top": 26.6434,
+        "t_tank_bottom": 26.4957,
+        "t_collector": 27.1816,
         "t_greenhouse": 14.2253,
         "t_outdoor": 12.4624
       },
@@ -7301,9 +7301,9 @@
     {
       "time": 39780,
       "values": {
-        "t_tank_top": 28.3111,
-        "t_tank_bottom": 28.2666,
-        "t_collector": 29.6578,
+        "t_tank_top": 26.6295,
+        "t_tank_bottom": 26.492,
+        "t_collector": 27.2755,
         "t_greenhouse": 14.1985,
         "t_outdoor": 12.4434
       },
@@ -7312,9 +7312,9 @@
     {
       "time": 39840,
       "values": {
-        "t_tank_top": 28.3073,
-        "t_tank_bottom": 28.2659,
-        "t_collector": 29.7012,
+        "t_tank_top": 26.6159,
+        "t_tank_bottom": 26.488,
+        "t_collector": 27.3614,
         "t_greenhouse": 14.1715,
         "t_outdoor": 12.4244
       },
@@ -7323,9 +7323,9 @@
     {
       "time": 39900,
       "values": {
-        "t_tank_top": 28.3035,
-        "t_tank_bottom": 28.265,
-        "t_collector": 29.7374,
+        "t_tank_top": 26.6027,
+        "t_tank_bottom": 26.4837,
+        "t_collector": 27.4392,
         "t_greenhouse": 14.1445,
         "t_outdoor": 12.4053
       },
@@ -7334,9 +7334,9 @@
     {
       "time": 39960,
       "values": {
-        "t_tank_top": 28.2999,
-        "t_tank_bottom": 28.2641,
-        "t_collector": 29.7665,
+        "t_tank_top": 26.5898,
+        "t_tank_bottom": 26.4791,
+        "t_collector": 27.5092,
         "t_greenhouse": 14.1174,
         "t_outdoor": 12.3861
       },
@@ -7345,9 +7345,9 @@
     {
       "time": 40020,
       "values": {
-        "t_tank_top": 28.2964,
-        "t_tank_bottom": 28.263,
-        "t_collector": 29.7887,
+        "t_tank_top": 26.5771,
+        "t_tank_bottom": 26.4741,
+        "t_collector": 27.5715,
         "t_greenhouse": 14.0903,
         "t_outdoor": 12.3669
       },
@@ -7356,9 +7356,9 @@
     {
       "time": 40080,
       "values": {
-        "t_tank_top": 28.293,
-        "t_tank_bottom": 28.2619,
-        "t_collector": 29.804,
+        "t_tank_top": 26.5648,
+        "t_tank_bottom": 26.4689,
+        "t_collector": 27.6263,
         "t_greenhouse": 14.0631,
         "t_outdoor": 12.3477
       },
@@ -7367,9 +7367,9 @@
     {
       "time": 40140,
       "values": {
-        "t_tank_top": 28.2896,
-        "t_tank_bottom": 28.2607,
-        "t_collector": 29.8126,
+        "t_tank_top": 26.5526,
+        "t_tank_bottom": 26.4634,
+        "t_collector": 27.6736,
         "t_greenhouse": 14.0358,
         "t_outdoor": 12.3284
       },
@@ -7378,9 +7378,9 @@
     {
       "time": 40200,
       "values": {
-        "t_tank_top": 28.2863,
-        "t_tank_bottom": 28.2594,
-        "t_collector": 29.8145,
+        "t_tank_top": 26.5407,
+        "t_tank_bottom": 26.4577,
+        "t_collector": 27.7136,
         "t_greenhouse": 14.0084,
         "t_outdoor": 12.3091
       },
@@ -7389,9 +7389,9 @@
     {
       "time": 40260,
       "values": {
-        "t_tank_top": 28.2831,
-        "t_tank_bottom": 28.2581,
-        "t_collector": 29.81,
+        "t_tank_top": 26.529,
+        "t_tank_bottom": 26.4518,
+        "t_collector": 27.7464,
         "t_greenhouse": 13.981,
         "t_outdoor": 12.2897
       },
@@ -7400,9 +7400,9 @@
     {
       "time": 40320,
       "values": {
-        "t_tank_top": 28.2799,
-        "t_tank_bottom": 28.2567,
-        "t_collector": 29.799,
+        "t_tank_top": 26.5175,
+        "t_tank_bottom": 26.4456,
+        "t_collector": 27.7722,
         "t_greenhouse": 13.9534,
         "t_outdoor": 12.2703
       },
@@ -7411,9 +7411,9 @@
     {
       "time": 40380,
       "values": {
-        "t_tank_top": 28.2768,
-        "t_tank_bottom": 28.2552,
-        "t_collector": 29.7818,
+        "t_tank_top": 26.5062,
+        "t_tank_bottom": 26.4393,
+        "t_collector": 27.791,
         "t_greenhouse": 13.9259,
         "t_outdoor": 12.2508
       },
@@ -7422,9 +7422,9 @@
     {
       "time": 40440,
       "values": {
-        "t_tank_top": 28.2738,
-        "t_tank_bottom": 28.2536,
-        "t_collector": 29.7584,
+        "t_tank_top": 26.495,
+        "t_tank_bottom": 26.4328,
+        "t_collector": 27.803,
         "t_greenhouse": 13.8982,
         "t_outdoor": 12.2313
       },
@@ -7433,9 +7433,9 @@
     {
       "time": 40500,
       "values": {
-        "t_tank_top": 28.2708,
-        "t_tank_bottom": 28.252,
-        "t_collector": 29.7289,
+        "t_tank_top": 26.484,
+        "t_tank_bottom": 26.4261,
+        "t_collector": 27.8083,
         "t_greenhouse": 13.8705,
         "t_outdoor": 12.2118
       },
@@ -7444,9 +7444,9 @@
     {
       "time": 40560,
       "values": {
-        "t_tank_top": 28.2678,
-        "t_tank_bottom": 28.2504,
-        "t_collector": 29.6934,
+        "t_tank_top": 26.4731,
+        "t_tank_bottom": 26.4193,
+        "t_collector": 27.807,
         "t_greenhouse": 13.8427,
         "t_outdoor": 12.1922
       },
@@ -7455,9 +7455,9 @@
     {
       "time": 40620,
       "values": {
-        "t_tank_top": 28.2649,
-        "t_tank_bottom": 28.2487,
-        "t_collector": 29.652,
+        "t_tank_top": 26.4624,
+        "t_tank_bottom": 26.4123,
+        "t_collector": 27.7992,
         "t_greenhouse": 13.8148,
         "t_outdoor": 12.1726
       },
@@ -7466,9 +7466,9 @@
     {
       "time": 40680,
       "values": {
-        "t_tank_top": 28.262,
-        "t_tank_bottom": 28.2469,
-        "t_collector": 29.6049,
+        "t_tank_top": 26.4518,
+        "t_tank_bottom": 26.4052,
+        "t_collector": 27.7851,
         "t_greenhouse": 13.7869,
         "t_outdoor": 12.1529
       },
@@ -7477,9 +7477,9 @@
     {
       "time": 40740,
       "values": {
-        "t_tank_top": 28.2592,
-        "t_tank_bottom": 28.2452,
-        "t_collector": 29.5521,
+        "t_tank_top": 26.4413,
+        "t_tank_bottom": 26.3979,
+        "t_collector": 27.7646,
         "t_greenhouse": 13.7589,
         "t_outdoor": 12.1332
       },
@@ -7488,9 +7488,9 @@
     {
       "time": 40800,
       "values": {
-        "t_tank_top": 28.2564,
-        "t_tank_bottom": 28.2433,
-        "t_collector": 29.4938,
+        "t_tank_top": 26.4309,
+        "t_tank_bottom": 26.3906,
+        "t_collector": 27.7381,
         "t_greenhouse": 13.7309,
         "t_outdoor": 12.1134
       },
@@ -7499,9 +7499,9 @@
     {
       "time": 40860,
       "values": {
-        "t_tank_top": 28.2536,
-        "t_tank_bottom": 28.2415,
-        "t_collector": 29.4299,
+        "t_tank_top": 26.4206,
+        "t_tank_bottom": 26.3831,
+        "t_collector": 27.7055,
         "t_greenhouse": 13.7027,
         "t_outdoor": 12.0936
       },
@@ -7510,9 +7510,9 @@
     {
       "time": 40920,
       "values": {
-        "t_tank_top": 28.2509,
-        "t_tank_bottom": 28.2396,
-        "t_collector": 29.3607,
+        "t_tank_top": 26.4104,
+        "t_tank_bottom": 26.3755,
+        "t_collector": 27.6669,
         "t_greenhouse": 13.6745,
         "t_outdoor": 12.0738
       },
@@ -7521,9 +7521,9 @@
     {
       "time": 40980,
       "values": {
-        "t_tank_top": 28.2482,
-        "t_tank_bottom": 28.2376,
-        "t_collector": 29.2862,
+        "t_tank_top": 26.4003,
+        "t_tank_bottom": 26.3678,
+        "t_collector": 27.6225,
         "t_greenhouse": 13.6463,
         "t_outdoor": 12.0539
       },
@@ -7532,9 +7532,9 @@
     {
       "time": 41040,
       "values": {
-        "t_tank_top": 28.2455,
-        "t_tank_bottom": 28.2357,
-        "t_collector": 29.2064,
+        "t_tank_top": 26.3903,
+        "t_tank_bottom": 26.36,
+        "t_collector": 27.5724,
         "t_greenhouse": 13.6179,
         "t_outdoor": 12.034
       },
@@ -7543,9 +7543,9 @@
     {
       "time": 41100,
       "values": {
-        "t_tank_top": 28.2428,
-        "t_tank_bottom": 28.2337,
-        "t_collector": 29.1216,
+        "t_tank_top": 26.3803,
+        "t_tank_bottom": 26.3522,
+        "t_collector": 27.5166,
         "t_greenhouse": 13.5896,
         "t_outdoor": 12.0141
       },
@@ -7554,9 +7554,9 @@
     {
       "time": 41160,
       "values": {
-        "t_tank_top": 28.2402,
-        "t_tank_bottom": 28.2317,
-        "t_collector": 29.0317,
+        "t_tank_top": 26.3704,
+        "t_tank_bottom": 26.3442,
+        "t_collector": 27.4553,
         "t_greenhouse": 13.5611,
         "t_outdoor": 11.9941
       },
@@ -7565,9 +7565,9 @@
     {
       "time": 41220,
       "values": {
-        "t_tank_top": 28.2376,
-        "t_tank_bottom": 28.2297,
-        "t_collector": 28.9369,
+        "t_tank_top": 26.3606,
+        "t_tank_bottom": 26.3362,
+        "t_collector": 27.3885,
         "t_greenhouse": 13.5326,
         "t_outdoor": 11.9741
       },
@@ -7576,9 +7576,9 @@
     {
       "time": 41280,
       "values": {
-        "t_tank_top": 28.235,
-        "t_tank_bottom": 28.2276,
-        "t_collector": 28.8372,
+        "t_tank_top": 26.3508,
+        "t_tank_bottom": 26.3281,
+        "t_collector": 27.3163,
         "t_greenhouse": 13.504,
         "t_outdoor": 11.954
       },
@@ -7587,9 +7587,9 @@
     {
       "time": 41340,
       "values": {
-        "t_tank_top": 28.2324,
-        "t_tank_bottom": 28.2255,
-        "t_collector": 28.7327,
+        "t_tank_top": 26.3411,
+        "t_tank_bottom": 26.32,
+        "t_collector": 27.2389,
         "t_greenhouse": 13.4754,
         "t_outdoor": 11.9339
       },
@@ -7598,9 +7598,9 @@
     {
       "time": 41400,
       "values": {
-        "t_tank_top": 28.2298,
-        "t_tank_bottom": 28.2234,
-        "t_collector": 28.6236,
+        "t_tank_top": 26.3314,
+        "t_tank_bottom": 26.3118,
+        "t_collector": 27.1564,
         "t_greenhouse": 13.4467,
         "t_outdoor": 11.9138
       },
@@ -7609,9 +7609,9 @@
     {
       "time": 41460,
       "values": {
-        "t_tank_top": 28.2272,
-        "t_tank_bottom": 28.2213,
-        "t_collector": 28.5098,
+        "t_tank_top": 26.3218,
+        "t_tank_bottom": 26.3035,
+        "t_collector": 27.0687,
         "t_greenhouse": 13.4179,
         "t_outdoor": 11.8936
       },
@@ -7620,9 +7620,9 @@
     {
       "time": 41520,
       "values": {
-        "t_tank_top": 28.2247,
-        "t_tank_bottom": 28.2192,
-        "t_collector": 28.3915,
+        "t_tank_top": 26.3122,
+        "t_tank_bottom": 26.2952,
+        "t_collector": 26.976,
         "t_greenhouse": 13.3891,
         "t_outdoor": 11.8734
       },
@@ -7631,9 +7631,9 @@
     {
       "time": 41580,
       "values": {
-        "t_tank_top": 28.2221,
-        "t_tank_bottom": 28.217,
-        "t_collector": 28.2687,
+        "t_tank_top": 26.3026,
+        "t_tank_bottom": 26.2868,
+        "t_collector": 26.8784,
         "t_greenhouse": 13.3602,
         "t_outdoor": 11.8531
       },
@@ -7642,9 +7642,9 @@
     {
       "time": 41640,
       "values": {
-        "t_tank_top": 28.2196,
-        "t_tank_bottom": 28.2149,
-        "t_collector": 28.1415,
+        "t_tank_top": 26.2931,
+        "t_tank_bottom": 26.2784,
+        "t_collector": 26.776,
         "t_greenhouse": 13.3312,
         "t_outdoor": 11.8328
       },
@@ -7653,9 +7653,9 @@
     {
       "time": 41700,
       "values": {
-        "t_tank_top": 28.2171,
-        "t_tank_bottom": 28.2127,
-        "t_collector": 28.0101,
+        "t_tank_top": 26.2836,
+        "t_tank_bottom": 26.2699,
+        "t_collector": 26.6688,
         "t_greenhouse": 13.3022,
         "t_outdoor": 11.8125
       },
@@ -7664,9 +7664,9 @@
     {
       "time": 41760,
       "values": {
-        "t_tank_top": 28.2146,
-        "t_tank_bottom": 28.2105,
-        "t_collector": 27.8744,
+        "t_tank_top": 26.2742,
+        "t_tank_bottom": 26.2614,
+        "t_collector": 26.557,
         "t_greenhouse": 13.2732,
         "t_outdoor": 11.7922
       },
@@ -7675,9 +7675,9 @@
     {
       "time": 41820,
       "values": {
-        "t_tank_top": 28.2121,
-        "t_tank_bottom": 28.2083,
-        "t_collector": 27.7345,
+        "t_tank_top": 26.2647,
+        "t_tank_bottom": 26.2528,
+        "t_collector": 26.4406,
         "t_greenhouse": 13.244,
         "t_outdoor": 11.7718
       },
@@ -7686,9 +7686,9 @@
     {
       "time": 41880,
       "values": {
-        "t_tank_top": 28.2096,
-        "t_tank_bottom": 28.206,
-        "t_collector": 27.5906,
+        "t_tank_top": 26.2553,
+        "t_tank_bottom": 26.2443,
+        "t_collector": 26.3197,
         "t_greenhouse": 13.2148,
         "t_outdoor": 11.7514
       },
@@ -7697,9 +7697,9 @@
     {
       "time": 41940,
       "values": {
-        "t_tank_top": 28.2071,
-        "t_tank_bottom": 28.2038,
-        "t_collector": 27.4426,
+        "t_tank_top": 26.2459,
+        "t_tank_bottom": 26.2356,
+        "t_collector": 26.1943,
         "t_greenhouse": 13.1856,
         "t_outdoor": 11.7309
       },
@@ -7708,9 +7708,9 @@
     {
       "time": 42000,
       "values": {
-        "t_tank_top": 28.2046,
-        "t_tank_bottom": 28.2016,
-        "t_collector": 27.2907,
+        "t_tank_top": 26.2365,
+        "t_tank_bottom": 26.227,
+        "t_collector": 26.0646,
         "t_greenhouse": 13.1563,
         "t_outdoor": 11.7104
       },
@@ -7719,9 +7719,9 @@
     {
       "time": 42060,
       "values": {
-        "t_tank_top": 28.2022,
-        "t_tank_bottom": 28.1993,
-        "t_collector": 27.1349,
+        "t_tank_top": 26.2272,
+        "t_tank_bottom": 26.2183,
+        "t_collector": 25.9306,
         "t_greenhouse": 13.1269,
         "t_outdoor": 11.6899
       },
@@ -7730,9 +7730,9 @@
     {
       "time": 42120,
       "values": {
-        "t_tank_top": 28.1997,
-        "t_tank_bottom": 28.197,
-        "t_collector": 26.9753,
+        "t_tank_top": 26.2178,
+        "t_tank_bottom": 26.2096,
+        "t_collector": 25.7924,
         "t_greenhouse": 13.0975,
         "t_outdoor": 11.6694
       },
@@ -7741,9 +7741,9 @@
     {
       "time": 42180,
       "values": {
-        "t_tank_top": 28.1972,
-        "t_tank_bottom": 28.1947,
-        "t_collector": 26.812,
+        "t_tank_top": 26.2085,
+        "t_tank_bottom": 26.2008,
+        "t_collector": 25.6501,
         "t_greenhouse": 13.0681,
         "t_outdoor": 11.6488
       },
@@ -7752,9 +7752,9 @@
     {
       "time": 42240,
       "values": {
-        "t_tank_top": 28.1948,
-        "t_tank_bottom": 28.1925,
-        "t_collector": 26.6449,
+        "t_tank_top": 26.1992,
+        "t_tank_bottom": 26.192,
+        "t_collector": 25.5037,
         "t_greenhouse": 13.0385,
         "t_outdoor": 11.6282
       },
@@ -7763,9 +7763,9 @@
     {
       "time": 42300,
       "values": {
-        "t_tank_top": 28.1923,
-        "t_tank_bottom": 28.1902,
-        "t_collector": 26.4742,
+        "t_tank_top": 26.1899,
+        "t_tank_bottom": 26.1832,
+        "t_collector": 25.3534,
         "t_greenhouse": 13.009,
         "t_outdoor": 11.6075
       },
@@ -7774,9 +7774,9 @@
     {
       "time": 42360,
       "values": {
-        "t_tank_top": 28.1899,
-        "t_tank_bottom": 28.1879,
-        "t_collector": 26.3,
+        "t_tank_top": 26.1806,
+        "t_tank_bottom": 26.1744,
+        "t_collector": 25.1991,
         "t_greenhouse": 12.9793,
         "t_outdoor": 11.5869
       },
@@ -7785,9 +7785,9 @@
     {
       "time": 42420,
       "values": {
-        "t_tank_top": 28.1874,
-        "t_tank_bottom": 28.1856,
-        "t_collector": 26.1223,
+        "t_tank_top": 26.1713,
+        "t_tank_bottom": 26.1656,
+        "t_collector": 25.041,
         "t_greenhouse": 12.9496,
         "t_outdoor": 11.5662
       },
@@ -7796,9 +7796,9 @@
     {
       "time": 42480,
       "values": {
-        "t_tank_top": 28.185,
-        "t_tank_bottom": 28.1832,
-        "t_collector": 25.9411,
+        "t_tank_top": 26.1621,
+        "t_tank_bottom": 26.1567,
+        "t_collector": 24.879,
         "t_greenhouse": 12.9199,
         "t_outdoor": 11.5454
       },
@@ -7807,9 +7807,9 @@
     {
       "time": 42540,
       "values": {
-        "t_tank_top": 28.1825,
-        "t_tank_bottom": 28.1809,
-        "t_collector": 25.7566,
+        "t_tank_top": 26.1528,
+        "t_tank_bottom": 26.1478,
+        "t_collector": 24.7134,
         "t_greenhouse": 12.8901,
         "t_outdoor": 11.5247
       },
@@ -7818,9 +7818,9 @@
     {
       "time": 42600,
       "values": {
-        "t_tank_top": 28.1801,
-        "t_tank_bottom": 28.1786,
-        "t_collector": 25.5687,
+        "t_tank_top": 26.1435,
+        "t_tank_bottom": 26.1389,
+        "t_collector": 24.5441,
         "t_greenhouse": 12.8603,
         "t_outdoor": 11.5039
       },
@@ -7829,9 +7829,9 @@
     {
       "time": 42660,
       "values": {
-        "t_tank_top": 28.1776,
-        "t_tank_bottom": 28.1762,
-        "t_collector": 25.3776,
+        "t_tank_top": 26.1343,
+        "t_tank_bottom": 26.1299,
+        "t_collector": 24.3712,
         "t_greenhouse": 12.8304,
         "t_outdoor": 11.4831
       },
@@ -7840,9 +7840,9 @@
     {
       "time": 42720,
       "values": {
-        "t_tank_top": 28.1752,
-        "t_tank_bottom": 28.1739,
-        "t_collector": 25.1833,
+        "t_tank_top": 26.125,
+        "t_tank_bottom": 26.121,
+        "t_collector": 24.1948,
         "t_greenhouse": 12.8004,
         "t_outdoor": 11.4622
       },
@@ -7851,9 +7851,9 @@
     {
       "time": 42780,
       "values": {
-        "t_tank_top": 28.1728,
-        "t_tank_bottom": 28.1715,
-        "t_collector": 24.9858,
+        "t_tank_top": 26.1158,
+        "t_tank_bottom": 26.112,
+        "t_collector": 24.0149,
         "t_greenhouse": 12.7704,
         "t_outdoor": 11.4413
       },
@@ -7862,9 +7862,9 @@
     {
       "time": 42840,
       "values": {
-        "t_tank_top": 28.1703,
-        "t_tank_bottom": 28.1692,
-        "t_collector": 24.7852,
+        "t_tank_top": 26.1065,
+        "t_tank_bottom": 26.103,
+        "t_collector": 23.8316,
         "t_greenhouse": 12.7404,
         "t_outdoor": 11.4204
       },
@@ -7873,9 +7873,9 @@
     {
       "time": 42900,
       "values": {
-        "t_tank_top": 28.1679,
-        "t_tank_bottom": 28.1668,
-        "t_collector": 24.5816,
+        "t_tank_top": 26.0973,
+        "t_tank_bottom": 26.094,
+        "t_collector": 23.6449,
         "t_greenhouse": 12.7103,
         "t_outdoor": 11.3995
       },
@@ -7884,9 +7884,9 @@
     {
       "time": 42960,
       "values": {
-        "t_tank_top": 28.1654,
-        "t_tank_bottom": 28.1645,
-        "t_collector": 24.375,
+        "t_tank_top": 26.088,
+        "t_tank_bottom": 26.085,
+        "t_collector": 23.455,
         "t_greenhouse": 12.6801,
         "t_outdoor": 11.3785
       },
@@ -7895,9 +7895,9 @@
     {
       "time": 43020,
       "values": {
-        "t_tank_top": 28.163,
-        "t_tank_bottom": 28.1621,
-        "t_collector": 24.1655,
+        "t_tank_top": 26.0788,
+        "t_tank_bottom": 26.076,
+        "t_collector": 23.2619,
         "t_greenhouse": 12.65,
         "t_outdoor": 11.3576
       },
@@ -7906,9 +7906,9 @@
     {
       "time": 43080,
       "values": {
-        "t_tank_top": 28.1605,
-        "t_tank_bottom": 28.1597,
-        "t_collector": 23.9531,
+        "t_tank_top": 26.0695,
+        "t_tank_bottom": 26.0669,
+        "t_collector": 23.0655,
         "t_greenhouse": 12.6197,
         "t_outdoor": 11.3365
       },
@@ -7917,9 +7917,9 @@
     {
       "time": 43140,
       "values": {
-        "t_tank_top": 28.1581,
-        "t_tank_bottom": 28.1573,
-        "t_collector": 23.7378,
+        "t_tank_top": 26.0603,
+        "t_tank_bottom": 26.0579,
+        "t_collector": 22.8661,
         "t_greenhouse": 12.5894,
         "t_outdoor": 11.3155
       },
@@ -7928,9 +7928,9 @@
     {
       "time": 43200,
       "values": {
-        "t_tank_top": 28.1557,
-        "t_tank_bottom": 28.1549,
-        "t_collector": 23.5198,
+        "t_tank_top": 26.051,
+        "t_tank_bottom": 26.0488,
+        "t_collector": 22.6635,
         "t_greenhouse": 12.5591,
         "t_outdoor": 11.2944
       },
@@ -7946,27 +7946,51 @@
     },
     {
       "kind": "sim",
-      "time": 584,
-      "text": "solar_charging → idle | tank stopped rising (peak T_top=10.5°C, now 11.2°C, drop -0.7°C) | T_coll=11.3 T_top=11.2 T_bot=9.8 T_gh=10.8 T_out=8.9",
+      "time": 576,
+      "text": "solar_charging → idle | tank stopped rising (peak T_top=10.5°C, now 11.2°C, drop -0.7°C) | T_coll=11.2 T_top=11.2 T_bot=9.7 T_gh=10.8 T_out=8.9",
       "mode": "idle"
     },
     {
       "kind": "sim",
-      "time": 715,
-      "text": "idle → solar_charging | delta=3.0°C > 10°C threshold | T_coll=12.9 T_top=11.1 T_bot=9.9 T_gh=10.8 T_out=9.0",
+      "time": 707,
+      "text": "idle → solar_charging | delta=3.0°C > 10°C threshold | T_coll=12.9 T_top=11.1 T_bot=9.8 T_gh=10.8 T_out=9.0",
       "mode": "solar_charging"
     },
     {
       "kind": "sim",
-      "time": 39086,
-      "text": "solar_charging → idle | tank stopped rising (peak T_top=28.3°C, now 28.4°C, drop -0.0°C) | T_coll=28.6 T_top=28.4 T_bot=28.3 T_gh=14.5 T_out=12.7",
+      "time": 37258,
+      "text": "solar_charging → idle | tank stopped rising (peak T_top=26.7°C, now 26.8°C, drop -0.1°C) | T_coll=27.3 T_top=26.8 T_bot=26.5 T_gh=15.3 T_out=13.2",
+      "mode": "idle"
+    },
+    {
+      "kind": "sim",
+      "time": 37683,
+      "text": "idle → solar_charging | delta=3.0°C > 10°C threshold | T_coll=29.5 T_top=26.7 T_bot=26.5 T_gh=15.1 T_out=13.1",
+      "mode": "solar_charging"
+    },
+    {
+      "kind": "sim",
+      "time": 38269,
+      "text": "solar_charging → idle | tank stopped rising (peak T_top=26.7°C, now 26.8°C, drop -0.1°C) | T_coll=27.1 T_top=26.8 T_bot=26.5 T_gh=14.9 T_out=12.9",
+      "mode": "idle"
+    },
+    {
+      "kind": "sim",
+      "time": 39019,
+      "text": "idle → solar_charging | delta=3.0°C > 10°C threshold | T_coll=29.5 T_top=26.6 T_bot=26.5 T_gh=14.5 T_out=12.7",
+      "mode": "solar_charging"
+    },
+    {
+      "kind": "sim",
+      "time": 39535,
+      "text": "solar_charging → idle | tank stopped rising (peak T_top=26.6°C, now 26.7°C, drop -0.1°C) | T_coll=26.8 T_top=26.7 T_bot=26.5 T_gh=14.3 T_out=12.5",
       "mode": "idle"
     }
   ],
   "final_model_state": {
-    "t_tank_top": 28.1557,
-    "t_tank_bottom": 28.1549,
-    "t_collector": 23.5198,
+    "t_tank_top": 26.051,
+    "t_tank_bottom": 26.0488,
+    "t_collector": 22.6635,
     "t_greenhouse": 12.5591,
     "t_outdoor": 11.2944,
     "irradiance": 0.0312,
@@ -7974,7 +7998,7 @@
   },
   "final_controller_state": {
     "currentMode": "idle",
-    "modeStartTime": 39086,
+    "modeStartTime": 39535,
     "collectorsDrained": false,
     "lastRefillAttempt": 0,
     "emergencyHeatingActive": false,

--- a/playground/js/physics.js
+++ b/playground/js/physics.js
@@ -44,7 +44,15 @@ const DEFAULTS = {
   collector_water_volume: 0.008,// m³ (8L in collectors)
   collector_plate_mass_cp: 20000, // J/K (absorber plate thermal capacity)
   tank_volume: 0.300,           // m³ (300L)
-  tank_UA: 3.0,                 // W/K tank heat loss (insulated)
+  // Standby loss to ambient, calibrated to ~13 W/K from logged history:
+  // clean overnight idle segments across a week cool at a median ~13.7 W/K
+  // (energy-weighted ~12.4) relative to outdoor. Far lossier than a sealed
+  // insulated cylinder because this is an unpressurised drainback tank
+  // vented through an open reservoir canister, so the water surface and dip
+  // tube shed heat by evaporation + convection. The production physics
+  // forecast fits its own leakage coefficient from data; this default just
+  // keeps the playground simulator and bootstrap demo realistic.
+  tank_UA: 13.0,                // W/K tank heat loss (open-vented drainback)
   greenhouse_UA: 100.0,         // W/K greenhouse envelope loss
   greenhouse_thermal_mass: 250000, // J/K (air + soil + structure)
   greenhouse_glazing_area: 4.0,  // m² effective south-facing glazing

--- a/tests/energy-balance-parity.test.mjs
+++ b/tests/energy-balance-parity.test.mjs
@@ -1,0 +1,84 @@
+// Parity guard for the energy code that is hand-mirrored across the
+// client (playground/js/physics.js + energy-balance.js) and the server
+// (server/lib/energy-balance.js). Those modules carry "keep in sync"
+// comments but nothing enforced it — this test fails the moment a
+// constant or the net-per-segment attribution rule diverges, the same
+// way bootstrap-history-drift guards the control-logic snapshot.
+
+import test from 'node:test';
+import assert from 'node:assert';
+import { createRequire } from 'node:module';
+import { computeEnergyBalance } from '../playground/js/energy-balance.js';
+import {
+  tankStoredEnergyKwh as clientStored,
+  tankKwhToDeltaC as clientDelta,
+} from '../playground/js/physics.js';
+
+const require = createRequire(import.meta.url);
+const server = require('../server/lib/energy-balance.js');
+
+test('scalar formulas are identical client ↔ server', () => {
+  for (const t of [8, 12, 12.0001, 20, 30, 43.3, 55, NaN]) {
+    assert.deepStrictEqual(
+      clientStored(t), server.tankStoredEnergyKwh(t),
+      'tankStoredEnergyKwh @' + t);
+  }
+  for (const k of [-3.2, 0, 0.05, 1, 6.3, 9.75, NaN]) {
+    assert.deepStrictEqual(
+      clientDelta(k), server.tankKwhToDeltaC(k),
+      'tankKwhToDeltaC @' + k);
+  }
+});
+
+const HOUR = 3600 * 1000;
+const pt = (now, h, avg) => ({ ts: now - h * HOUR, tank_top: avg + 1, tank_bottom: avg - 1 });
+const ev = (now, h, to) => ({ ts: now - h * HOUR, type: 'mode', to });
+
+// The client splits a window into day/night sections; the server buckets
+// the whole 24 h. With monotonic-within-segment data the net-per-segment
+// attribution is additive across the split, so the client sections must
+// sum to the server's daily buckets. Any divergence in the bucketing rule
+// (sign handling, mode→bucket mapping, boundary attribution) breaks this.
+function clientTotalsWh(bal) {
+  const sum = (k) => (bal.night ? bal.night[k] : 0) + (bal.day ? bal.day[k] : 0);
+  return {
+    gatheredWh: sum('gatheredKwh') * 1000,
+    heatingWh: sum('heatingKwh') * 1000,
+    leakageWh: sum('leakageKwh') * 1000,
+  };
+}
+
+function assertParity(label, points, events, now) {
+  const c = clientTotalsWh(computeEnergyBalance(points, events, now));
+  const s = server.computeDailyFromHistory(points, events, now);
+  assert.ok(Math.abs(c.gatheredWh - s.gatheredWh) < 1e-6, label + ' gathered: ' + c.gatheredWh + ' vs ' + s.gatheredWh);
+  assert.ok(Math.abs(c.heatingWh - s.heatingLossWh) < 1e-6, label + ' heating: ' + c.heatingWh + ' vs ' + s.heatingLossWh);
+  assert.ok(Math.abs(c.leakageWh - s.leakageLossWh) < 1e-6, label + ' leakage: ' + c.leakageWh + ' vs ' + s.leakageLossWh);
+}
+
+test('bucketing parity: heating + idle + sensor noise', () => {
+  const now = Date.parse('2026-05-01T12:00:00Z');
+  const events = [ev(now, 23, 'idle'), ev(now, 18, 'greenhouse_heating'), ev(now, 17.5, 'idle')];
+  // Monotonic within each segment; jitter only as small monotone steps so
+  // the split stays additive while still exercising the noise paths.
+  const points = [
+    pt(now, 23, 30.4), pt(now, 20, 29.6),         // idle cooling
+    pt(now, 18, 29.4),                            // heating begins
+    pt(now, 17.7, 26), pt(now, 17.5, 24),         // heating drop
+    pt(now, 12, 23.6), pt(now, 6, 22.8), pt(now, 0.05, 22), // idle cooling
+  ];
+  assertParity('heating+idle', points, events, now);
+});
+
+test('bucketing parity: solar charging then idle', () => {
+  const now = Date.parse('2026-05-01T15:00:00Z');
+  // Day must stay ongoing (last charge within DAY_GAP of now) so the
+  // client's night+day sections partition the whole window — a completed
+  // day would drop the pre-day idle, which the server still counts.
+  const events = [ev(now, 23, 'idle'), ev(now, 8, 'solar_charging')];
+  const points = [
+    pt(now, 23, 20), pt(now, 8.1, 19.5),          // pre-charge idle
+    pt(now, 8, 20), pt(now, 5, 30), pt(now, 0.05, 38), // charging climb to now
+  ];
+  assertParity('charging+idle', points, events, now);
+});

--- a/tests/frontend/balance-card.spec.js
+++ b/tests/frontend/balance-card.spec.js
@@ -1,0 +1,68 @@
+// @ts-check
+//
+// Renders the Status-view "Today's balance" card with real history points
+// and asserts the user-visible formatting decisions that unit tests can't
+// see end-to-end: each stat shows its temperature swing (Δ°C), "Released"
+// is a bare magnitude (no double-negative), "Net today" keeps its sign,
+// and the destination split caption survives. The card only renders in
+// live mode, so we flip phase=live and drive the public fetch path
+// directly rather than standing up a WebSocket.
+
+import { test, expect } from './fixtures.js';
+
+test.describe("Today's balance card", () => {
+  test('renders both sections with temperature deltas and a signed net', async ({ page }) => {
+    const now = Date.now();
+    const H = 3600 * 1000;
+    const pt = (h, avg) => ({ ts: now - h * H, tank_top: avg + 1, tank_bottom: avg - 1 });
+    const ev = (h, to) => ({ ts: now - h * H, type: 'mode', to });
+    // Completed night with a heating pulse + idle leakage, then an ongoing
+    // solar-charging day with post-peak idle leakage.
+    const points = [
+      pt(20, 30), pt(18, 28),            // night idle leakage
+      pt(17.4, 24), pt(17.1, 22),        // night heating drop
+      pt(12, 21), pt(8.1, 20.5),         // night idle leakage to morning
+      pt(8, 21), pt(5, 35),              // day solar charging climb
+      pt(2, 33), pt(1.5, 32.5), pt(0.05, 32), // day idle leakage (ongoing)
+    ];
+    const events = [
+      ev(21, 'idle'), ev(17.5, 'greenhouse_heating'), ev(17.1, 'idle'),
+      ev(8, 'solar_charging'), ev(1.5, 'idle'),
+    ];
+
+    await page.route('**/api/history**', route => route.fulfill({
+      status: 200, contentType: 'application/json',
+      body: JSON.stringify({ points, events, spaceHeaterEvents: [] }),
+    }));
+    await page.route('**/api/events**', route => route.fulfill({
+      status: 200, contentType: 'application/json',
+      body: JSON.stringify({ events: [], hasMore: false }),
+    }));
+
+    await page.goto('/playground/#status');
+    await page.waitForFunction(() => window.__initComplete === true);
+
+    await page.evaluate(async () => {
+      const st = await import('/playground/js/app-state.js');
+      st.store.set('phase', 'live');
+      const bc = await import('/playground/js/main/balance-card.js');
+      bc.fetchBalanceHistory();
+    });
+
+    await expect(page.locator('#balance-card')).toBeVisible({ timeout: 5000 });
+
+    const nightHtml = await page.locator('#balance-night-stats').evaluate(el => el.innerHTML);
+    expect(nightHtml).toMatch(/Released/);
+    expect(nightHtml).toMatch(/Δ\d+°C/);                    // temperature swing shown
+    expect(nightHtml).toMatch(/to greenhouse/);             // split caption
+    expect(nightHtml).toMatch(/to air/);
+    expect(nightHtml).not.toMatch(/balance-stat-value">−/); // no double-negative
+
+    const dayHtml = await page.locator('#balance-day-stats').evaluate(el => el.innerHTML);
+    expect(dayHtml).toMatch(/Gathered/);
+    expect(dayHtml).toMatch(/Net today/);
+    expect(dayHtml).toMatch(/Δ\d+°C/);                      // gathered/released swing
+    expect(dayHtml).toMatch(/Net today<\/span><div><span class="balance-stat-value positive">\+/); // signed net
+    expect(dayHtml).toMatch(/Δ\+\d+°C/);                    // signed net swing
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up work on the daily energy balance, layered on top of the merged #208. Four logical changes:

- **Calibrate the simulator tank standby loss** from `tank_UA` 3.0 → 13.0 W/K, fit to ~13 W/K from logged overnight idle segments (open-vented drainback tank loses heat by evaporation + convection, far lossier than a sealed cylinder). Only affects the **playground simulator + bootstrap demo** — the production physics forecast (`server/lib/forecast/physics-step.js`) fits its own leakage coefficient and is untouched. `playground/assets/bootstrap-history.json` regenerated in the same commit; the drift test confirms the snapshot matches.
- **Add a client↔server energy parity test** (`tests/energy-balance-parity.test.mjs`). The energy math is hand-mirrored across `playground/js/{physics,energy-balance}.js` and `server/lib/energy-balance.js` with "keep in sync" comments but nothing enforced it. The test fails the moment a scalar formula or the net-per-segment bucketing rule diverges.
- **Add a balance-card render test** (`tests/frontend/balance-card.spec.js`) asserting the user-visible formatting end-to-end: Δ°C beside each kWh figure, "Released" as a bare magnitude (no double-negative), and a signed "Net today".
- **Tooling:** a SessionStart hook that provisions Claude-web sessions (npm ci + Playwright/Chromium version alignment), and a stale `shelly/**` knip-ignore drop.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run knip` — exit 0
- [x] `npm run check:file-size -- --strict` — 0 over hard cap
- [x] `npm run check:assets -- --strict` — all assets referenced
- [x] `npm run test:unit` — 1252 pass (incl. new parity + bootstrap drift)
- [x] `npx playwright test` — frontend (incl. new balance-card spec) + e2e green

https://claude.ai/code/session_01TZxLTxNsh9QLDaHnRYzZt2

---
_Generated by [Claude Code](https://claude.ai/code/session_01TZxLTxNsh9QLDaHnRYzZt2)_