### PR TITLE
Fix flaky relay shake-animation test under CI worker contention

### DIFF
--- a/tests/frontend/device-config.spec.js
+++ b/tests/frontend/device-config.spec.js
@@ -341,8 +341,17 @@ test.describe('Relay toggle board', () => {
     await fanBtn.click();
     await expect(fanBtn).toHaveClass(/\bon\b/);
 
-    // State broadcast says fan is still OFF (command failed)
-    await page.evaluate(() => {
+    // State broadcast says fan is still OFF (command failed). The
+    // contradiction reverts the optimistic ON and adds the error/shake
+    // class synchronously, then a 400 ms timer (relay-board.js) clears
+    // it. That window is too short to observe reliably with Playwright's
+    // out-of-process polling: under CI worker contention the round-trips
+    // between injecting the state and the toHaveClass poll could exceed
+    // 400 ms, so the assertion would miss the class entirely. __wsInject
+    // dispatches onmessage synchronously and the whole state→relay
+    // reconcile path is synchronous, so we read the class list in the
+    // same evaluate to capture the transient state race-free.
+    const afterContradiction = await page.evaluate(() => {
       window.__wsInject({ type: 'state', data: {
         mode: 'idle', temps: { collector: 25, tank_top: 40, tank_bottom: 35, greenhouse: 18, outdoor: 10 },
         valves: { vi_btm: false, vi_top: false, vi_coll: false, vo_coll: false, vo_rad: false, vo_tank: false, v_air: false },
@@ -350,14 +359,21 @@ test.describe('Relay toggle board', () => {
         controls_enabled: true,
         manual_override: { active: true, expiresAt: Math.floor(Date.now()/1000) + 300, },
       }});
+      const fan = document.querySelector('.relay-btn[data-relay="fan"]');
+      return { on: fan.classList.contains('on'), error: fan.classList.contains('relay-btn--error') };
     });
 
-    // Button reverted to OFF with error animation
-    await expect(fanBtn).not.toHaveClass(/\bon\b/);
-    await expect(fanBtn).toHaveClass(/relay-btn--error/);
+    // Button reverted to OFF with the error (shake) animation applied.
+    expect(afterContradiction.on).toBe(false);
+    expect(afterContradiction.error).toBe(true);
 
-    // Error class removed after animation
-    await expect(fanBtn).not.toHaveClass(/relay-btn--error/, { timeout: 1000 });
+    // Error class removed after the animation completes. The original
+    // 1000 ms cap was the actual flake: the 400 ms auto-clear setTimeout
+    // gets starved under CI worker contention and fired past 1000 ms,
+    // so the assertion timed out with the class still applied. Give it
+    // ample headroom — the assertion only needs to prove it eventually
+    // clears, and a genuine "never clears" regression still fails fast.
+    await expect(fanBtn).not.toHaveClass(/relay-btn--error/, { timeout: 4000 });
   });
 
   test('countdown timer visible during override', async ({ page }) => {


### PR DESCRIPTION
## Summary

Ran the full CI test suite with every test repeated 5× to hunt for flaky tests:

| Suite | How it was run | Result |
|---|---|---|
| `npm run test:unit` (1254 tests) | whole suite ×5 | stable, 0 failures |
| frontend Playwright (331 tests) | `--repeat-each=5 --workers=4` (1655 executions, matches CI shard worker count) | stable, 0 failures |
| e2e Playwright (21 tests) | `--repeat-each=5 --workers=4` (105 executions) | stable, 0 failures |
| frontend Playwright **stress** | `--repeat-each=3 --workers=6` (993 executions, deliberate over-subscription) | **1 flaky test found** |

The single flake surfaced only under worker over-subscription (the project's own `playwright.config.js` notes workers=6 exposes timing races that workers=4 hides):

**`device-config.spec.js` › Relay toggle board › "state broadcast contradiction triggers shake animation"**

The test asserts on the transient `relay-btn--error` (shake) class, which `relay-board.js` adds synchronously on a failed-command state broadcast and clears via a `setTimeout(…, 400)`. Under CPU contention that 400 ms timer is starved and fires *after* the test's 1000 ms `not.toHaveClass` cap — so the assertion timed out with the class still applied.

## Fix

- Read the applied-class state **synchronously inside the inject `evaluate`**. The `__wsInject` → `onmessage` → relay-reconcile path is fully synchronous, so the "shake applied" check (button reverted to OFF, error class present) can no longer race the auto-clear timer.
- Widen the "error class cleared" assertion timeout from 1000 ms → 4000 ms, so a starved-but-eventually-fired timer doesn't flake while a genuine "never clears" regression still fails fast.

The scenario under test is unchanged (contradiction → shake applied → shake auto-clears); only the assertions were made race-free.

## Test plan

- [x] `npm run lint` — clean
- [x] `device-config.spec.js` at default workers (4) — 38/38 pass
- [x] Re-ran the exact stress that caught it (`--repeat-each=3 --workers=6`, 993 executions) **after** the fix → **993 passed, 0 failures**, shake test green all 3 repeats
- [x] Pre-push CI gate passed

https://claude.ai/code/session_01LLbR3xRWHmnerybzaUfFna

---
_Generated by [Claude Code](https://claude.ai/code/session_01LLbR3xRWHmnerybzaUfFna)_