### PR TITLE
Add Stop-hook PR watcher so merge-on-green can't hang on a dropped webhook

### DIFF
--- a/.claude/hooks/pr-watch-stop.sh
+++ b/.claude/hooks/pr-watch-stop.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Stop hook: keep the session polling while it is watching a PR for CI to
+# finish, so a dropped `subscribe_pr_activity` webhook can't leave a
+# "merge once CI is green" task hung forever (the webhook wake is flaky in
+# the web sandbox). See CLAUDE.md "Merge-on-green".
+#
+# Inert by default: with no .claude/.pr-watch sentinel it exits 0 and the
+# session stops normally. The sentinel is created ONLY when an agent is
+# explicitly watching a PR, so ordinary sessions — including local
+# interactive ones — are completely unaffected (one stat() per Stop).
+#
+# When the sentinel exists, the hook sleeps ~one CI cycle then blocks the
+# stop, feeding the agent back a get_check_runs re-check (a real turn, so
+# it can call the GitHub MCP tools — the shell here has no token and the
+# shared egress IP is rate-limited, so bash itself cannot read CI status).
+# Bounded by DEADLINE: a stuck/queued PR can never loop forever, and a
+# missing/garbled DEADLINE fails safe (clears the sentinel, allows stop).
+set -uo pipefail
+
+proj="${CLAUDE_PROJECT_DIR:-.}"
+sentinel="$proj/.claude/.pr-watch"
+
+# Not watching anything → let the session stop.
+[ -f "$sentinel" ] || exit 0
+
+# Parse via grep (never source — the file must not be executed).
+pr=$(grep -oE '^PR=[0-9]+' "$sentinel" | head -1 | cut -d= -f2)
+repo=$(grep -oE '^REPO=[^[:space:]]+' "$sentinel" | head -1 | cut -d= -f2)
+deadline=$(grep -oE '^DEADLINE=[0-9]+' "$sentinel" | head -1 | cut -d= -f2)
+now=$(date +%s)
+
+# Fail safe: no usable deadline, or past it → stop polling.
+if ! [ "${deadline:-0}" -gt "$now" ] 2>/dev/null; then
+  rm -f "$sentinel"
+  printf '{"decision":"block","reason":"PR watch on #%s ended (deadline reached or sentinel was malformed); .claude/.pr-watch has been cleared. Do one final get_check_runs via mcp__github__pull_request_read, report the outcome to the user, and do NOT recreate the sentinel."}\n' "${pr:-?}"
+  exit 0
+fi
+
+# Throttle to roughly one CI cycle (CI here finishes in ~1 min). Kept under
+# the 60 s Stop-hook timeout.
+sleep "${PR_WATCH_POLL_SECONDS:-45}"
+
+printf '{"decision":"block","reason":"Still watching PR #%s (%s) for CI. Re-check now: mcp__github__pull_request_read method=get_check_runs. If every required check has conclusion success, merge via mcp__github__merge_pull_request then run: rm -f .claude/.pr-watch . If any check failed, run rm -f .claude/.pr-watch then reproduce-and-fix per the CLAUDE.md autofix cap (or report if out of scope). If checks are still queued or in_progress, just end your turn and this hook will poll again."}\n' "${pr:-?}" "${repo:-}"
+exit 0

--- a/.claude/hooks/pr-watch-stop.sh
+++ b/.claude/hooks/pr-watch-stop.sh
@@ -36,9 +36,9 @@ if ! [ "${deadline:-0}" -gt "$now" ] 2>/dev/null; then
   exit 0
 fi
 
-# Throttle to roughly one CI cycle (CI here finishes in ~1 min). Kept under
-# the 60 s Stop-hook timeout.
-sleep "${PR_WATCH_POLL_SECONDS:-45}"
+# Poll every 20 s so completion is caught fast (CI here finishes in ~1 min).
+# Kept well under the 60 s Stop-hook timeout.
+sleep "${PR_WATCH_POLL_SECONDS:-20}"
 
 printf '{"decision":"block","reason":"Still watching PR #%s (%s) for CI. Re-check now: mcp__github__pull_request_read method=get_check_runs. If every required check has conclusion success, merge via mcp__github__merge_pull_request then run: rm -f .claude/.pr-watch . If any check failed, run rm -f .claude/.pr-watch then reproduce-and-fix per the CLAUDE.md autofix cap (or report if out of scope). If checks are still queued or in_progress, just end your turn and this hook will poll again."}\n' "${pr:-?}" "${repo:-}"
 exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -21,6 +21,16 @@
           }
         ]
       }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/pr-watch-stop.sh"
+          }
+        ]
+      }
     ]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 .superpowers/
 .claude/settings.local.json
