### PR TITLE
Fix e2e harness teardown crash on SIGTERM (broker.close is callback-style)

### DIFF
--- a/tests/e2e-harness-shutdown.test.js
+++ b/tests/e2e-harness-shutdown.test.js
@@ -1,0 +1,66 @@
+/**
+ * Regression: the e2e harness (tests/e2e/_setup/start.cjs) crashed on
+ * teardown. Its SIGTERM/SIGINT handler did `broker.close().then(...)`, but
+ * aedes' `broker.close()` returns `undefined` and signals completion via a
+ * callback — so `.then` threw a TypeError. Every Playwright e2e run ended
+ * with an uncaught exception + non-zero exit on webServer teardown, and a
+ * stalled broker close was never awaited.
+ *
+ * Fix: pass a callback to `broker.close()` (with an unref'd timer fallback
+ * so a stalled close still lets the process exit).
+ *
+ * The behavioural half builds a real aedes broker (in-memory; no port is
+ * bound, so this is sandbox-safe and fast) and pins the close() contract.
+ * The source-guard half ensures start.cjs never regresses to the broken
+ * `.close().then()` shape.
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const { Aedes } = require('aedes');
+
+const START_CJS = path.join(__dirname, 'e2e', '_setup', 'start.cjs');
+
+describe('e2e harness shutdown', () => {
+  it('aedes broker.close() returns undefined and signals via callback', async () => {
+    // This is the contract the bug violated: close() is callback-style and
+    // its return value is undefined, so calling .then() on it throws.
+    const broker = await Aedes.createBroker();
+    let returnValue;
+    await new Promise((resolve, reject) => {
+      const timer = setTimeout(
+        () => reject(new Error('broker.close() never invoked its callback')),
+        2000,
+      );
+      returnValue = broker.close(() => {
+        clearTimeout(timer);
+        resolve();
+      });
+    });
+    assert.equal(
+      returnValue,
+      undefined,
+      'broker.close() returns undefined — callers must use the callback, not .then()',
+    );
+  });
+
+  it('start.cjs does not call broker.close().then() (crashes teardown)', () => {
+    const src = fs.readFileSync(START_CJS, 'utf8');
+    assert.doesNotMatch(
+      src,
+      /broker\.close\(\s*\)\s*\.then/,
+      'broker.close().then(...) throws — aedes close() returns undefined',
+    );
+  });
+
+  it('start.cjs passes a callback to broker.close()', () => {
+    const src = fs.readFileSync(START_CJS, 'utf8');
+    assert.match(
+      src,
+      /broker\.close\(\s*[^)]/,
+      'shutdown must pass a completion callback to broker.close()',
+    );
+  });
+});

--- a/tests/e2e/_setup/start.cjs
+++ b/tests/e2e/_setup/start.cjs
@@ -102,7 +102,13 @@ Aedes.createBroker().then((broker) => {
   // Register teardown hooks once the broker is live.
   const shutdown = () => {
     try { mqttServer.close(); } catch (_) { /* noop */ }
-    broker.close().then(() => process.exit(0), () => process.exit(1));
+    // aedes' broker.close() is callback-style and returns undefined —
+    // calling .then() on its return value threw a TypeError that crashed
+    // teardown (exit 1) on every SIGTERM. Pass a callback; the unref'd
+    // timer is a fallback so a stalled close still lets the harness exit.
+    const done = () => process.exit(0);
+    try { broker.close(done); } catch (_) { done(); }
+    setTimeout(done, 1000).unref();
   };
   process.on('SIGTERM', shutdown);
   process.on('SIGINT', shutdown);


### PR DESCRIPTION
## Summary

I ran the full CI test matrix repeatedly — **each test 5×** (and then some) — to hunt for flaky tests. **No flaky tests were found**; the suite is genuinely robust. The repeated runs did surface one real defect in the e2e test harness, which this PR fixes.

### Flaky-test hunt results (all green)

| Suite | Runs | Result |
|---|---|---|
| `test:unit` | 5× + 10× stress = **15 full-suite runs** | 1252 pass, **0 fail** every run |
| `test:frontend` | **5×** at workers=4 (CI level) | 1655/1655 pass, **0 fail** |
| `test:frontend` (stress) | **3×** at workers=8 (2× CI concurrency) | 993/993 pass, **0 fail** |
| `test:e2e` | **5×** (repeat-each) | 105/105 pass, **0 fail** |

`--repeat-each` with `retries: 0` means any flake surfaces as a hard failure. The workers=8 stress run deliberately exceeds the CI worker cap (the config comment warns that higher concurrency can surface init-race flakes in specs lacking `__initComplete` gates) — it stayed green, so those races aren't reproducible on the current code.

### The bug this PR fixes

`tests/e2e/_setup/start.cjs` crashed on **every** Playwright webServer teardown. Its SIGTERM/SIGINT handler did:

```js
broker.close().then(() => process.exit(0), () => process.exit(1));
```

But aedes' `broker.close()` is **callback-style and returns `undefined`**, so `.then` threw an uncaught `TypeError`. Playwright ignores the teardown exit code, so individual e2e specs still passed — but every run ended with a stack trace and an unclean shutdown (broker never drained, harness exited non-zero). Repeatedly invoking the e2e suite (exactly what a flaky-test hunt does) made this obvious.

**Fix:** pass a completion callback to `broker.close()`, with an `unref`'d timer fallback so a stalled close still lets the process exit cleanly.

## Test plan

- [x] `tests/e2e-harness-shutdown.test.js` (new) — fails on the old code, passes on the fix:
  - behavioural check pinning aedes' callback-style `close()` contract (in-memory broker, no port bound → fast + sandbox-safe)
  - source guard so the harness never regresses to the `.close().then()` shape
- [x] Manually booted the harness and sent SIGTERM → **exit code 0, zero TypeErrors** (previously crashed)
- [x] `npm run test:e2e` → 21 passed, **0 TypeErrors in teardown**
- [x] `npm run lint`, `npm run knip`, `check:file-size --strict`, `check:assets --strict` → all clean
- [x] `npm run test:unit` → 1255 pass (+3 new), 0 fail

https://claude.ai/code/session_01GPgau2tkawPozX5SH56vQT

---
_Generated by [Claude Code](https://claude.ai/code/session_01GPgau2tkawPozX5SH56vQT)_