+.claude/.pr-watch
 tests/output/
 test-results/
 node_modules/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,7 +215,7 @@ The cap exists because runaway CI loops mask design-level problems (flaky test, 
    printf 'PR=%s\nREPO=Wnt/greenhouse-solar-heater\nDEADLINE=%s\n' 209 "$(( $(date +%s) + 1200 ))" > .claude/.pr-watch
    ```
 
-   `.claude/hooks/pr-watch-stop.sh` (a `Stop` hook) then blocks the session from going idle, sleeps ~45 s, and feeds you back a `get_check_runs` re-check each cycle. On all-green: `merge_pull_request`, then `rm -f .claude/.pr-watch`. On any failure or once `DEADLINE` passes: clear the sentinel and report/fix per the autofix cap. The hook is **inert without the sentinel**, so it never affects ordinary or local sessions. Remove the sentinel the moment the user redirects.
+   `.claude/hooks/pr-watch-stop.sh` (a `Stop` hook) then blocks the session from going idle, sleeps ~20 s, and feeds you back a `get_check_runs` re-check each cycle. On all-green: `merge_pull_request`, then `rm -f .claude/.pr-watch`. On any failure or once `DEADLINE` passes: clear the sentinel and report/fix per the autofix cap. The hook is **inert without the sentinel**, so it never affects ordinary or local sessions. Remove the sentinel the moment the user redirects.
 
 2. **`/loop 1m`** the same `get_check_runs`-then-merge check, if you'd rather drive it explicitly. Stop the loop once the PR is merged or conclusively failed.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,6 +205,22 @@ On a CI-failure event, **loop until green**: read the failing job (`pull_request
 
 The cap exists because runaway CI loops mask design-level problems (flaky test, environment drift, hidden coupling). Escalate immediately on contract-shape failures (test asserts a deliberate API change you didn't anticipate, schema drift, type-system shifts) — those are the user's call. Loop freely on lint nitpicks, type errors, file-size cap breaches (compress, don't bypass), and coverage regressions on files you touched.
 
+### Merge-on-green: don't trust the webhook alone
+
+`subscribe_pr_activity` wakes the session via a GitHub webhook that the web sandbox **sometimes drops**, leaving a "merge once CI is green" task hung indefinitely. CI here finishes in ~1 min, so when the task is to watch/merge a PR, always back the subscription with an active poll. The shell **cannot** poll GitHub itself (no token; the shared egress IP's unauthenticated API budget is exhausted) — only the MCP tools can, and only inside an agent turn. Two ways to get those turns on a timer:
+
+1. **Stop-hook poller (automatic, preferred).** Arm it by writing the gitignored sentinel `.claude/.pr-watch`:
+
+   ```bash
+   printf 'PR=%s\nREPO=Wnt/greenhouse-solar-heater\nDEADLINE=%s\n' 209 "$(( $(date +%s) + 1200 ))" > .claude/.pr-watch
+   ```
+
+   `.claude/hooks/pr-watch-stop.sh` (a `Stop` hook) then blocks the session from going idle, sleeps ~45 s, and feeds you back a `get_check_runs` re-check each cycle. On all-green: `merge_pull_request`, then `rm -f .claude/.pr-watch`. On any failure or once `DEADLINE` passes: clear the sentinel and report/fix per the autofix cap. The hook is **inert without the sentinel**, so it never affects ordinary or local sessions. Remove the sentinel the moment the user redirects.
+
+2. **`/loop 1m`** the same `get_check_runs`-then-merge check, if you'd rather drive it explicitly. Stop the loop once the PR is merged or conclusively failed.
+
+Keep `subscribe_pr_activity` too — it's instant when it works; the poller is just the safety net.
+
 ## Test Setup Gotchas
 
 - **Run `npm ci` first if `node_modules/` is missing.** With deps installed, the full unit suite (`npm run test:unit`, 788 tests) completes in **~20 s** locally; individual files are sub-second to a few seconds. If a run is taking materially longer, something is wrong — don't "wait it out." Common causes: missing deps (several tests hang indefinitely on missing transitive requires rather than erroring; `sensor-apply` and `sensor-discovery` are the usual offenders because they build local HTTP servers that wait on a peer module that never loads), or stale `node` processes from a previous killed run (check `ps -C node` and `pkill -9 node`).


### PR DESCRIPTION
## Summary

Fixes the recurring "merge once CI is green" hang. `subscribe_pr_activity` wakes an idle session via a GitHub webhook that the web sandbox sometimes drops, leaving the task stuck forever. The shell can't poll GitHub to compensate (no token; the shared egress IP's unauthenticated API budget is exhausted), so only the MCP tools — inside an agent turn — can read CI status.

- **`Stop` hook poller** (`.claude/hooks/pr-watch-stop.sh`): when a gitignored `.claude/.pr-watch` sentinel exists, it blocks the session from going idle, sleeps ~one CI cycle (~45 s), and feeds the agent a `get_check_runs` re-check each turn until it merges or the sentinel's `DEADLINE` passes. **Inert without the sentinel**, so ordinary and local interactive sessions are unaffected (one `stat()` per Stop). Deadline-bounded and fail-safe (a missing/garbled deadline clears the sentinel and allows the stop) so it can never loop indefinitely.
- **CLAUDE.md "Merge-on-green"** convention documenting both the Stop-hook poller and an explicit `/loop 1m` alternative, with the note that the webhook subscription alone is unreliable and must be backed by an active poll.

## Test plan

- [x] Hook unit-tested across all paths: inert (no sentinel), active (valid block JSON, sentinel kept), expired deadline (sentinel removed), malformed sentinel (fail-safe remove)
- [x] `settings.json` valid JSON; `Stop` hook registered alongside existing `SessionStart` / `PreToolUse`
- [x] No shell-lint gate in CI; pre-push gate (lint/knip/file-size/assets/unit/playwright) passed on push

https://claude.ai/code/session_01TZxLTxNsh9QLDaHnRYzZt2

---
_Generated by [Claude Code](https://claude.ai/code/session_01TZxLTxNsh9QLDaHnRYzZt2)_